### PR TITLE
Support workspace cloaking through a delimited list of server paths

### DIFF
--- a/src/main/java/hudson/plugins/tfs/TeamFoundationServerScm.java
+++ b/src/main/java/hudson/plugins/tfs/TeamFoundationServerScm.java
@@ -5,7 +5,10 @@ import static hudson.Util.fixEmpty;
 import java.io.File;
 import java.io.IOException;
 import java.text.ParseException;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Calendar;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
@@ -74,6 +77,7 @@ public class TeamFoundationServerScm extends SCM {
 
     private final String serverUrl;
     private final String projectPath;
+    private final Collection<String> cloakPaths;
     private final String localPath;
     private final String workspaceName;
     private transient @Deprecated String userPassword;
@@ -89,12 +93,12 @@ public class TeamFoundationServerScm extends SCM {
     private static final Logger logger = Logger.getLogger(TeamFoundationServerScm.class.getName());
 
     @Deprecated
-    public TeamFoundationServerScm(String serverUrl, String projectPath, String localPath, boolean useUpdate, String workspaceName, String userName, String password) {
-        this(serverUrl, projectPath, localPath, useUpdate, workspaceName, userName, Secret.fromString(password));
+    public TeamFoundationServerScm(String serverUrl, String projectPath, String cloakPaths, String localPath, boolean useUpdate, String workspaceName, String userName, String password) {
+        this(serverUrl, projectPath, cloakPaths, localPath, useUpdate, workspaceName, userName, Secret.fromString(password));
     }
 
     @DataBoundConstructor
-    public TeamFoundationServerScm(String serverUrl, String projectPath, String localPath, boolean useUpdate, String workspaceName, String userName, Secret password) {
+    public TeamFoundationServerScm(String serverUrl, String projectPath, String cloakPaths, String localPath, boolean useUpdate, String workspaceName, String userName, Secret password) {
         this.serverUrl = serverUrl;
         this.projectPath = projectPath;
         this.useUpdate = useUpdate;
@@ -102,6 +106,14 @@ public class TeamFoundationServerScm extends SCM {
         this.workspaceName = (Util.fixEmptyAndTrim(workspaceName) == null ? "Hudson-${JOB_NAME}-${NODE_NAME}" : workspaceName);
         this.userName = userName;
         this.password = password;
+        
+        List<String> cloakPathsList = new ArrayList<String>();
+        if (cloakPaths != null && !cloakPaths.isEmpty()) {
+        	for (String cloakPath : cloakPaths.split(";")) {
+        		cloakPathsList.add(cloakPath.trim());
+        	}
+        }
+        this.cloakPaths = cloakPathsList;
     }
 
     /* Migrate legacy data */
@@ -122,6 +134,10 @@ public class TeamFoundationServerScm extends SCM {
 
     public String getProjectPath() {
         return projectPath;
+    }
+
+    public String getCloakPaths() {
+    	return StringUtils.join(cloakPaths, ";\n");
     }
 
     public String getLocalPath() {
@@ -178,7 +194,7 @@ public class TeamFoundationServerScm extends SCM {
     public boolean checkout(AbstractBuild<?, ?> build, Launcher launcher, FilePath workspaceFilePath, BuildListener listener, File changelogFile) throws IOException, InterruptedException {
         Server server = createServer(new TfTool(getDescriptor().getTfExecutable(), launcher, listener, workspaceFilePath), build);
         try {
-            WorkspaceConfiguration workspaceConfiguration = new WorkspaceConfiguration(server.getUrl(), getWorkspaceName(build, Computer.currentComputer()), getProjectPath(build), getLocalPath());
+            WorkspaceConfiguration workspaceConfiguration = new WorkspaceConfiguration(server.getUrl(), getWorkspaceName(build, Computer.currentComputer()), getProjectPath(build), cloakPaths, getLocalPath());
             
             // Check if the configuration has changed
             if (build.getPreviousBuild() != null) {
@@ -194,7 +210,7 @@ public class TeamFoundationServerScm extends SCM {
             }
             
             build.addAction(workspaceConfiguration);
-            CheckoutAction action = new CheckoutAction(workspaceConfiguration.getWorkspaceName(), workspaceConfiguration.getProjectPath(), workspaceConfiguration.getWorkfolder(), isUseUpdate());
+            CheckoutAction action = new CheckoutAction(workspaceConfiguration.getWorkspaceName(), workspaceConfiguration.getProjectPath(), workspaceConfiguration.getCloakPaths(), workspaceConfiguration.getWorkfolder(), isUseUpdate());
             try {
                 List<ChangeSet> list = checkout(build, workspaceFilePath, server, action);
                 ChangeSetWriter writer = new ChangeSetWriter();
@@ -207,7 +223,7 @@ public class TeamFoundationServerScm extends SCM {
             try {
                 setWorkspaceChangesetVersion(null);
                 String projectPath = workspaceConfiguration.getProjectPath();
-                Project project = server.getProject(projectPath);
+                Project project = server.getProject(projectPath, workspaceConfiguration.getCloakPaths());
                 // TODO: even better would be to call this first, then use the changeset when calling checkout
                 int buildChangeset = project.getRemoteChangesetVersion(build.getTimestamp());
                 setWorkspaceChangesetVersion(Integer.toString(buildChangeset, 10));
@@ -253,7 +269,7 @@ public class TeamFoundationServerScm extends SCM {
         } else {
             Server server = createServer(new TfTool(getDescriptor().getTfExecutable(), launcher, listener, workspace), lastRun);
             try {
-                return (server.getProject(getProjectPath(lastRun)).getDetailedHistory(
+                return (server.getProject(getProjectPath(lastRun), cloakPaths).getDetailedHistory(
                             lastRun.getTimestamp(), 
                             Calendar.getInstance()
                         ).size() > 0);
@@ -376,6 +392,8 @@ public class TeamFoundationServerScm extends SCM {
         public static final Pattern USER_AT_DOMAIN_REGEX = Pattern.compile("^([^\\/\\\\\"\\[\\]:|<>+=;,\\*@]+)@([a-z][a-z0-9.-]+)$", Pattern.CASE_INSENSITIVE);
         public static final Pattern DOMAIN_SLASH_USER_REGEX = Pattern.compile("^([a-z][a-z0-9.-]+)\\\\([^\\/\\\\\"\\[\\]:|<>+=;,\\*@]+)$", Pattern.CASE_INSENSITIVE);
         public static final Pattern PROJECT_PATH_REGEX = Pattern.compile("^\\$\\/.*", Pattern.CASE_INSENSITIVE);
+        public static final Pattern CLOAK_PATHS_REGEX = Pattern.compile("^\\$[^\\$;]+(\\s*;\\s*\\$[^\\$;]+){0,}$", Pattern.CASE_INSENSITIVE);
+        
         private String tfExecutable;
         
         public DescriptorImpl() {
@@ -437,6 +455,12 @@ public class TeamFoundationServerScm extends SCM {
                     "Workspace name is mandatory", value);
         }
         
+        public FormValidation doCloakPathsCheck(@QueryParameter final String value) {
+            return doRegexCheck(new Pattern[]{CLOAK_PATHS_REGEX},
+                    "Each cloak path must begin with '$/'. Multiple paths must be delimited with ';'.", 
+                    null, value );
+        }
+        
         @Override
         public boolean configure(StaplerRequest req, JSONObject formData) throws FormException {
             tfExecutable = Util.fixEmpty(req.getParameter("tfs.tfExecutable").trim());
@@ -488,7 +512,7 @@ public class TeamFoundationServerScm extends SCM {
         Run<?, ?> build = project.getLastBuild();
         final TfTool tool = new TfTool(getDescriptor().getTfExecutable(), localLauncher, listener, workspace);
         final Server server = createServer(tool, build);
-        final Project tfsProject = server.getProject(projectPath);
+        final Project tfsProject = server.getProject(projectPath, cloakPaths);
         try {
             final List<ChangeSet> briefHistory = tfsProject.getBriefHistory(
                         tfsBaseline.changesetVersion,

--- a/src/main/java/hudson/plugins/tfs/TeamFoundationServerScm.java
+++ b/src/main/java/hudson/plugins/tfs/TeamFoundationServerScm.java
@@ -106,14 +106,17 @@ public class TeamFoundationServerScm extends SCM {
         this.workspaceName = (Util.fixEmptyAndTrim(workspaceName) == null ? "Hudson-${JOB_NAME}-${NODE_NAME}" : workspaceName);
         this.userName = userName;
         this.password = password;
-        
+        this.cloakPaths = splitCloakPaths(cloakPaths);;
+    }
+    
+    private List<String> splitCloakPaths(String cloakPaths) {
         List<String> cloakPathsList = new ArrayList<String>();
-        if (cloakPaths != null && !cloakPaths.isEmpty()) {
-        	for (String cloakPath : cloakPaths.split(";")) {
-        		cloakPathsList.add(cloakPath.trim());
-        	}
+        if (cloakPaths != null && cloakPaths.trim().length() > 0) {
+            for (String cloakPath : cloakPaths.split(";")) {
+                cloakPathsList.add(cloakPath.trim());
+            }
         }
-        this.cloakPaths = cloakPathsList;
+        return cloakPathsList;
     }
 
     /* Migrate legacy data */

--- a/src/main/java/hudson/plugins/tfs/actions/CheckoutAction.java
+++ b/src/main/java/hudson/plugins/tfs/actions/CheckoutAction.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Calendar;
+import java.util.Collection;
 import java.util.List;
 
 import hudson.FilePath;
@@ -18,12 +19,14 @@ public class CheckoutAction {
 
     private final String workspaceName;
     private final String projectPath;
+    private Collection<String> cloakPaths;
     private final String localFolder;
     private final boolean useUpdate;
 
-    public CheckoutAction(String workspaceName, String projectPath, String localFolder, boolean useUpdate) {
+    public CheckoutAction(String workspaceName, String projectPath, Collection<String> cloakPaths, String localFolder, boolean useUpdate) {
         this.workspaceName = workspaceName;
         this.projectPath = projectPath;
+        this.cloakPaths = cloakPaths;
         this.localFolder = localFolder;
         this.useUpdate = useUpdate;
     }
@@ -51,7 +54,7 @@ public class CheckoutAction {
     private Project getProject(Server server, FilePath workspacePath)
 			throws IOException, InterruptedException {
 		Workspaces workspaces = server.getWorkspaces();
-        Project project = server.getProject(projectPath);
+        Project project = server.getProject(projectPath, cloakPaths);
         
         if (workspaces.exists(workspaceName) && !useUpdate) {
             Workspace workspace = workspaces.getWorkspace(workspaceName);

--- a/src/main/java/hudson/plugins/tfs/commands/CloakCommand.java
+++ b/src/main/java/hudson/plugins/tfs/commands/CloakCommand.java
@@ -1,0 +1,33 @@
+package hudson.plugins.tfs.commands;
+
+import hudson.plugins.tfs.util.MaskedArgumentListBuilder;
+
+public class CloakCommand extends AbstractCommand {
+
+    private final String projectPath;
+    private final String workspaceName;
+    
+    public CloakCommand(ServerConfigurationProvider provider, 
+            String projectPath) {
+        this(provider, projectPath, null);
+    }
+
+    public CloakCommand(ServerConfigurationProvider provider, 
+            String projectPath, String workspaceName) {
+        super(provider);
+        this.projectPath = projectPath;
+        this.workspaceName = workspaceName;
+    }
+
+    public MaskedArgumentListBuilder getArguments() {
+        MaskedArgumentListBuilder arguments = new MaskedArgumentListBuilder();        
+        arguments.add("workfold");        
+        arguments.add("-cloak");
+        arguments.add(projectPath);
+        if (workspaceName != null) {
+            arguments.add(String.format("-workspace:%s", workspaceName));
+        }
+        addLoginArgument(arguments);
+        return arguments;
+    }
+}

--- a/src/main/java/hudson/plugins/tfs/model/Project.java
+++ b/src/main/java/hudson/plugins/tfs/model/Project.java
@@ -11,6 +11,7 @@ import java.io.Reader;
 import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Calendar;
+import java.util.Collection;
 import java.util.Date;
 import java.util.List;
 
@@ -35,15 +36,21 @@ import com.microsoft.tfs.core.clients.webservices.IdentityManagementService;
 public class Project {
 
     private final String projectPath;
+    private final Collection<String> cloakPaths;
     private final Server server;
 
-    public Project(Server server, String projectPath) {
+    public Project(Server server, String projectPath, Collection<String> cloakPaths) {
         this.server = server;
         this.projectPath = projectPath;
+        this.cloakPaths = cloakPaths;
     }
 
     public String getProjectPath() {
         return projectPath;
+    }
+
+    public Collection<String> getCloakPaths() {
+        return cloakPaths;
     }
 
     static hudson.plugins.tfs.model.ChangeSet.Item convertServerChange

--- a/src/main/java/hudson/plugins/tfs/model/Server.java
+++ b/src/main/java/hudson/plugins/tfs/model/Server.java
@@ -1,6 +1,7 @@
 package hudson.plugins.tfs.model;
 
 import com.microsoft.tfs.core.TFSConfigurationServer;
+
 import hudson.plugins.tfs.TfTool;
 import hudson.plugins.tfs.commands.ServerConfigurationProvider;
 import hudson.plugins.tfs.util.MaskedArgumentListBuilder;
@@ -14,6 +15,7 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.security.CodeSource;
 import java.security.ProtectionDomain;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -97,9 +99,9 @@ public class Server implements ServerConfigurationProvider, Closable {
         this(null, url, null, null);
     }
 
-    public Project getProject(String projectPath) {
+    public Project getProject(String projectPath, Collection<String> cloakPaths) {
         if (! projects.containsKey(projectPath)) {
-            projects.put(projectPath, new Project(this, projectPath));
+            projects.put(projectPath, new Project(this, projectPath, cloakPaths));
         }
         return projects.get(projectPath);
     }

--- a/src/main/java/hudson/plugins/tfs/model/Workspace.java
+++ b/src/main/java/hudson/plugins/tfs/model/Workspace.java
@@ -8,6 +8,7 @@ import java.util.List;
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
 
+import hudson.plugins.tfs.commands.CloakCommand;
 import hudson.plugins.tfs.commands.GetWorkspaceMappingsCommand;
 import hudson.plugins.tfs.commands.MapWorkfolderCommand;
 import hudson.plugins.tfs.commands.UnmapWorkfolderCommand;
@@ -35,6 +36,11 @@ public class Workspace {
     public void mapWorkfolder(Project project, String workFolder) throws IOException, InterruptedException {
         MapWorkfolderCommand command = new MapWorkfolderCommand(server, project.getProjectPath(), workFolder, name);
         server.execute(command.getArguments()).close();
+        
+    	for (String cloakPath : project.getCloakPaths()) {
+    		CloakCommand cloakCommand = new CloakCommand(server, cloakPath);
+    		server.execute(cloakCommand.getArguments()).close();
+    	}
     }
 
     public void unmapWorkfolder(String workFolder) throws IOException, InterruptedException {

--- a/src/main/java/hudson/plugins/tfs/model/WorkspaceConfiguration.java
+++ b/src/main/java/hudson/plugins/tfs/model/WorkspaceConfiguration.java
@@ -1,6 +1,7 @@
 package hudson.plugins.tfs.model;
 
 import java.io.Serializable;
+import java.util.Collection;
 
 import hudson.model.InvisibleAction;
 
@@ -16,13 +17,15 @@ public class WorkspaceConfiguration extends InvisibleAction implements Serializa
     private final String workspaceName;
     private final String workfolder;
     private final String projectPath;
+    private Collection<String> cloakPaths;
     private final String serverUrl;
     private boolean workspaceExists;
 
-    public WorkspaceConfiguration(String serverUrl, String workspaceName, String projectPath, String workfolder) {
+    public WorkspaceConfiguration(String serverUrl, String workspaceName, String projectPath, Collection<String> cloakPaths, String workfolder) {
         this.workspaceName = workspaceName;
         this.workfolder = workfolder;
         this.projectPath = projectPath;
+        this.cloakPaths = cloakPaths;
         this.serverUrl = serverUrl;
         this.workspaceExists = true;
     }
@@ -31,6 +34,7 @@ public class WorkspaceConfiguration extends InvisibleAction implements Serializa
         this.workspaceName = configuration.workspaceName;
         this.workfolder = configuration.workfolder;
         this.projectPath = configuration.projectPath;
+        this.cloakPaths = configuration.cloakPaths;
         this.serverUrl = configuration.serverUrl;
         this.workspaceExists = configuration.workspaceExists;
     }
@@ -47,6 +51,9 @@ public class WorkspaceConfiguration extends InvisibleAction implements Serializa
         return projectPath;
     }
 
+    public Collection<String> getCloakPaths() {
+        return cloakPaths;
+    }
     public String getServerUrl() {
         return serverUrl;
     }
@@ -64,6 +71,7 @@ public class WorkspaceConfiguration extends InvisibleAction implements Serializa
         final int prime = 31;
         int result = 1;
         result = prime * result + ((projectPath == null) ? 0 : projectPath.hashCode());
+        result = prime * result + ((cloakPaths == null) ? 0 : cloakPaths.hashCode());
         result = prime * result + ((serverUrl == null) ? 0 : serverUrl.hashCode());
         result = prime * result + ((workfolder == null) ? 0 : workfolder.hashCode());
         result = prime * result + (workspaceExists ? 1231 : 1237);
@@ -85,6 +93,15 @@ public class WorkspaceConfiguration extends InvisibleAction implements Serializa
                 return false;
         } else if (!projectPath.equals(other.projectPath))
             return false;
+        if (cloakPaths == null) {
+        	if (other.cloakPaths != null)
+        		return false;
+        } else if (other.cloakPaths == null)
+        	return false;
+        else if (cloakPaths.size() != other.cloakPaths.size())
+        	return false;
+        else if (!cloakPaths.containsAll(other.cloakPaths))
+        	return false;
         if (serverUrl == null) {
             if (other.serverUrl != null)
                 return false;

--- a/src/main/resources/hudson/plugins/tfs/TeamFoundationServerScm/config.jelly
+++ b/src/main/resources/hudson/plugins/tfs/TeamFoundationServerScm/config.jelly
@@ -18,18 +18,22 @@
 
     <f:advanced>
 
-		<f:entry field="useUpdate" title="Use update" description="If checked, Hudson will not delete the workspace at end of each build, making the build faster. But this causes the artifacts from the previous build to remain when a new build starts.">
-			<f:checkbox default="true"/>
-		</f:entry>
+        <f:entry field="useUpdate" title="Use update" description="If checked, Hudson will not delete the workspace at end of each build, making the build faster. But this causes the artifacts from the previous build to remain when a new build starts.">
+            <f:checkbox default="true"/>
+        </f:entry>
     
-	    <f:entry field="localPath" title="Local workfolder">
-	        <f:textbox default="."
-	             clazz="required" checkMessage="${%Local workfolder is mandatory, empty field will use job workspace as workfolder.}"/>
-	    </f:entry>
+        <f:entry field="localPath" title="Local workfolder">
+            <f:textbox default="."
+                clazz="required" checkMessage="${%Local workfolder is mandatory, empty field will use job workspace as workfolder.}"/>
+        </f:entry>
 
         <f:entry field="workspaceName" title="Workspace name">
             <f:textbox default="Hudson-$${JOB_NAME}-$${NODE_NAME}"
-             checkUrl="'${rootURL}/scm/TeamFoundationServerScm/workspaceNameCheck?value='+escape(this.value)"/>
+                checkUrl="'${rootURL}/scm/TeamFoundationServerScm/workspaceNameCheck?value='+escape(this.value)"/>
+        </f:entry>
+    
+        <f:entry field="cloakPaths" title="Cloak Paths">
+            <f:textarea checkUrl="'${rootURL}/scm/TeamFoundationServerScm/cloakPathsCheck?value='+escape(this.value)"/>
         </f:entry>
     </f:advanced>
     

--- a/src/main/resources/hudson/plugins/tfs/TeamFoundationServerScm/help-cloakPaths.html
+++ b/src/main/resources/hudson/plugins/tfs/TeamFoundationServerScm/help-cloakPaths.html
@@ -1,0 +1,11 @@
+<div>
+  <p>
+	A collection of TFS server paths to cloak to prevent their inclusion in the workspace.
+	Paths that are cloaked will not be pulled into the local workspace when the contents
+	from TFS are pulled down.
+  </p>
+  <p>
+	Multiple entries must be delimited by semicolon characters (';'). Entries can be placed
+	onto separate lines, but still require the delimiter.
+  </p>
+</div>

--- a/src/test/java/hudson/plugins/tfs/TeamFoundationServerScmTest.java
+++ b/src/test/java/hudson/plugins/tfs/TeamFoundationServerScmTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import java.io.File;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -46,7 +47,7 @@ public class TeamFoundationServerScmTest {
         when(build.getProject()).thenReturn(project);
         when(project.getName()).thenReturn("ThisIsAJob");
 
-        TeamFoundationServerScm scm = new TeamFoundationServerScm(null, null, ".", false, "erik_${JOB_NAME}", "user", "password");
+        TeamFoundationServerScm scm = new TeamFoundationServerScm(null, null, null, ".", false, "erik_${JOB_NAME}", "user", "password");
         assertEquals("Workspace name was incorrect", "erik_ThisIsAJob", scm.getWorkspaceName(build, mock(Computer.class)));
     }
     
@@ -88,22 +89,33 @@ public class TeamFoundationServerScmTest {
         assertTrue("Workspace name regex dit not match an invalid workspace name", TeamFoundationServerScm.DescriptorImpl.WORKSPACE_NAME_REGEX.matcher("work space").matches());
     }
     
+    @Test 
+    public void assertDoCloakPathsCheckRegexWorks() {
+        assertFalse("Cloak paths regex matched an invalid cloak path", TeamFoundationServerScm.DescriptorImpl.CLOAK_PATHS_REGEX.matcher("tfsandbox").matches());
+        assertFalse("Cloak paths regex matched an invalid cloak path", TeamFoundationServerScm.DescriptorImpl.CLOAK_PATHS_REGEX.matcher("tfsandbox/with/sub/pathes").matches());
+        assertFalse("Cloak paths regex matched an invalid cloak path", TeamFoundationServerScm.DescriptorImpl.CLOAK_PATHS_REGEX.matcher("tfsandbox$/with/sub/pathes").matches());
+        assertTrue("Cloak paths regex did not match a valid cloak path", TeamFoundationServerScm.DescriptorImpl.CLOAK_PATHS_REGEX.matcher("$/tfsandbox").matches());
+        assertTrue("Cloak paths regex did not match a valid cloak path", TeamFoundationServerScm.DescriptorImpl.CLOAK_PATHS_REGEX.matcher("$/tfsandbox/path with space/subpath").matches());
+        assertTrue("Cloak paths regex did not match a valid cloak path", TeamFoundationServerScm.DescriptorImpl.CLOAK_PATHS_REGEX.matcher("$/tfsandbox/path1;$/tfsandbox/path2").matches());
+        assertTrue("Cloak paths regex did not match a valid cloak path", TeamFoundationServerScm.DescriptorImpl.CLOAK_PATHS_REGEX.matcher("$/tfsandbox/path1 ; $/tfsandbox/path2 ; $/tfsandbox/path3").matches());
+    }
+    
     @Test
     public void assertDefaultValueIsUsedForEmptyLocalPath() {
-        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", "", false, "workspace", "user", "password");
+        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", null, "", false, "workspace", "user", "password");
         assertEquals("Default value for work folder was incorrect", ".", scm.getLocalPath());
     }
     
     @Test
     public void assertDefaultValueIsUsedForEmptyWorkspaceName() {
-        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", ".", false, "", "user", "password");
+        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", null, ".", false, "", "user", "password");
         assertEquals("Default value for workspace was incorrect", "Hudson-${JOB_NAME}-${NODE_NAME}", scm.getWorkspaceName());
     }
     
     @Test
     public void assertGetModuleRootReturnsWorkFolder() throws Exception {
         workspace = Util.createTempFilePath();
-        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", "workfolder", false, "", "user", "password");
+        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", null, "workfolder", false, "", "user", "password");
         FilePath moduleRoot = scm.getModuleRoot(workspace);
         assertEquals("Name for module root was incorrect", "workfolder", moduleRoot.getName());
         assertEquals("The parent for module root was incorrect", workspace.getName(), moduleRoot.getParent().getName());
@@ -112,7 +124,7 @@ public class TeamFoundationServerScmTest {
     @Test
     public void assertGetModuleRootWorksForDotWorkFolder() throws Exception {
         workspace = Util.createTempFilePath();
-        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", ".", false, "", "user", "password");
+        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", null, ".", false, "", "user", "password");
         FilePath moduleRoot = scm.getModuleRoot(workspace);
         assertTrue("The module root was reported as not existing even if its virtually the same as workspace",
                 moduleRoot.exists());
@@ -121,7 +133,7 @@ public class TeamFoundationServerScmTest {
     
     @Test
     public void assertWorkspaceNameIsAddedToEnvVars() throws Exception {
-        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", ".", false, "WORKSPACE_SAMPLE", "user", "password");
+        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", null, ".", false, "WORKSPACE_SAMPLE", "user", "password");
         AbstractBuild build = mock(AbstractBuild.class);
         AbstractProject project = mock(AbstractProject.class);
         when(build.getProject()).thenReturn(project);
@@ -134,7 +146,7 @@ public class TeamFoundationServerScmTest {
     
     @Test
     public void assertWorksfolderPathIsAddedToEnvVars() throws Exception {
-        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", "PATH", false, "WORKSPACE_SAMPLE", "user", "password");
+        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", null, "PATH", false, "WORKSPACE_SAMPLE", "user", "password");
         
         Map<String, String> env = new HashMap<String, String>();
         env.put("WORKSPACE", "/this/is/a");
@@ -144,7 +156,7 @@ public class TeamFoundationServerScmTest {
     
     @Test
     public void assertProjectPathIsAddedToEnvVars() throws Exception {
-        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", "PATH", false, "WORKSPACE_SAMPLE", "user", "password");
+        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", null, "PATH", false, "WORKSPACE_SAMPLE", "user", "password");
         Map<String, String> env = new HashMap<String, String>();
         scm.buildEnvVars(mock(AbstractBuild.class), env );        
         assertEquals("The project path was incorrect", "projectpath", env.get(TeamFoundationServerScm.PROJECTPATH_ENV_STR));
@@ -152,7 +164,7 @@ public class TeamFoundationServerScmTest {
     
     @Test
     public void assertServerUrlIsAddedToEnvVars() throws Exception {
-        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", "PATH", false, "WORKSPACE_SAMPLE", "user", "password");
+        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", null, "PATH", false, "WORKSPACE_SAMPLE", "user", "password");
         Map<String, String> env = new HashMap<String, String>();
         scm.buildEnvVars(mock(AbstractBuild.class), env );        
         assertEquals("The server URL was incorrect", "serverurl", env.get(TeamFoundationServerScm.SERVERURL_ENV_STR));
@@ -160,7 +172,7 @@ public class TeamFoundationServerScmTest {
     
     @Test
     public void assertTfsUserNameIsAddedToEnvVars() throws Exception {
-        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", "PATH", false, "WORKSPACE_SAMPLE", "user", "password");
+        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", null, "PATH", false, "WORKSPACE_SAMPLE", "user", "password");
         Map<String, String> env = new HashMap<String, String>();
         scm.buildEnvVars(mock(AbstractBuild.class), env );        
         assertEquals("The TFS user name was incorrect", "user", env.get(TeamFoundationServerScm.USERNAME_ENV_STR));
@@ -168,7 +180,7 @@ public class TeamFoundationServerScmTest {
     
     @Test
     public void assertTfsWorkspaceChangesetIsAddedToEnvVars() throws Exception {
-        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", "PATH", false, "WORKSPACE_SAMPLE", "user", "password");
+        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", null, "PATH", false, "WORKSPACE_SAMPLE", "user", "password");
         scm.setWorkspaceChangesetVersion("12345");
         Map<String, String> env = new HashMap<String, String>();
         scm.buildEnvVars(mock(AbstractBuild.class), env );        
@@ -177,7 +189,7 @@ public class TeamFoundationServerScmTest {
   
     @Test
     public void assertTfsWorkspaceChangesetIsNotAddedToEnvVarsIfEmpty() throws Exception {
-        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", "PATH", false, "WORKSPACE_SAMPLE", "user", "password");
+        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", null, "PATH", false, "WORKSPACE_SAMPLE", "user", "password");
         scm.setWorkspaceChangesetVersion("");
         Map<String, String> env = new HashMap<String, String>();
         scm.buildEnvVars(mock(AbstractBuild.class), env );        
@@ -186,7 +198,7 @@ public class TeamFoundationServerScmTest {
 
     @Test
     public void assertTfsWorkspaceChangesetIsNotAddedToEnvVarsIfNull() throws Exception {
-        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", "PATH", false, "WORKSPACE_SAMPLE", "user", "password");
+        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", null, "PATH", false, "WORKSPACE_SAMPLE", "user", "password");
         scm.setWorkspaceChangesetVersion(null);
         Map<String, String> env = new HashMap<String, String>();
         scm.buildEnvVars(mock(AbstractBuild.class), env );        
@@ -198,7 +210,7 @@ public class TeamFoundationServerScmTest {
      */
     @Test
     public void assertWorkspaceNameReplacesInvalidChars() {
-        TeamFoundationServerScm scm = new TeamFoundationServerScm(null, null, ".", false, "A\"B/C:D<E>F|G*H?I", "user", "password");
+        TeamFoundationServerScm scm = new TeamFoundationServerScm(null, null, null, ".", false, "A\"B/C:D<E>F|G*H?I", "user", "password");
         assertEquals("Workspace name contained invalid chars", "A_B_C_D_E_F_G_H_I", scm.getWorkspaceName(null, null));
     }
     
@@ -207,7 +219,7 @@ public class TeamFoundationServerScmTest {
      */
     @Test
     public void assertWorkspaceNameReplacesEndingPeriod() {
-        TeamFoundationServerScm scm = new TeamFoundationServerScm(null, null, ".", false, "Workspace.Name.", "user", "password");
+        TeamFoundationServerScm scm = new TeamFoundationServerScm(null, null, null, ".", false, "Workspace.Name.", "user", "password");
         assertEquals("Workspace name ends with period", "Workspace.Name_", scm.getWorkspaceName(null, null));
     }
     
@@ -216,7 +228,7 @@ public class TeamFoundationServerScmTest {
      */
     @Test
     public void assertWorkspaceNameReplacesEndingSpace() {
-        TeamFoundationServerScm scm = new TeamFoundationServerScm(null, null, ".", false, "Workspace Name ", "user", "password");
+        TeamFoundationServerScm scm = new TeamFoundationServerScm(null, null, null, ".", false, "Workspace Name ", "user", "password");
         assertEquals("Workspace name ends with space", "Workspace Name_", scm.getWorkspaceName(null, null));
     }    
     
@@ -226,7 +238,7 @@ public class TeamFoundationServerScmTest {
         AbstractBuild build = mock(AbstractBuild.class);
         when(build.getAction(ParametersAction.class)).thenReturn(action);
 
-        TeamFoundationServerScm scm = new TeamFoundationServerScm("https://${PARAM}.com", null, ".", false, "", "user", "password");
+        TeamFoundationServerScm scm = new TeamFoundationServerScm("https://${PARAM}.com", null, null, ".", false, "", "user", "password");
         assertEquals("The server url wasnt resolved", "https://RESOLVED.com", scm.getServerUrl(build));
     }    
     
@@ -236,7 +248,7 @@ public class TeamFoundationServerScmTest {
         AbstractBuild build = mock(AbstractBuild.class);
         when(build.getAction(ParametersAction.class)).thenReturn(action);
 
-        TeamFoundationServerScm scm = new TeamFoundationServerScm(null, "$/$PARAM/path", ".", false, "", "user", "password");
+        TeamFoundationServerScm scm = new TeamFoundationServerScm(null, "$/$PARAM/path", null, ".", false, "", "user", "password");
         assertEquals("The project path wasnt resolved", "$/RESOLVED/path", scm.getProjectPath(build));
     }    
     
@@ -246,14 +258,14 @@ public class TeamFoundationServerScmTest {
         AbstractBuild build = mock(AbstractBuild.class);
         when(build.getAction(ParametersAction.class)).thenReturn(action);
 
-        TeamFoundationServerScm scm = new TeamFoundationServerScm(null, null, ".", false, "WS-${PARAM}", "user", "password");
+        TeamFoundationServerScm scm = new TeamFoundationServerScm(null, null, null, ".", false, "WS-${PARAM}", "user", "password");
         assertEquals("The workspace name wasnt resolved", "WS-RESOLVED", scm.getWorkspaceName(build, mock(Computer.class)));
     }
     
     @Test public void assertTfsWorkspaceIsntRemovedIfThereIsNoBuildWhenProcessWorkspaceBeforeDeletion() throws Exception {
         AbstractProject project = mock(AbstractProject.class);
         Node node = mock(Node.class);
-        TeamFoundationServerScm scm = new TeamFoundationServerScm("server", "projectpath", ".", false, "workspace", "user", "password");
+        TeamFoundationServerScm scm = new TeamFoundationServerScm("server", "projectpath", null, ".", false, "workspace", "user", "password");
         assertThat(scm.processWorkspaceBeforeDeletion(project, workspace, node), is(true));
         verify(project).getLastBuild();
         verifyNoMoreInteractions(project);
@@ -269,7 +281,7 @@ public class TeamFoundationServerScmTest {
         when(build.getBuiltOn()).thenReturn(node).thenReturn(node);
         when(node.getNodeName()).thenReturn("node1").thenReturn("node2");
         when(inNode.getNodeName()).thenReturn("needleNode").thenReturn("needleNode");
-        TeamFoundationServerScm scm = new TeamFoundationServerScm("server", "projectpath", ".", false, "workspace", "user", "password");
+        TeamFoundationServerScm scm = new TeamFoundationServerScm("server", "projectpath", null, ".", false, "workspace", "user", "password");
         assertThat( scm.processWorkspaceBeforeDeletion(project, workspace, inNode), is(true));
         verify(project).getLastBuild();
         verify(node, times(2)).getNodeName();

--- a/src/test/java/hudson/plugins/tfs/actions/CheckoutActionTest.java
+++ b/src/test/java/hudson/plugins/tfs/actions/CheckoutActionTest.java
@@ -46,12 +46,12 @@ public class CheckoutActionTest {
     @Test
     public void assertFirstCheckoutByLabelNotUsingUpdate() throws Exception {
     	when(server.getWorkspaces()).thenReturn(workspaces);
-    	when(server.getProject("project")).thenReturn(project);
+    	when(server.getProject("project", new ArrayList<String>())).thenReturn(project);
     	when(workspaces.exists("workspace")).thenReturn(true).thenReturn(false);
     	when(workspaces.newWorkspace("workspace")).thenReturn(workspace);
     	when(workspaces.getWorkspace("workspace")).thenReturn(workspace);
     	
-    	new CheckoutAction("workspace", "project", ".", false).checkoutByLabel(server, hudsonWs,MY_LABEL);
+    	new CheckoutAction("workspace", "project", new ArrayList<String>(), ".", false).checkoutByLabel(server, hudsonWs,MY_LABEL);
     	
     	verify(workspaces).newWorkspace("workspace");
     	verify(workspace).mapWorkfolder(project, hudsonWs.getRemote());
@@ -62,12 +62,12 @@ public class CheckoutActionTest {
     @Test
     public void assertFirstCheckoutNotUsingUpdate() throws Exception {
         when(server.getWorkspaces()).thenReturn(workspaces);
-        when(server.getProject("project")).thenReturn(project);
+        when(server.getProject("project", new ArrayList<String>())).thenReturn(project);
         when(workspaces.exists("workspace")).thenReturn(true).thenReturn(false);
         when(workspaces.newWorkspace("workspace")).thenReturn(workspace);
         when(workspaces.getWorkspace("workspace")).thenReturn(workspace);
         
-        new CheckoutAction("workspace", "project", ".", false).checkout(server, hudsonWs,null, Util.getCalendar(2009, 9, 24));
+        new CheckoutAction("workspace", "project", new ArrayList<String>(), ".", false).checkout(server, hudsonWs,null, Util.getCalendar(2009, 9, 24));
         
         verify(workspaces).newWorkspace("workspace");
         verify(workspace).mapWorkfolder(project, hudsonWs.getRemote());
@@ -78,11 +78,11 @@ public class CheckoutActionTest {
     @Test
     public void assertFirstCheckoutByLabelUsingUpdate() throws Exception {
         when(server.getWorkspaces()).thenReturn(workspaces);
-        when(server.getProject("project")).thenReturn(project);
+        when(server.getProject("project", new ArrayList<String>())).thenReturn(project);
         when(workspaces.exists(new Workspace(server, "workspace"))).thenReturn(false);
         when(workspaces.newWorkspace("workspace")).thenReturn(workspace);
         
-        new CheckoutAction("workspace", "project", ".", true).checkoutByLabel(server, hudsonWs, MY_LABEL);
+        new CheckoutAction("workspace", "project", new ArrayList<String>(), ".", true).checkoutByLabel(server, hudsonWs, MY_LABEL);
         
         verify(workspaces).newWorkspace("workspace");
         verify(workspace).mapWorkfolder(project, hudsonWs.getRemote());
@@ -93,11 +93,11 @@ public class CheckoutActionTest {
     @Test
     public void assertFirstCheckoutUsingUpdate() throws Exception {
     	when(server.getWorkspaces()).thenReturn(workspaces);
-    	when(server.getProject("project")).thenReturn(project);
+    	when(server.getProject("project", new ArrayList<String>())).thenReturn(project);
     	when(workspaces.exists(new Workspace(server, "workspace"))).thenReturn(false);
     	when(workspaces.newWorkspace("workspace")).thenReturn(workspace);
     	
-    	new CheckoutAction("workspace", "project", ".", true).checkout(server, hudsonWs,null, Util.getCalendar(2009, 9, 24));
+    	new CheckoutAction("workspace", "project", new ArrayList<String>(), ".", true).checkout(server, hudsonWs,null, Util.getCalendar(2009, 9, 24));
     	
     	verify(workspaces).newWorkspace("workspace");
     	verify(workspace).mapWorkfolder(project, hudsonWs.getRemote());
@@ -108,13 +108,13 @@ public class CheckoutActionTest {
     @Test
     public void assertSecondCheckoutByLabelUsingUpdate() throws Exception {
         when(server.getWorkspaces()).thenReturn(workspaces);
-        when(server.getProject("project")).thenReturn(project);
+        when(server.getProject("project", new ArrayList<String>())).thenReturn(project);
         when(workspaces.exists("workspace")).thenReturn(true);
         when(workspaces.getWorkspace("workspace")).thenReturn(workspace);
         when(server.getLocalHostname()).thenReturn("LocalComputer");
         when(workspace.getComputer()).thenReturn("LocalComputer");
         
-        new CheckoutAction("workspace", "project", ".", true).checkoutByLabel(server, hudsonWs, MY_LABEL);
+        new CheckoutAction("workspace", "project", new ArrayList<String>(), ".", true).checkoutByLabel(server, hudsonWs, MY_LABEL);
 
         verify(project).getFiles(".", MY_LABEL);
         verify(workspaces, never()).newWorkspace("workspace");
@@ -125,13 +125,13 @@ public class CheckoutActionTest {
     @Test
     public void assertSecondCheckoutUsingUpdate() throws Exception {
         when(server.getWorkspaces()).thenReturn(workspaces);
-        when(server.getProject("project")).thenReturn(project);
+        when(server.getProject("project", new ArrayList<String>())).thenReturn(project);
         when(workspaces.exists("workspace")).thenReturn(true);
         when(workspaces.getWorkspace("workspace")).thenReturn(workspace);
         when(server.getLocalHostname()).thenReturn("LocalComputer");
         when(workspace.getComputer()).thenReturn("LocalComputer");
         
-        new CheckoutAction("workspace", "project", ".", true).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
+        new CheckoutAction("workspace", "project", new ArrayList<String>(), ".", true).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
 
         verify(project).getFiles(".", "D2009-09-24T00:00:00Z");
         verify(workspaces, never()).newWorkspace("workspace");
@@ -142,12 +142,12 @@ public class CheckoutActionTest {
     @Test
     public void assertSecondCheckoutByLabelNotUsingUpdate() throws Exception {
         when(server.getWorkspaces()).thenReturn(workspaces);
-        when(server.getProject("project")).thenReturn(project);
+        when(server.getProject("project", new ArrayList<String>())).thenReturn(project);
         when(workspaces.exists("workspace")).thenReturn(true).thenReturn(false);
         when(workspaces.newWorkspace("workspace")).thenReturn(workspace);
         when(workspaces.getWorkspace("workspace")).thenReturn(workspace);
         
-        new CheckoutAction("workspace", "project", ".", false).checkoutByLabel(server, hudsonWs, MY_LABEL);
+        new CheckoutAction("workspace", "project", new ArrayList<String>(), ".", false).checkoutByLabel(server, hudsonWs, MY_LABEL);
 
         verify(workspaces).newWorkspace("workspace");
         verify(workspace).mapWorkfolder(project, hudsonWs.getRemote());
@@ -158,12 +158,12 @@ public class CheckoutActionTest {
     @Test
     public void assertSecondCheckoutNotUsingUpdate() throws Exception {
         when(server.getWorkspaces()).thenReturn(workspaces);
-        when(server.getProject("project")).thenReturn(project);
+        when(server.getProject("project", new ArrayList<String>())).thenReturn(project);
         when(workspaces.exists("workspace")).thenReturn(true).thenReturn(false);
         when(workspaces.newWorkspace("workspace")).thenReturn(workspace);
         when(workspaces.getWorkspace("workspace")).thenReturn(workspace);
         
-        new CheckoutAction("workspace", "project", ".", false).checkout(server, hudsonWs,null, Util.getCalendar(2009, 9, 24));
+        new CheckoutAction("workspace", "project", new ArrayList<String>(), ".", false).checkout(server, hudsonWs,null, Util.getCalendar(2009, 9, 24));
 
         verify(workspaces).newWorkspace("workspace");
         verify(workspace).mapWorkfolder(project, hudsonWs.getRemote());
@@ -174,13 +174,13 @@ public class CheckoutActionTest {
     @Test
     public void assertDetailedHistoryIsNotRetrievedInFirstBuildCheckingOutByLabel() throws Exception {
         when(server.getWorkspaces()).thenReturn(workspaces);
-        when(server.getProject("project")).thenReturn(project);
+        when(server.getProject("project", new ArrayList<String>())).thenReturn(project);
         when(workspaces.exists("workspace")).thenReturn(true);
         when(workspaces.getWorkspace("workspace")).thenReturn(workspace);
         when(server.getLocalHostname()).thenReturn("LocalComputer");
         when(workspace.getComputer()).thenReturn("LocalComputer");
         
-        new CheckoutAction("workspace", "project", ".", true).checkoutByLabel(server, hudsonWs, MY_LABEL);
+        new CheckoutAction("workspace", "project", new ArrayList<String>(), ".", true).checkoutByLabel(server, hudsonWs, MY_LABEL);
         
         verify(project, never()).getDetailedHistory(isA(Calendar.class), isA(Calendar.class));
     }
@@ -188,13 +188,13 @@ public class CheckoutActionTest {
     @Test
     public void assertDetailedHistoryIsNotRetrievedInFirstBuild() throws Exception {
         when(server.getWorkspaces()).thenReturn(workspaces);
-        when(server.getProject("project")).thenReturn(project);
+        when(server.getProject("project", new ArrayList<String>())).thenReturn(project);
         when(workspaces.exists("workspace")).thenReturn(true);
         when(workspaces.getWorkspace("workspace")).thenReturn(workspace);
         when(server.getLocalHostname()).thenReturn("LocalComputer");
         when(workspace.getComputer()).thenReturn("LocalComputer");
         
-        new CheckoutAction("workspace", "project", ".", true).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
+        new CheckoutAction("workspace", "project", new ArrayList<String>(), ".", true).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
         
         verify(project, never()).getDetailedHistory(isA(Calendar.class), isA(Calendar.class));
     }
@@ -203,14 +203,14 @@ public class CheckoutActionTest {
     public void assertDetailedHistoryIsRetrievedInSecondBuildCheckingOutByLabel() throws Exception {
         List<ChangeSet> list = new ArrayList<ChangeSet>();
         when(server.getWorkspaces()).thenReturn(workspaces);
-        when(server.getProject("project")).thenReturn(project);
+        when(server.getProject("project", new ArrayList<String>())).thenReturn(project);
         when(workspaces.exists("workspace")).thenReturn(true);
         when(workspaces.getWorkspace("workspace")).thenReturn(workspace);
         when(server.getLocalHostname()).thenReturn("LocalComputer");
         when(workspace.getComputer()).thenReturn("LocalComputer");
         when(project.getDetailedHistory(isA(String.class))).thenReturn(list);
         
-        CheckoutAction action = new CheckoutAction("workspace", "project", ".", true);
+        CheckoutAction action = new CheckoutAction("workspace", "project", new ArrayList<String>(), ".", true);
         List<ChangeSet> actualList = action.checkoutByLabel(server, hudsonWs, MY_LABEL);
         assertSame("The list from the detailed history, was not the same as returned from checkout", list, actualList);
         
@@ -221,14 +221,14 @@ public class CheckoutActionTest {
     public void assertDetailedHistoryIsRetrievedInSecondBuild() throws Exception {
         List<ChangeSet> list = new ArrayList<ChangeSet>();
         when(server.getWorkspaces()).thenReturn(workspaces);
-        when(server.getProject("project")).thenReturn(project);
+        when(server.getProject("project", new ArrayList<String>())).thenReturn(project);
         when(workspaces.exists("workspace")).thenReturn(true);
         when(workspaces.getWorkspace("workspace")).thenReturn(workspace);
         when(server.getLocalHostname()).thenReturn("LocalComputer");
         when(workspace.getComputer()).thenReturn("LocalComputer");
         when(project.getDetailedHistory(isA(Calendar.class), isA(Calendar.class))).thenReturn(list);
         
-        CheckoutAction action = new CheckoutAction("workspace", "project", ".", true);
+        CheckoutAction action = new CheckoutAction("workspace", "project", new ArrayList<String>(), ".", true);
         List<ChangeSet> actualList = action.checkout(server, hudsonWs, Util.getCalendar(2008, 9, 24), Util.getCalendar(2008, 10, 24));
         assertSame("The list from the detailed history, was not the same as returned from checkout", list, actualList);
         
@@ -243,11 +243,11 @@ public class CheckoutActionTest {
         tfsWs.createTempFile("temp", "txt");
         
         when(server.getWorkspaces()).thenReturn(workspaces);
-        when(server.getProject("project")).thenReturn(project);
+        when(server.getProject("project", new ArrayList<String>())).thenReturn(project);
         when(workspaces.exists(new Workspace(server, "workspace"))).thenReturn(false);
         when(workspaces.newWorkspace("workspace")).thenReturn(workspace);
         
-        new CheckoutAction("workspace", "project", "tfs-ws", false).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
+        new CheckoutAction("workspace", "project", new ArrayList<String>(), "tfs-ws", false).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
         
         assertTrue("The local folder was removed", tfsWs.exists());
         assertEquals("The local TFS folder was not cleaned", 0, tfsWs.list((FileFilter)null).size());
@@ -262,11 +262,11 @@ public class CheckoutActionTest {
         tfsWs.createTempFile("temp", "txt");
         
         when(server.getWorkspaces()).thenReturn(workspaces);
-        when(server.getProject("project")).thenReturn(project);
+        when(server.getProject("project", new ArrayList<String>())).thenReturn(project);
         when(workspaces.exists(new Workspace(server, "workspace"))).thenReturn(false);
         when(workspaces.newWorkspace("workspace")).thenReturn(workspace);
         
-        new CheckoutAction("workspace", "project", "tfs-ws", false).checkoutByLabel(server, hudsonWs, MY_LABEL);
+        new CheckoutAction("workspace", "project", new ArrayList<String>(), "tfs-ws", false).checkoutByLabel(server, hudsonWs, MY_LABEL);
         
         assertTrue("The local folder was removed", tfsWs.exists());
         assertEquals("The local TFS folder was not cleaned", 0, tfsWs.list((FileFilter)null).size());
@@ -280,13 +280,13 @@ public class CheckoutActionTest {
         tfsWs.createTempFile("temp", "txt");
         
         when(server.getWorkspaces()).thenReturn(workspaces);
-        when(server.getProject("project")).thenReturn(project);
+        when(server.getProject("project", new ArrayList<String>())).thenReturn(project);
         when(workspaces.exists("workspace")).thenReturn(true);
         when(workspaces.getWorkspace("workspace")).thenReturn(workspace);
         when(server.getLocalHostname()).thenReturn("LocalComputer");
         when(workspace.getComputer()).thenReturn("LocalComputer");
         
-        new CheckoutAction("workspace", "project", "tfs-ws", true).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
+        new CheckoutAction("workspace", "project", new ArrayList<String>(), "tfs-ws", true).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
 
         assertTrue("The local folder was removed", tfsWs.exists());
         assertEquals("The TFS workspace path was cleaned", 1, hudsonWs.list((FileFilter)null).size());
@@ -298,10 +298,10 @@ public class CheckoutActionTest {
         when(server.getWorkspaces()).thenReturn(workspaces);
         when(workspaces.exists("workspace")).thenReturn(true).thenReturn(false);
         when(workspaces.getWorkspace("workspace")).thenReturn(workspace);
-        when(server.getProject("project")).thenReturn(project);
+        when(server.getProject("project", new ArrayList<String>())).thenReturn(project);
         when(workspaces.newWorkspace("workspace")).thenReturn(workspace);
         
-        new CheckoutAction("workspace", "project", ".", false).checkoutByLabel(server, hudsonWs, MY_LABEL);
+        new CheckoutAction("workspace", "project", new ArrayList<String>(), ".", false).checkoutByLabel(server, hudsonWs, MY_LABEL);
         
         verify(server).getWorkspaces();
         verify(workspaces, times(2)).exists("workspace");
@@ -317,10 +317,10 @@ public class CheckoutActionTest {
         when(server.getWorkspaces()).thenReturn(workspaces);
         when(workspaces.exists("workspace")).thenReturn(true).thenReturn(false);
         when(workspaces.getWorkspace("workspace")).thenReturn(workspace);
-        when(server.getProject("project")).thenReturn(project);
+        when(server.getProject("project", new ArrayList<String>())).thenReturn(project);
         when(workspaces.newWorkspace("workspace")).thenReturn(workspace);
         
-        new CheckoutAction("workspace", "project", ".", false).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
+        new CheckoutAction("workspace", "project", new ArrayList<String>(), ".", false).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
         
         verify(server).getWorkspaces();
         verify(workspaces, times(2)).exists("workspace");
@@ -336,9 +336,9 @@ public class CheckoutActionTest {
         when(server.getWorkspaces()).thenReturn(workspaces);
         when(workspaces.exists("workspace")).thenReturn(true).thenReturn(true);
         when(workspaces.getWorkspace("workspace")).thenReturn(workspace);
-        when(server.getProject("project")).thenReturn(project);
+        when(server.getProject("project", new ArrayList<String>())).thenReturn(project);
         
-        new CheckoutAction("workspace", "project", ".", true).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
+        new CheckoutAction("workspace", "project", new ArrayList<String>(), ".", true).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
         
         verify(server).getWorkspaces();
         verify(workspaces, times(2)).exists("workspace");
@@ -352,9 +352,9 @@ public class CheckoutActionTest {
         when(server.getWorkspaces()).thenReturn(workspaces);
         when(workspaces.exists("workspace")).thenReturn(true).thenReturn(true);
         when(workspaces.getWorkspace("workspace")).thenReturn(workspace);
-        when(server.getProject("project")).thenReturn(project);
+        when(server.getProject("project", new ArrayList<String>())).thenReturn(project);
         
-        new CheckoutAction("workspace", "project", ".", true).checkoutByLabel(server, hudsonWs, MY_LABEL);
+        new CheckoutAction("workspace", "project", new ArrayList<String>(), ".", true).checkoutByLabel(server, hudsonWs, MY_LABEL);
         
         verify(server).getWorkspaces();
         verify(workspaces, times(2)).exists("workspace");
@@ -368,9 +368,9 @@ public class CheckoutActionTest {
         when(server.getWorkspaces()).thenReturn(workspaces);
         when(workspaces.exists("workspace")).thenReturn(false).thenReturn(false);
         when(workspaces.newWorkspace("workspace")).thenReturn(workspace);
-        when(server.getProject("project")).thenReturn(project);
+        when(server.getProject("project", new ArrayList<String>())).thenReturn(project);
         
-        new CheckoutAction("workspace", "project", ".", false).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
+        new CheckoutAction("workspace", "project", new ArrayList<String>(), ".", false).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
         
         verify(server).getWorkspaces();
         verify(workspaces, times(2)).exists("workspace");
@@ -384,9 +384,9 @@ public class CheckoutActionTest {
         when(server.getWorkspaces()).thenReturn(workspaces);
         when(workspaces.exists("workspace")).thenReturn(false).thenReturn(false);
         when(workspaces.newWorkspace("workspace")).thenReturn(workspace);
-        when(server.getProject("project")).thenReturn(project);
+        when(server.getProject("project", new ArrayList<String>())).thenReturn(project);
         
-        new CheckoutAction("workspace", "project", ".", false).checkoutByLabel(server, hudsonWs, MY_LABEL);
+        new CheckoutAction("workspace", "project", new ArrayList<String>(), ".", false).checkoutByLabel(server, hudsonWs, MY_LABEL);
         
         verify(server).getWorkspaces();
         verify(workspaces, times(2)).exists("workspace");
@@ -399,14 +399,14 @@ public class CheckoutActionTest {
     public void assertCheckoutOnlyRetrievesChangesToTheStartTimestampForCurrentBuild() throws Exception {
         List<ChangeSet> list = new ArrayList<ChangeSet>();
         when(server.getWorkspaces()).thenReturn(workspaces);
-        when(server.getProject("project")).thenReturn(project);
+        when(server.getProject("project", new ArrayList<String>())).thenReturn(project);
         when(workspaces.exists("workspace")).thenReturn(true);
         when(workspaces.getWorkspace("workspace")).thenReturn(workspace);
         when(server.getLocalHostname()).thenReturn("LocalComputer");
         when(workspace.getComputer()).thenReturn("LocalComputer");
         when(project.getDetailedHistory(isA(Calendar.class), isA(Calendar.class))).thenReturn(list);
         
-        CheckoutAction action = new CheckoutAction("workspace", "project", ".", true);
+        CheckoutAction action = new CheckoutAction("workspace", "project", new ArrayList<String>(), ".", true);
         List<ChangeSet> actualList = action.checkout(server, hudsonWs, Util.getCalendar(2008, 9, 24), Util.getCalendar(2009, 9, 24));
         assertSame("The list from the detailed history, was not the same as returned from checkout", list, actualList);
         

--- a/src/test/java/hudson/plugins/tfs/browsers/TeamSystemWebAccessBrowserTest.java
+++ b/src/test/java/hudson/plugins/tfs/browsers/TeamSystemWebAccessBrowserTest.java
@@ -18,134 +18,94 @@ import org.jvnet.hudson.test.Bug;
 @SuppressWarnings("rawtypes")
 public class TeamSystemWebAccessBrowserTest {
 
-	/**
-	 * http://tswaserver:8090/cs.aspx?cs=99
-	 */
-	@Test
-	public void assertChangeSetLink() throws Exception {
-		TeamSystemWebAccessBrowser browser = new TeamSystemWebAccessBrowser(
-				"http://tswaserver:8090/ViewChangeset.aspx?changeset=6200");
-		ChangeSet changeSet = new ChangeSet("99", null, "user", "comment");
-		URL actual = browser.getChangeSetLink(changeSet);
-		assertEquals("The change set link was incorrect",
-				"http://tswaserver:8090/cs.aspx?cs=99", actual.toString());
-	}
+    /**
+     * http://tswaserver:8090/cs.aspx?cs=99
+     */
+    @Test public void assertChangeSetLink() throws Exception {
+        TeamSystemWebAccessBrowser browser = new TeamSystemWebAccessBrowser("http://tswaserver:8090/ViewChangeset.aspx?changeset=6200");
+        ChangeSet changeSet = new ChangeSet("99", null, "user", "comment");
+        URL actual = browser.getChangeSetLink(changeSet);
+        assertEquals("The change set link was incorrect", "http://tswaserver:8090/cs.aspx?cs=99", actual.toString());
+    }
 
 	@Bug(7394)
 	@Test
 	public void assertChangeSetLinkWithOnlyServerUrl() throws Exception {
-		TeamSystemWebAccessBrowser browser = new TeamSystemWebAccessBrowser(
-				"http://tswaserver");
+		TeamSystemWebAccessBrowser browser = new TeamSystemWebAccessBrowser("http://tswaserver");
 		ChangeSet changeSet = new ChangeSet("99", null, "user", "comment");
 		URL actual = browser.getChangeSetLink(changeSet);
-		assertEquals("The change set link was incorrect",
-				"http://tswaserver/cs.aspx?cs=99", actual.toString());
+		assertEquals("The change set link was incorrect", "http://tswaserver/cs.aspx?cs=99", actual.toString());
 	}
 
 	@Bug(7394)
 	@Test
-	public void assertChangeSetLinkWithOnlyServerUrlWithTrailingSlash()
-			throws Exception {
-		TeamSystemWebAccessBrowser browser = new TeamSystemWebAccessBrowser(
-				"http://tswaserver/");
+	public void assertChangeSetLinkWithOnlyServerUrlWithTrailingSlash() throws Exception {
+		TeamSystemWebAccessBrowser browser = new TeamSystemWebAccessBrowser("http://tswaserver/");
 		ChangeSet changeSet = new ChangeSet("99", null, "user", "comment");
 		URL actual = browser.getChangeSetLink(changeSet);
-		assertEquals("The change set link was incorrect",
-				"http://tswaserver/cs.aspx?cs=99", actual.toString());
+		assertEquals("The change set link was incorrect","http://tswaserver/cs.aspx?cs=99", actual.toString());
 	}
+    
+    @Test public void assertChangeSetLinkUsesScmConfiguration() throws Exception {
+        AbstractBuild build = mock(AbstractBuild.class);
+        AbstractProject<?,?> project = mock(AbstractProject.class);
+        when(build.getProject()).thenReturn(project);
+        when(project.getScm()).thenReturn(new TeamFoundationServerScm("http://server:80", null, "", null, false, null, null, (Secret) null));
+        
+        ChangeSet changeset = new ChangeSet("62643", null, "user", "comment");
+        new ChangeLogSet(build, new ChangeSet[]{ changeset});        
+        TeamSystemWebAccessBrowser browser = new TeamSystemWebAccessBrowser("");
+        URL actual = browser.getChangeSetLink(changeset);
+        assertEquals("The change set link was incorrect", "http://server:80/cs.aspx?cs=62643", actual.toString());
+    }
 
-	@Test
-	public void assertChangeSetLinkUsesScmConfiguration() throws Exception {
-		AbstractBuild build = mock(AbstractBuild.class);
-		AbstractProject<?, ?> project = mock(AbstractProject.class);
-		when(build.getProject()).thenReturn(project);
-		when(project.getScm()).thenReturn(
-				new TeamFoundationServerScm("http://server:80", null,
-						"", null, false, null, null, (Secret) null));
+    /**
+     * http://tswaserver:8090/view.aspx?path=$/Project/Folder/file.cs&cs=99
+     */
+    @Test public void assertFileLink() throws Exception {
+        TeamSystemWebAccessBrowser browser = new TeamSystemWebAccessBrowser("http://tswaserver:8090/ViewChangeset.aspx?changeset=6200");
+        ChangeSet changeSet = new ChangeSet("99", null, "user", "comment");
+        ChangeSet.Item item = new ChangeSet.Item("$/Project/Folder/file.cs", "add");
+        changeSet.add(item);
+        URL actual = browser.getFileLink(item);
+        assertEquals("The change set link was incorrect", "http://tswaserver:8090/view.aspx?path=$/Project/Folder/file.cs&cs=99", actual.toString());
+    }
 
-		ChangeSet changeset = new ChangeSet("62643", null, "user", "comment");
-		new ChangeLogSet(build, new ChangeSet[] { changeset });
-		TeamSystemWebAccessBrowser browser = new TeamSystemWebAccessBrowser("");
-		URL actual = browser.getChangeSetLink(changeset);
-		assertEquals("The change set link was incorrect",
-				"http://server:80/cs.aspx?cs=62643", actual.toString());
-	}
+    /**
+     * http://tswaserver:8090/diff.aspx?opath=$/Project/Folder/file.cs&ocs=99&mpath=$/Project/Folder/file.cs&mcs=98
+     */
+    @Test public void assertDiffLink() throws Exception {
+        TeamSystemWebAccessBrowser browser = new TeamSystemWebAccessBrowser("http://tswaserver:8090/ViewChangeset.aspx?changeset=6200");
+        ChangeSet changeSet = new ChangeSet("99", null, "user", "comment");
+        ChangeSet.Item item = new ChangeSet.Item("$/Project/Folder/file.cs", "edit");
+        changeSet.add(item);
+        URL actual = browser.getDiffLink(item);
+        assertEquals("The change set link was incorrect", "http://tswaserver:8090/diff.aspx?opath=$/Project/Folder/file.cs&ocs=98&mpath=$/Project/Folder/file.cs&mcs=99", actual.toString());
+    }
 
-	/**
-	 * http://tswaserver:8090/view.aspx?path=$/Project/Folder/file.cs&cs=99
-	 */
-	@Test
-	public void assertFileLink() throws Exception {
-		TeamSystemWebAccessBrowser browser = new TeamSystemWebAccessBrowser(
-				"http://tswaserver:8090/ViewChangeset.aspx?changeset=6200");
-		ChangeSet changeSet = new ChangeSet("99", null, "user", "comment");
-		ChangeSet.Item item = new ChangeSet.Item("$/Project/Folder/file.cs",
-				"add");
-		changeSet.add(item);
-		URL actual = browser.getFileLink(item);
-		assertEquals(
-				"The change set link was incorrect",
-				"http://tswaserver:8090/view.aspx?path=$/Project/Folder/file.cs&cs=99",
-				actual.toString());
-	}
+    @Test public void assertNullDiffLinkForAddedFile() throws Exception {
+        TeamSystemWebAccessBrowser browser = new TeamSystemWebAccessBrowser("http://tswaserver:8090/ViewChangeset.aspx?changeset=6200");
+        ChangeSet changeSet = new ChangeSet("99", null, "user", "comment");
+        ChangeSet.Item item = new ChangeSet.Item("$/Project/Folder/file.cs", "add");
+        changeSet.add(item);
+        assertNull("The diff link should be null for new files", browser.getDiffLink(item));
+    }
 
-	/**
-	 * http://tswaserver:8090/diff.aspx?opath=$/Project/Folder/file.cs&ocs=99&
-	 * mpath=$/Project/Folder/file.cs&mcs=98
-	 */
-	@Test
-	public void assertDiffLink() throws Exception {
-		TeamSystemWebAccessBrowser browser = new TeamSystemWebAccessBrowser(
-				"http://tswaserver:8090/ViewChangeset.aspx?changeset=6200");
-		ChangeSet changeSet = new ChangeSet("99", null, "user", "comment");
-		ChangeSet.Item item = new ChangeSet.Item("$/Project/Folder/file.cs",
-				"edit");
-		changeSet.add(item);
-		URL actual = browser.getDiffLink(item);
-		assertEquals(
-				"The change set link was incorrect",
-				"http://tswaserver:8090/diff.aspx?opath=$/Project/Folder/file.cs&ocs=98&mpath=$/Project/Folder/file.cs&mcs=99",
-				actual.toString());
-	}
-
-	@Test
-	public void assertNullDiffLinkForAddedFile() throws Exception {
-		TeamSystemWebAccessBrowser browser = new TeamSystemWebAccessBrowser(
-				"http://tswaserver:8090/ViewChangeset.aspx?changeset=6200");
-		ChangeSet changeSet = new ChangeSet("99", null, "user", "comment");
-		ChangeSet.Item item = new ChangeSet.Item("$/Project/Folder/file.cs",
-				"add");
-		changeSet.add(item);
-		assertNull("The diff link should be null for new files",
-				browser.getDiffLink(item));
-	}
-
-	@Test
-	public void assertNullDiffLinkForInvalidChangeSetVersion() throws Exception {
-		TeamSystemWebAccessBrowser browser = new TeamSystemWebAccessBrowser(
-				"http://tswaserver:8090/ViewChangeset.aspx?changeset=6200");
-		ChangeSet changeSet = new ChangeSet("aaaa", null, "user", "comment");
-		ChangeSet.Item item = new ChangeSet.Item("$/Project/Folder/file.cs",
-				"edit");
-		changeSet.add(item);
-		assertNull(
-				"The diff link should be null for invalid change set version",
-				browser.getDiffLink(item));
-	}
-
-	@Test
-	public void assertDescriptorBaseUrlRemovesName() throws Exception {
-		String expected = TeamSystemWebAccessBrowser.DescriptorImpl
-				.getBaseUrl("http://server:80/UI/Pages/Scc/ViewChangeset.aspx?changeset=62643");
-		assertEquals("The base url was incorrect",
-				"http://server:80/UI/Pages/Scc/", expected);
-	}
-
-	@Test
-	public void assertDescriptorBaseUrlDoesNotRemoveLastPath() throws Exception {
-		String expected = TeamSystemWebAccessBrowser.DescriptorImpl
-				.getBaseUrl("http://server:80/UI/Pages/Scc/");
-		assertEquals("The base url was incorrect",
-				"http://server:80/UI/Pages/Scc/", expected);
-	}
+    @Test public void assertNullDiffLinkForInvalidChangeSetVersion() throws Exception {
+        TeamSystemWebAccessBrowser browser = new TeamSystemWebAccessBrowser("http://tswaserver:8090/ViewChangeset.aspx?changeset=6200");
+        ChangeSet changeSet = new ChangeSet("aaaa", null, "user", "comment");
+        ChangeSet.Item item = new ChangeSet.Item("$/Project/Folder/file.cs", "edit");
+        changeSet.add(item);
+        assertNull("The diff link should be null for invalid change set version", browser.getDiffLink(item));
+    }
+    
+    @Test public void assertDescriptorBaseUrlRemovesName() throws Exception {
+        String expected = TeamSystemWebAccessBrowser.DescriptorImpl.getBaseUrl("http://server:80/UI/Pages/Scc/ViewChangeset.aspx?changeset=62643");
+        assertEquals("The base url was incorrect", "http://server:80/UI/Pages/Scc/", expected);
+    }
+    
+    @Test public void assertDescriptorBaseUrlDoesNotRemoveLastPath() throws Exception {
+        String expected = TeamSystemWebAccessBrowser.DescriptorImpl.getBaseUrl("http://server:80/UI/Pages/Scc/");
+        assertEquals("The base url was incorrect", "http://server:80/UI/Pages/Scc/", expected);
+    }
 }

--- a/src/test/java/hudson/plugins/tfs/browsers/TeamSystemWebAccessBrowserTest.java
+++ b/src/test/java/hudson/plugins/tfs/browsers/TeamSystemWebAccessBrowserTest.java
@@ -18,94 +18,134 @@ import org.jvnet.hudson.test.Bug;
 @SuppressWarnings("rawtypes")
 public class TeamSystemWebAccessBrowserTest {
 
-    /**
-     * http://tswaserver:8090/cs.aspx?cs=99
-     */
-    @Test public void assertChangeSetLink() throws Exception {
-        TeamSystemWebAccessBrowser browser = new TeamSystemWebAccessBrowser("http://tswaserver:8090/ViewChangeset.aspx?changeset=6200");
-        ChangeSet changeSet = new ChangeSet("99", null, "user", "comment");
-        URL actual = browser.getChangeSetLink(changeSet);
-        assertEquals("The change set link was incorrect", "http://tswaserver:8090/cs.aspx?cs=99", actual.toString());
-    }
+	/**
+	 * http://tswaserver:8090/cs.aspx?cs=99
+	 */
+	@Test
+	public void assertChangeSetLink() throws Exception {
+		TeamSystemWebAccessBrowser browser = new TeamSystemWebAccessBrowser(
+				"http://tswaserver:8090/ViewChangeset.aspx?changeset=6200");
+		ChangeSet changeSet = new ChangeSet("99", null, "user", "comment");
+		URL actual = browser.getChangeSetLink(changeSet);
+		assertEquals("The change set link was incorrect",
+				"http://tswaserver:8090/cs.aspx?cs=99", actual.toString());
+	}
 
 	@Bug(7394)
 	@Test
 	public void assertChangeSetLinkWithOnlyServerUrl() throws Exception {
-		TeamSystemWebAccessBrowser browser = new TeamSystemWebAccessBrowser("http://tswaserver");
+		TeamSystemWebAccessBrowser browser = new TeamSystemWebAccessBrowser(
+				"http://tswaserver");
 		ChangeSet changeSet = new ChangeSet("99", null, "user", "comment");
 		URL actual = browser.getChangeSetLink(changeSet);
-		assertEquals("The change set link was incorrect", "http://tswaserver/cs.aspx?cs=99", actual.toString());
+		assertEquals("The change set link was incorrect",
+				"http://tswaserver/cs.aspx?cs=99", actual.toString());
 	}
 
 	@Bug(7394)
 	@Test
-	public void assertChangeSetLinkWithOnlyServerUrlWithTrailingSlash() throws Exception {
-		TeamSystemWebAccessBrowser browser = new TeamSystemWebAccessBrowser("http://tswaserver/");
+	public void assertChangeSetLinkWithOnlyServerUrlWithTrailingSlash()
+			throws Exception {
+		TeamSystemWebAccessBrowser browser = new TeamSystemWebAccessBrowser(
+				"http://tswaserver/");
 		ChangeSet changeSet = new ChangeSet("99", null, "user", "comment");
 		URL actual = browser.getChangeSetLink(changeSet);
-		assertEquals("The change set link was incorrect","http://tswaserver/cs.aspx?cs=99", actual.toString());
+		assertEquals("The change set link was incorrect",
+				"http://tswaserver/cs.aspx?cs=99", actual.toString());
 	}
-    
-    @Test public void assertChangeSetLinkUsesScmConfiguration() throws Exception {
-        AbstractBuild build = mock(AbstractBuild.class);
-        AbstractProject<?,?> project = mock(AbstractProject.class);
-        when(build.getProject()).thenReturn(project);
-        when(project.getScm()).thenReturn(new TeamFoundationServerScm("http://server:80", null, null, false, null, null, (Secret) null));
-        
-        ChangeSet changeset = new ChangeSet("62643", null, "user", "comment");
-        new ChangeLogSet(build, new ChangeSet[]{ changeset});        
-        TeamSystemWebAccessBrowser browser = new TeamSystemWebAccessBrowser("");
-        URL actual = browser.getChangeSetLink(changeset);
-        assertEquals("The change set link was incorrect", "http://server:80/cs.aspx?cs=62643", actual.toString());
-    }
 
-    /**
-     * http://tswaserver:8090/view.aspx?path=$/Project/Folder/file.cs&cs=99
-     */
-    @Test public void assertFileLink() throws Exception {
-        TeamSystemWebAccessBrowser browser = new TeamSystemWebAccessBrowser("http://tswaserver:8090/ViewChangeset.aspx?changeset=6200");
-        ChangeSet changeSet = new ChangeSet("99", null, "user", "comment");
-        ChangeSet.Item item = new ChangeSet.Item("$/Project/Folder/file.cs", "add");
-        changeSet.add(item);
-        URL actual = browser.getFileLink(item);
-        assertEquals("The change set link was incorrect", "http://tswaserver:8090/view.aspx?path=$/Project/Folder/file.cs&cs=99", actual.toString());
-    }
+	@Test
+	public void assertChangeSetLinkUsesScmConfiguration() throws Exception {
+		AbstractBuild build = mock(AbstractBuild.class);
+		AbstractProject<?, ?> project = mock(AbstractProject.class);
+		when(build.getProject()).thenReturn(project);
+		when(project.getScm()).thenReturn(
+				new TeamFoundationServerScm("http://server:80", null,
+						"", null, false, null, null, (Secret) null));
 
-    /**
-     * http://tswaserver:8090/diff.aspx?opath=$/Project/Folder/file.cs&ocs=99&mpath=$/Project/Folder/file.cs&mcs=98
-     */
-    @Test public void assertDiffLink() throws Exception {
-        TeamSystemWebAccessBrowser browser = new TeamSystemWebAccessBrowser("http://tswaserver:8090/ViewChangeset.aspx?changeset=6200");
-        ChangeSet changeSet = new ChangeSet("99", null, "user", "comment");
-        ChangeSet.Item item = new ChangeSet.Item("$/Project/Folder/file.cs", "edit");
-        changeSet.add(item);
-        URL actual = browser.getDiffLink(item);
-        assertEquals("The change set link was incorrect", "http://tswaserver:8090/diff.aspx?opath=$/Project/Folder/file.cs&ocs=98&mpath=$/Project/Folder/file.cs&mcs=99", actual.toString());
-    }
+		ChangeSet changeset = new ChangeSet("62643", null, "user", "comment");
+		new ChangeLogSet(build, new ChangeSet[] { changeset });
+		TeamSystemWebAccessBrowser browser = new TeamSystemWebAccessBrowser("");
+		URL actual = browser.getChangeSetLink(changeset);
+		assertEquals("The change set link was incorrect",
+				"http://server:80/cs.aspx?cs=62643", actual.toString());
+	}
 
-    @Test public void assertNullDiffLinkForAddedFile() throws Exception {
-        TeamSystemWebAccessBrowser browser = new TeamSystemWebAccessBrowser("http://tswaserver:8090/ViewChangeset.aspx?changeset=6200");
-        ChangeSet changeSet = new ChangeSet("99", null, "user", "comment");
-        ChangeSet.Item item = new ChangeSet.Item("$/Project/Folder/file.cs", "add");
-        changeSet.add(item);
-        assertNull("The diff link should be null for new files", browser.getDiffLink(item));
-    }
+	/**
+	 * http://tswaserver:8090/view.aspx?path=$/Project/Folder/file.cs&cs=99
+	 */
+	@Test
+	public void assertFileLink() throws Exception {
+		TeamSystemWebAccessBrowser browser = new TeamSystemWebAccessBrowser(
+				"http://tswaserver:8090/ViewChangeset.aspx?changeset=6200");
+		ChangeSet changeSet = new ChangeSet("99", null, "user", "comment");
+		ChangeSet.Item item = new ChangeSet.Item("$/Project/Folder/file.cs",
+				"add");
+		changeSet.add(item);
+		URL actual = browser.getFileLink(item);
+		assertEquals(
+				"The change set link was incorrect",
+				"http://tswaserver:8090/view.aspx?path=$/Project/Folder/file.cs&cs=99",
+				actual.toString());
+	}
 
-    @Test public void assertNullDiffLinkForInvalidChangeSetVersion() throws Exception {
-        TeamSystemWebAccessBrowser browser = new TeamSystemWebAccessBrowser("http://tswaserver:8090/ViewChangeset.aspx?changeset=6200");
-        ChangeSet changeSet = new ChangeSet("aaaa", null, "user", "comment");
-        ChangeSet.Item item = new ChangeSet.Item("$/Project/Folder/file.cs", "edit");
-        changeSet.add(item);
-        assertNull("The diff link should be null for invalid change set version", browser.getDiffLink(item));
-    }
-    
-    @Test public void assertDescriptorBaseUrlRemovesName() throws Exception {
-        String expected = TeamSystemWebAccessBrowser.DescriptorImpl.getBaseUrl("http://server:80/UI/Pages/Scc/ViewChangeset.aspx?changeset=62643");
-        assertEquals("The base url was incorrect", "http://server:80/UI/Pages/Scc/", expected);
-    }
-    
-    @Test public void assertDescriptorBaseUrlDoesNotRemoveLastPath() throws Exception {
-        String expected = TeamSystemWebAccessBrowser.DescriptorImpl.getBaseUrl("http://server:80/UI/Pages/Scc/");
-        assertEquals("The base url was incorrect", "http://server:80/UI/Pages/Scc/", expected);
-    }
+	/**
+	 * http://tswaserver:8090/diff.aspx?opath=$/Project/Folder/file.cs&ocs=99&
+	 * mpath=$/Project/Folder/file.cs&mcs=98
+	 */
+	@Test
+	public void assertDiffLink() throws Exception {
+		TeamSystemWebAccessBrowser browser = new TeamSystemWebAccessBrowser(
+				"http://tswaserver:8090/ViewChangeset.aspx?changeset=6200");
+		ChangeSet changeSet = new ChangeSet("99", null, "user", "comment");
+		ChangeSet.Item item = new ChangeSet.Item("$/Project/Folder/file.cs",
+				"edit");
+		changeSet.add(item);
+		URL actual = browser.getDiffLink(item);
+		assertEquals(
+				"The change set link was incorrect",
+				"http://tswaserver:8090/diff.aspx?opath=$/Project/Folder/file.cs&ocs=98&mpath=$/Project/Folder/file.cs&mcs=99",
+				actual.toString());
+	}
+
+	@Test
+	public void assertNullDiffLinkForAddedFile() throws Exception {
+		TeamSystemWebAccessBrowser browser = new TeamSystemWebAccessBrowser(
+				"http://tswaserver:8090/ViewChangeset.aspx?changeset=6200");
+		ChangeSet changeSet = new ChangeSet("99", null, "user", "comment");
+		ChangeSet.Item item = new ChangeSet.Item("$/Project/Folder/file.cs",
+				"add");
+		changeSet.add(item);
+		assertNull("The diff link should be null for new files",
+				browser.getDiffLink(item));
+	}
+
+	@Test
+	public void assertNullDiffLinkForInvalidChangeSetVersion() throws Exception {
+		TeamSystemWebAccessBrowser browser = new TeamSystemWebAccessBrowser(
+				"http://tswaserver:8090/ViewChangeset.aspx?changeset=6200");
+		ChangeSet changeSet = new ChangeSet("aaaa", null, "user", "comment");
+		ChangeSet.Item item = new ChangeSet.Item("$/Project/Folder/file.cs",
+				"edit");
+		changeSet.add(item);
+		assertNull(
+				"The diff link should be null for invalid change set version",
+				browser.getDiffLink(item));
+	}
+
+	@Test
+	public void assertDescriptorBaseUrlRemovesName() throws Exception {
+		String expected = TeamSystemWebAccessBrowser.DescriptorImpl
+				.getBaseUrl("http://server:80/UI/Pages/Scc/ViewChangeset.aspx?changeset=62643");
+		assertEquals("The base url was incorrect",
+				"http://server:80/UI/Pages/Scc/", expected);
+	}
+
+	@Test
+	public void assertDescriptorBaseUrlDoesNotRemoveLastPath() throws Exception {
+		String expected = TeamSystemWebAccessBrowser.DescriptorImpl
+				.getBaseUrl("http://server:80/UI/Pages/Scc/");
+		assertEquals("The base url was incorrect",
+				"http://server:80/UI/Pages/Scc/", expected);
+	}
 }

--- a/src/test/java/hudson/plugins/tfs/commands/CloakCommandTest.java
+++ b/src/test/java/hudson/plugins/tfs/commands/CloakCommandTest.java
@@ -1,0 +1,35 @@
+package hudson.plugins.tfs.commands;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+import hudson.plugins.tfs.commands.MapWorkfolderCommand;
+import hudson.plugins.tfs.util.MaskedArgumentListBuilder;
+
+import org.junit.Test;
+
+public class CloakCommandTest {
+    
+    @Test
+    public void assertArguments() {
+        ServerConfigurationProvider config = mock(ServerConfigurationProvider.class);
+        when(config.getUrl()).thenReturn("https//tfs02.codeplex.com");
+        when(config.getUserName()).thenReturn("snd\\user_cp");
+        when(config.getUserPassword()).thenReturn("password");
+        
+        MaskedArgumentListBuilder arguments = new CloakCommand(config, "$/serverPath/hide").getArguments();
+        assertNotNull("Arguments were null", arguments);
+        assertEquals("workfold -cloak $/serverPath/hide -login:snd\\user_cp,password", arguments.toStringWithQuote());
+    }
+    
+    @Test
+    public void assertArgumentsWithWorkspace() {
+        ServerConfigurationProvider config = mock(ServerConfigurationProvider.class);
+        when(config.getUrl()).thenReturn("https//tfs02.codeplex.com");
+        when(config.getUserName()).thenReturn("snd\\user_cp");
+        when(config.getUserPassword()).thenReturn("password");
+        
+        MaskedArgumentListBuilder arguments = new CloakCommand(config, "$/serverPath/hide", "workspaceName").getArguments();
+        assertNotNull("Arguments were null", arguments);
+        assertEquals("workfold -cloak $/serverPath/hide -workspace:workspaceName -login:snd\\user_cp,password", arguments.toStringWithQuote());
+    }
+}

--- a/src/test/java/hudson/plugins/tfs/model/ProjectTest.java
+++ b/src/test/java/hudson/plugins/tfs/model/ProjectTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.*;
 
 import java.io.Reader;
 import java.io.StringReader;
+import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.List;
 
@@ -97,7 +98,7 @@ public class ProjectTest extends SwedishLocaleTestCase {
     public void assertGetFiles() throws Exception {
         Server server = mock(Server.class);
         when(server.execute(isA(MaskedArgumentListBuilder.class))).thenReturn(new StringReader(""));
-        Project project = new Project(server, "$/serverpath");
+        Project project = new Project(server, "$/serverpath", new ArrayList<String>());
         project.getFiles(".");
         verify(server).execute(isA(MaskedArgumentListBuilder.class));
     }
@@ -106,7 +107,7 @@ public class ProjectTest extends SwedishLocaleTestCase {
     public void assertGetFilesUsesVersion() throws Exception {
         Server server = mock(Server.class);
         when(server.execute(isA(MaskedArgumentListBuilder.class))).thenReturn(new StringReader(""));
-        Project project = new Project(server, "$/serverpath");
+        Project project = new Project(server, "$/serverpath", new ArrayList<String>());
         project.getFiles(".", "C5");
         verify(server).execute(isA(MaskedArgumentListBuilder.class));
     }
@@ -116,7 +117,7 @@ public class ProjectTest extends SwedishLocaleTestCase {
         Reader spy = spy(new StringReader(""));
         Server server = mock(Server.class);
         when(server.execute(isA(MaskedArgumentListBuilder.class))).thenReturn(spy);
-        new Project(server, "$/serverpath").getFiles("localpath");
+        new Project(server, "$/serverpath", new ArrayList<String>()).getFiles("localpath");
 
         verify(spy).close();
     }
@@ -129,7 +130,7 @@ public class ProjectTest extends SwedishLocaleTestCase {
                 "--------- -------------- -------------------- ----------------------------------------------------------------------------\n" +
                 "\n" +
                 "12495     SND\\redsolo_cp 2008-jun-27 13:21:25 changed and created one\n"));
-        Project project = new Project(server, "$/serverpath");
+        Project project = new Project(server, "$/serverpath", new ArrayList<String>());
         String workspaceChangesetVersion = project.getWorkspaceChangesetVersion("localpath", "workspace_name", "owner");
         assertNotNull("The returned workspace changeset versions is null", workspaceChangesetVersion);
         assertEquals("Workspace changeset number was incorrect", "12495", workspaceChangesetVersion);
@@ -141,7 +142,7 @@ public class ProjectTest extends SwedishLocaleTestCase {
         Reader spy = spy(new StringReader(""));
         Server server = mock(Server.class);
         when(server.execute(isA(MaskedArgumentListBuilder.class))).thenReturn(spy);
-        new Project(server, "$/serverpath").getWorkspaceChangesetVersion("localpath", "workspace_name", "owner");
+        new Project(server, "$/serverpath", new ArrayList<String>()).getWorkspaceChangesetVersion("localpath", "workspace_name", "owner");
 
         verify(spy).close();
     }    

--- a/src/test/java/hudson/plugins/tfs/model/ServerTest.java
+++ b/src/test/java/hudson/plugins/tfs/model/ServerTest.java
@@ -3,6 +3,8 @@ package hudson.plugins.tfs.model;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
+import java.util.ArrayList;
+
 import hudson.plugins.tfs.TfTool;
 
 import org.junit.Before;
@@ -29,16 +31,16 @@ public class ServerTest {
     @Test
     public void assertGetProjectWithSameProjectPathReturnsSameInstance() {
         Server server = new Server("url");
-        assertNotNull("Project object can not be null", server.getProject("$/projectPath"));
+        assertNotNull("Project object can not be null", server.getProject("$/projectPath", new ArrayList<String>()));
         assertSame("getProject() returned different objects", 
-                server.getProject("$/projectPath"), server.getProject("$/projectPath"));
+                server.getProject("$/projectPath", new ArrayList<String>()), server.getProject("$/projectPath", new ArrayList<String>()));
     }
     
     @Test
     public void assertGetProjectWithDifferentProjectPathReturnsNotSameInstance() {
         Server server = new Server("url");
         assertNotSame("getProject() did not return different objects", 
-                server.getProject("$/projectPath"), server.getProject("$/otherPath"));
+                server.getProject("$/projectPath", new ArrayList<String>()), server.getProject("$/otherPath", new ArrayList<String>()));
     }
     
     @Test

--- a/src/test/java/hudson/plugins/tfs/model/WorkspaceConfigurationTest.java
+++ b/src/test/java/hudson/plugins/tfs/model/WorkspaceConfigurationTest.java
@@ -3,19 +3,26 @@ package hudson.plugins.tfs.model;
 import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.*;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.junit.Test;
 
 public class WorkspaceConfigurationTest {
 
     @Test public void assertConfigurationsEquals() {
-        WorkspaceConfiguration one = new WorkspaceConfiguration("server", "workspace", "project", "workfolder");
-        WorkspaceConfiguration two = new WorkspaceConfiguration("server", "workspace", "project", "workfolder");
+    	List<String> cloakList = new ArrayList<String>();
+    	cloakList.add("cloak");
+    	
+        WorkspaceConfiguration one = new WorkspaceConfiguration("server", "workspace", "project", cloakList, "workfolder");
+        WorkspaceConfiguration two = new WorkspaceConfiguration("server", "workspace", "project", cloakList, "workfolder");
         assertThat(one, is(two));
         assertThat(two, is(one));
         assertThat(one, is(one));
-        assertThat(one, not(new WorkspaceConfiguration("aserver", "workspace", "project", "workfolder")));
-        assertThat(one, not(new WorkspaceConfiguration("server", "aworkspace", "project", "workfolder")));
-        assertThat(one, not(new WorkspaceConfiguration("server", "workspace", "aproject", "workfolder")));
-        assertThat(one, not(new WorkspaceConfiguration("server", "workspace", "project", "aworkfolder")));
+        assertThat(one, not(new WorkspaceConfiguration("aserver", "workspace", "project", cloakList, "workfolder")));
+        assertThat(one, not(new WorkspaceConfiguration("server", "aworkspace", "project", cloakList, "workfolder")));
+        assertThat(one, not(new WorkspaceConfiguration("server", "workspace", "aproject", cloakList, "workfolder")));
+        assertThat(one, not(new WorkspaceConfiguration("server", "workspace", "project", cloakList, "aworkfolder")));
+        assertThat(one, not(new WorkspaceConfiguration("server", "workspace", "project", new ArrayList<String>(), "aworkfolder")));
     }
 }

--- a/src/test/java/hudson/plugins/tfs/util/BuildWorkspaceConfigurationRetrieverTest.java
+++ b/src/test/java/hudson/plugins/tfs/util/BuildWorkspaceConfigurationRetrieverTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
 import java.io.IOException;
+import java.util.ArrayList;
 
 import hudson.model.AbstractBuild;
 import hudson.model.Node;
@@ -22,7 +23,7 @@ public class BuildWorkspaceConfigurationRetrieverTest {
         AbstractBuild build = mock(AbstractBuild.class);
         Node node = mock(Node.class);
         Node needleNode = mock(Node.class);
-        WorkspaceConfiguration configuration = new WorkspaceConfiguration("serverUrl", "workspaceName", "projectPath", "workfolder");
+        WorkspaceConfiguration configuration = new WorkspaceConfiguration("serverUrl", "workspaceName", "projectPath", new ArrayList<String>(), "workfolder");
         when(build.getPreviousBuild()).thenReturn(build).thenReturn(null);
         when(build.getBuiltOn()).thenReturn(node, node, null);
         when(node.getNodeName()).thenReturn("node1", "needleNode");
@@ -93,7 +94,7 @@ public class BuildWorkspaceConfigurationRetrieverTest {
         when(build.getPreviousBuild()).thenReturn(build);
         when(build.getBuiltOn()).thenReturn(node);
         when(node.getNodeName()).thenReturn("needleNode");
-        when(build.getAction(WorkspaceConfiguration.class)).thenReturn(new WorkspaceConfiguration("serverUrl", "workspaceName", "projectPath", "workfolder"));
+        when(build.getAction(WorkspaceConfiguration.class)).thenReturn(new WorkspaceConfiguration("serverUrl", "workspaceName", "projectPath", new ArrayList<String>(), "workfolder"));
         
         BuildWorkspaceConfiguration configuration = new BuildWorkspaceConfigurationRetriever().getLatestForNode(node, build);
         assertThat( configuration.getWorkspaceName(), is("workspaceName"));
@@ -108,7 +109,7 @@ public class BuildWorkspaceConfigurationRetrieverTest {
         AbstractBuild build = mock(AbstractBuild.class);
         Node node = mock(Node.class);
         Node needleNode = mock(Node.class);
-        WorkspaceConfiguration configuration = new WorkspaceConfiguration("serverUrl", "workspaceName", "projectPath", "workfolder");
+        WorkspaceConfiguration configuration = new WorkspaceConfiguration("serverUrl", "workspaceName", "projectPath", new ArrayList<String>(), "workfolder");
         when(build.getPreviousBuild()).thenReturn(build).thenReturn(null);
         when(build.getBuiltOn()).thenReturn(null);
 


### PR DESCRIPTION
This change adds support for cloaking in the TFS workspaces. Along with providing the server path, a delimited list of server paths can optionally be included for cloaking. During workspace creation, each of the cloak paths are cloaked after the workspace is initially mapped.

This should resolve [JENKINS-4709](https://issues.jenkins-ci.org/browse/JENKINS-4709).

For those wanting to specify multiple paths without changing the folder name or relative layout of the files, this also handles [JENKINS-4542](https://issues.jenkins-ci.org/browse/JENKINS-4542) and [JENKINS-11007](https://issues.jenkins-ci.org/browse/JENKINS-11007).