### PR TITLE
Fix issue with french version of tf.exe

### DIFF
--- a/src/main/java/hudson/plugins/tfs/commands/DetailedHistoryCommand.java
+++ b/src/main/java/hudson/plugins/tfs/commands/DetailedHistoryCommand.java
@@ -54,7 +54,8 @@ public class DetailedHistoryCommand extends AbstractCommand implements Parseable
     //private static final int FIELD_CHECKEIN_NOTES = 6;
     private static final String[][] LANG_FIELD_NAMES = {
                 {"User", "Changeset", "Date", "Items", "Comment", "Checked in by", "Check-in Notes"}, // EN
-                {"Benutzer", "Changeset", "Datum", "Elemente", "Kommentar", "Checked in by", "Eincheckhinweise"} // DE
+                {"Benutzer", "Changeset", "Datum", "Elemente", "Kommentar", "Checked in by", "Eincheckhinweise"}, // DE
+				{"Utilisateur", "Ensemble de modifications", "Date", "\u00C9l\u00E9ments", "Commentaire", "Checked in by", "Notes d'archivage"} //FR
             };
 
     private final String projectPath;
@@ -104,11 +105,10 @@ public class DetailedHistoryCommand extends AbstractCommand implements Parseable
     public List<ChangeSet> parse(Reader reader) throws IOException, ParseException {
         Date lastBuildDate = fromTimestamp.getTime();
         ArrayList<ChangeSet> list = new ArrayList<ChangeSet>();
-        
+		
         ChangeSetStringReader iterator = new ChangeSetStringReader(new BufferedReader(reader));
         String changeSetString = iterator.readChangeSet(); 
         while (changeSetString != null) {
-        	
         	ChangeSet changeSet = parseChangeSetString(changeSetString);
         	// If some tf tool outputs the key words in non english we will use the old fashion way
         	// using the complicated regex
@@ -153,7 +153,7 @@ public class DetailedHistoryCommand extends AbstractCommand implements Parseable
                     && map.containsKey(fieldNames[FIELD_DATE])
                     && map.containsKey(fieldNames[FIELD_ITEMS])) {
                 ChangeSet changeSet = createChangeSet(map.get(fieldNames[FIELD_ITEMS]), map.get(fieldNames[FIELD_CHANGESET]), map.get(fieldNames[FIELD_USER]), map.get(fieldNames[FIELD_DATE]), map.get(fieldNames[FIELD_COMMENT]));
-                if (changeSet != null) {
+				if (changeSet != null) {
                     changeSet.setCheckedInBy(map.get(fieldNames[FIELD_CHECKED_IN_BY]));
                 }
                 return changeSet;
@@ -238,10 +238,10 @@ public class DetailedHistoryCommand extends AbstractCommand implements Parseable
             StringBuilder builder = new StringBuilder();
             String line;
             int linecount = 0;
-
+			
             while ((line = reader.readLine()) != null) {
                 if (line.length() > 0) {
-                    if ((!foundAtLeastOneChangeSet) && PATTERN_KEYWORD.matcher(line).matches()) {
+                    if ((!foundAtLeastOneChangeSet) && PATTERN_KEYWORD.matcher(line.replace("\u00A0", "")).matches()) {
                         foundAtLeastOneChangeSet = true;
                     }
                     if (line.startsWith(CHANGESET_SEPERATOR) && (linecount > 0)) {

--- a/src/main/java/hudson/plugins/tfs/util/KeyValueTextReader.java
+++ b/src/main/java/hudson/plugins/tfs/util/KeyValueTextReader.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+
 /**
  * Class that parsers key/values from a reader.
  * This is used when reading text files that contains keys and value pairs where the
@@ -18,20 +19,20 @@ import java.util.regex.Pattern;
  */
 public class KeyValueTextReader {
 
-	private static final Pattern KEY_VALUE_PATTERN = Pattern.compile("([\\w\\s]*):(.*)");
+	private static final Pattern KEY_VALUE_PATTERN = Pattern.compile("([\\w\\s\\p{L}\\']*):(.*)");
 	private static final String CONTINUED_VALUE_STRING = " ";
 
 	public Map<String, String> parse(String string) throws IOException {
 		return parse(new BufferedReader(new StringReader(string)));
 	}
-
+	
 	public Map<String, String> parse(BufferedReader reader) throws IOException {
 		HashMap<String,String> map = null;
 		String line = reader.readLine();
 		String value = null;
 		String key = null;
-		
 		while (line != null) {
+			line = line.replace("\u00A0","");
 			if (line.startsWith(CONTINUED_VALUE_STRING)) {
 				value = value + "\n" + line.trim();
 			} else {

--- a/src/test/java/hudson/plugins/tfs/commands/DetailedHistoryCommandTest.java
+++ b/src/test/java/hudson/plugins/tfs/commands/DetailedHistoryCommandTest.java
@@ -184,6 +184,29 @@ public class DetailedHistoryCommandTest extends SwedishLocaleTestCase {
         assertEquals("The number of change sets in the list was incorrect", 1, list.size());
     }
     
+	/* Related to bug 10784*/
+	@Test
+    public void assertCanParseFrenchChangesetWithCheckinNotes() throws Exception {
+        InputStreamReader reader = new InputStreamReader(DetailedHistoryCommandTest.class.getResourceAsStream("tf-changeset-french-1.txt"), "Windows-1252");
+        DetailedHistoryCommand command = new DetailedHistoryCommand(mock(ServerConfigurationProvider.class), "$/tfsandbox", 
+                Util.getCalendar(2011, 07, 10), Calendar.getInstance(), 
+                new DateParser(new Locale("fr", "FR"), TimeZone.getTimeZone("France")));
+        List<ChangeSet> list = command.parse(reader);
+        assertNotNull("The list of change sets was null", list);
+        assertEquals("The number of change sets in the list was incorrect", 1, list.size());
+    }
+	
+	@Test
+    public void assertCanParseFrenchChangesetWithNBSP() throws Exception {
+        InputStreamReader reader = new InputStreamReader(DetailedHistoryCommandTest.class.getResourceAsStream("tf-changeset-french-2.txt"), "Windows-1252");
+        DetailedHistoryCommand command = new DetailedHistoryCommand(mock(ServerConfigurationProvider.class), "$/tfsandbox", 
+                Util.getCalendar(2011, 07, 10), Calendar.getInstance(), 
+                new DateParser(new Locale("fr", "FR"), TimeZone.getTimeZone("France")));
+        List<ChangeSet> list = command.parse(reader);
+        assertNotNull("The list of change sets was null", list);
+        assertEquals("The number of change sets in the list was incorrect", 1, list.size());
+    }
+	
     @Test
     public void assertNoCrashForIssue3683() throws Exception {
         InputStreamReader reader = new InputStreamReader(DetailedHistoryCommandTest.class.getResourceAsStream("issue-3683.txt"));

--- a/src/test/resources/hudson/plugins/tfs/commands/tf-changeset-french-1.txt
+++ b/src/test/resources/hudson/plugins/tfs/commands/tf-changeset-french-1.txt
@@ -1,0 +1,11 @@
+-------------------------------------------------------------------------------
+Ensemble de modifications: 302
+Utilisateur: georg
+Date: mercredi 13 juin 2012 16:24:59
+Commentaire:
+Éléments:
+  modifier $/InvestInform/commons/Utils14/src/main/java/de/safir/api/types/ApiSafirBool.java
+Notes d'archivage:
+  Vérificateur de code:
+  Vérificateur de la sécurité:
+  Vérificateur des performances:

--- a/src/test/resources/hudson/plugins/tfs/commands/tf-changeset-french-2.txt
+++ b/src/test/resources/hudson/plugins/tfs/commands/tf-changeset-french-2.txt
@@ -1,0 +1,11 @@
+-------------------------------------------------------------------------------
+Ensemble de modifications: 303
+Utilisateur: georg
+Date: mercredi 13 juin 2012 16:24:59
+Commentaire :
+Éléments  :
+  modifier $/InvestInform/commons/Utils14/src/main/java/de/safir/api/types/ApiSafirBool.java
+Notes d'archivage :
+  Vérificateur de code :
+  Vérificateur de la sécurité :
+  Vérificateur des performances :


### PR DESCRIPTION
This set of modifications fix french issue (using charset Windows-1252).
The plugin can parse ChangeSet from the french version of tf.exe.
Should fix problem the previous pull-request