### PR TITLE
Partial Success == Failure

### DIFF
--- a/src/test/java/hudson/plugins/tfs/TfToolTest.java
+++ b/src/test/java/hudson/plugins/tfs/TfToolTest.java
@@ -60,8 +60,8 @@ public class TfToolTest {
         tool.execute(new String[]{"history"});
     }
 
-    @Test
-    public void assertPartialSuccessReturnCodeDoesNotThrowAbortException() throws Exception {
+    @Test(expected=AbortException.class)
+    public void assertPartialSuccessReturnCodeThrowsAbortException() throws Exception {
         when(launcher.launch(isA(Launcher.ProcStarter.class))).thenReturn(proc);
         when(proc.join()).thenReturn(TfTool.PARTIAL_SUCCESS_EXIT_CODE);
 


### PR DESCRIPTION
changed to cause a partial success of a tfs operation to be considered a failure rather than a success.

See the inline javadoc for reasoning. 

If @olivierdagenais or anybody else considers this a problem, I can change it to use a global configuration (or job specific configuration) defaulting to the old behaviour.

I checked out the TFS documentation as well as the commit history of this plugin but I could not find any indication why a partial success is considered a success. If anybody has more insight I would love to know.