### PR TITLE
[FIXED JENKINS-23344] - Fixed whenToLabel in config.xml

### DIFF
--- a/src/main/java/hudson/plugins/tfs/TFSLabeler.java
+++ b/src/main/java/hudson/plugins/tfs/TFSLabeler.java
@@ -49,15 +49,6 @@ public class TFSLabeler extends Notifier {
         public boolean isApplicable(Class<? extends AbstractProject> jobType) {
             return true;
         }
-
-        @Override
-        public Publisher newInstance(StaplerRequest req, JSONObject formData) throws FormException {
-            return new TFSLabeler(
-                    req.getParameter("tfsLabeler.whenToLabel"),
-                    req.getParameter("tfsLabeler.labelName")
-            );
-        }
-
     }
 
     @DataBoundConstructor


### PR DESCRIPTION
The overridden newInstance() method was causing the whenToLabel
element to be removed from a job's config.xml file when a configuration update was made.

This required the user to manually edit the job's config.xml file and reload configuration from disk.