### PR TITLE
Fix upgrade to Secret

### DIFF
--- a/src/main/java/hudson/plugins/tfs/TeamFoundationServerScm.java
+++ b/src/main/java/hudson/plugins/tfs/TeamFoundationServerScm.java
@@ -106,8 +106,10 @@ public class TeamFoundationServerScm extends SCM {
 
     /* Migrate legacy data */
     private Object readResolve() {
-        if (password == null && userPassword != null)
+        if (password == null && userPassword != null) {
             password = Secret.fromString(Scrambler.descramble(userPassword));
+            userPassword = null;
+        }
         return this;
     }
 

--- a/src/main/java/hudson/plugins/tfs/TeamFoundationServerScm.java
+++ b/src/main/java/hudson/plugins/tfs/TeamFoundationServerScm.java
@@ -76,7 +76,7 @@ public class TeamFoundationServerScm extends SCM {
     private final String projectPath;
     private final String localPath;
     private final String workspaceName;
-    private transient @Deprecated String userPassword;
+    private @Deprecated String userPassword;
     private /* almost final */ Secret password;
     private final String userName;
     private final boolean useUpdate;
@@ -107,7 +107,7 @@ public class TeamFoundationServerScm extends SCM {
     /* Migrate legacy data */
     private Object readResolve() {
         if (password == null && userPassword != null)
-            password = Secret.fromString(Scrambler.scramble(userPassword));
+            password = Secret.fromString(Scrambler.descramble(userPassword));
         return this;
     }
 


### PR DESCRIPTION
This fixes a defect that was introduced in bd98b91ea614c307a6bb1e0af36d9dd2a5646e29 whereby upgrading the plugin would have forced users to re-enter the TFS account's password in each job.  Upgrades to the plugin will now be safe and without loss of data.

Manual testing
--------------
1. Create job that polls TFS using version 3.1.1 of the plugin.  Verify it can authenticate to the TFS server.  Notice the job's `config.xml` file contains a `userPassword` element.
2. Upgrade the plugin to include the changes from this branch. (this may require restarting Jenkins)
3. Verify the job created in step 1 can still authenticate to the TFS server.
4. Edit the job's configuration and hit Save without changing anything.  Notice the job's `config.xml` file no longer contains a `userPassword` element but a `password` element only.

Mission accomplished!