### PR TITLE
Safely convert URI to File

### DIFF
--- a/src/main/java/hudson/plugins/tfs/model/Server.java
+++ b/src/main/java/hudson/plugins/tfs/model/Server.java
@@ -66,14 +66,22 @@ public class Server implements ServerConfigurationProvider, Closable {
             final Class<TFSTeamProjectCollection> metaclass = TFSTeamProjectCollection.class;
             final ProtectionDomain protectionDomain = metaclass.getProtectionDomain();
             final CodeSource codeSource = protectionDomain.getCodeSource();
-            // TODO: codeSource could be null; what should we do, then?
+            if (codeSource == null) {
+                // TODO: log that we were unable to determine the codeSource
+                return;
+            }
             final URL location = codeSource.getLocation();
-            URI locationUri = null;
-            try {
-                locationUri = location.toURI();
-            } catch (URISyntaxException e) {
-                // this shouldn't happen
-                // TODO: consider logging this situation if it ever happens
+            // inspired by http://hg.netbeans.org/main/file/default/openide.filesystems/src/org/openide/filesystems/FileUtil.java#l1992
+            final String u = location.toString();
+            URI locationUri;
+            if (u.startsWith("jar:file:") && u.endsWith("!/")) {
+                locationUri = URI.create(u.substring(4, u.length() - 2));
+            }
+            else if (u.startsWith("file:")) {
+                locationUri = URI.create(u);
+            }
+            else {
+                // TODO: log that we were unable to determine location from codeSource
                 return;
             }
             final File pathToJar = new File(locationUri);


### PR DESCRIPTION
Addressing @jglick's [comment](https://github.com/jenkinsci/tfs-plugin/commit/f4e33a28f622f36a2f725b7ed3692877720a043e#commitcomment-4588234) on f4e33a28f622f36a2f725b7ed3692877720a043e regarding the unsafe conversion of `URI` to `File`.
