### PR TITLE
Fix UnsatisfiedLinkError when path to plugin contains spaces.

### DIFF
--- a/src/main/java/hudson/plugins/tfs/model/Server.java
+++ b/src/main/java/hudson/plugins/tfs/model/Server.java
@@ -8,6 +8,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.Reader;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.security.CodeSource;
 import java.security.ProtectionDomain;
@@ -67,7 +68,15 @@ public class Server implements ServerConfigurationProvider, Closable {
             final CodeSource codeSource = protectionDomain.getCodeSource();
             // TODO: codeSource could be null; what should we do, then?
             final URL location = codeSource.getLocation();
-            final String stringPathToJar = location.getFile();
+            URI locationUri = null;
+            try {
+                locationUri = location.toURI();
+            } catch (URISyntaxException e) {
+                // this shouldn't happen
+                // TODO: consider logging this situation if it ever happens
+                return;
+            }
+            final String stringPathToJar = locationUri.getPath();
             final File pathToJar = new File(stringPathToJar);
             final File pathToLibFolder = pathToJar.getParentFile();
             final File pathToNativeFolder = new File(pathToLibFolder, "native");


### PR DESCRIPTION
Convert URL to URI for decoding.
URI will decode entities when retrieving the path, something URL won't do.  This makes a difference when the location was something like `file:/C:/Program%20Files/Jenkins/`.

Manual testing:
1. Created a Windows 7 x64 VM.
2. Downloaded Jenkins 1.536 for Windows and ran the installer, picking defaults.
3. Installed the TFS plugin version 3.0.0.
4. Created a job that used TFS as the SCM.
5. Ran the job
5.1. The job failed with an `UnsatisfiedLinkError`
5.2. The value of the `com.microsoft.tfs.jni.native.base-directory` property looked like `C:\Program%20Files%20(x86)\Jenkins\plugins\tfs\WEB-INF\lib\native`
6. Upgraded the TFS plugin to version 3.0.1-SNAPSHOT by restarting Jenkins.
7. Ran the job again.
7.1. The job suceeeded.
7.2. The value of the `com.microsoft.tfs.jni.native.base-directory` property looked like `C:\Program Files (x86)\Jenkins\plugins\tfs\WEB-INF\lib\native`
