### PR TITLE
Fix checkout by version spec

### DIFF
--- a/src/main/java/hudson/plugins/tfs/TeamFoundationServerScm.java
+++ b/src/main/java/hudson/plugins/tfs/TeamFoundationServerScm.java
@@ -196,11 +196,11 @@ public class TeamFoundationServerScm extends SCM {
             }
             
             build.addAction(workspaceConfiguration);
+            VariableResolver<String> buildVariableResolver = build.getBuildVariableResolver();
+            String singleVersionSpec = buildVariableResolver.resolve(VERSION_SPEC);
             CheckoutAction action = new CheckoutAction(workspaceConfiguration.getWorkspaceName(), workspaceConfiguration.getProjectPath(), workspaceConfiguration.getWorkfolder(), isUseUpdate());
             try {
                 List<ChangeSet> list;
-                VariableResolver<String> buildVariableResolver = build.getBuildVariableResolver();
-                String singleVersionSpec = buildVariableResolver.resolve(VERSION_SPEC);
                 if (StringUtils.isNotEmpty(singleVersionSpec)) {
                     list = action.checkoutBySingleVersionSpec(server, workspaceFilePath, singleVersionSpec);
                 }

--- a/src/main/java/hudson/plugins/tfs/TeamFoundationServerScm.java
+++ b/src/main/java/hudson/plugins/tfs/TeamFoundationServerScm.java
@@ -231,13 +231,9 @@ public class TeamFoundationServerScm extends SCM {
 			throws IOException, InterruptedException, ParseException {
 		
 		VariableResolver<String> buildVariableResolver = build.getBuildVariableResolver();
-		String label = buildVariableResolver.resolve(VERSION_SPEC);
-		if (StringUtils.isNotEmpty(label)) {
-			if (label.startsWith("L")) {
-		        String preffixRemoved = label.substring(1);
-				return action.checkoutByLabel(server, workspaceFilePath, preffixRemoved);
-			}
-			//TODO to be implemented another checkout strategies...
+		String singleVersionSpec = buildVariableResolver.resolve(VERSION_SPEC);
+		if (StringUtils.isNotEmpty(singleVersionSpec)) {
+			return action.checkoutBySingleVersionSpec(server, workspaceFilePath, singleVersionSpec);
 		}
 		
 		return action.checkout(server, workspaceFilePath, (build.getPreviousBuild() != null ? build.getPreviousBuild().getTimestamp() : null), build.getTimestamp());

--- a/src/main/java/hudson/plugins/tfs/TeamFoundationServerScm.java
+++ b/src/main/java/hudson/plugins/tfs/TeamFoundationServerScm.java
@@ -198,6 +198,7 @@ public class TeamFoundationServerScm extends SCM {
             build.addAction(workspaceConfiguration);
             VariableResolver<String> buildVariableResolver = build.getBuildVariableResolver();
             String singleVersionSpec = buildVariableResolver.resolve(VERSION_SPEC);
+            int buildChangeset;
             CheckoutAction action = new CheckoutAction(workspaceConfiguration.getWorkspaceName(), workspaceConfiguration.getProjectPath(), workspaceConfiguration.getWorkfolder(), isUseUpdate());
             try {
                 List<ChangeSet> list;
@@ -219,7 +220,7 @@ public class TeamFoundationServerScm extends SCM {
                 String projectPath = workspaceConfiguration.getProjectPath();
                 Project project = server.getProject(projectPath);
                 // TODO: even better would be to call this first, then use the changeset when calling checkout
-                int buildChangeset = project.getRemoteChangesetVersion(build.getTimestamp());
+                buildChangeset = project.getRemoteChangesetVersion(build.getTimestamp());
                 setWorkspaceChangesetVersion(Integer.toString(buildChangeset, 10));
                 
                 // by adding this action, we prevent calcRevisionsFromBuild() from being called

--- a/src/main/java/hudson/plugins/tfs/TeamFoundationServerScm.java
+++ b/src/main/java/hudson/plugins/tfs/TeamFoundationServerScm.java
@@ -199,7 +199,9 @@ public class TeamFoundationServerScm extends SCM {
             build.addAction(workspaceConfiguration);
             VariableResolver<String> buildVariableResolver = build.getBuildVariableResolver();
             String singleVersionSpec = buildVariableResolver.resolve(VERSION_SPEC);
-            recordWorkspaceChangesetVersion(build, listener, server, workspaceConfiguration, singleVersionSpec);
+            final String projectPath = workspaceConfiguration.getProjectPath();
+            final Project project = server.getProject(projectPath);
+            recordWorkspaceChangesetVersion(build, listener, project, projectPath, singleVersionSpec);
 
             CheckoutAction action = new CheckoutAction(workspaceConfiguration.getWorkspaceName(), workspaceConfiguration.getProjectPath(), workspaceConfiguration.getWorkfolder(), isUseUpdate());
             try {
@@ -222,12 +224,10 @@ public class TeamFoundationServerScm extends SCM {
         return true;
     }
 
-    void recordWorkspaceChangesetVersion(final AbstractBuild<?, ?> build, final BuildListener listener, final Server server, final WorkspaceConfiguration workspaceConfiguration, final String singleVersionSpec) throws IOException, InterruptedException {
+    void recordWorkspaceChangesetVersion(final AbstractBuild<?, ?> build, final BuildListener listener, final Project project, final String projectPath, final String singleVersionSpec) throws IOException, InterruptedException {
         int buildChangeset;
         try {
             setWorkspaceChangesetVersion(null);
-            String projectPath = workspaceConfiguration.getProjectPath();
-            Project project = server.getProject(projectPath);
             // TODO: even better would be to call this first, then use the changeset when calling checkout
             buildChangeset = project.getRemoteChangesetVersion(new DateVersionSpec(build.getTimestamp()));
             setWorkspaceChangesetVersion(Integer.toString(buildChangeset, 10));

--- a/src/main/java/hudson/plugins/tfs/TeamFoundationServerScm.java
+++ b/src/main/java/hudson/plugins/tfs/TeamFoundationServerScm.java
@@ -13,6 +13,7 @@ import java.util.logging.Logger;
 import java.util.regex.Pattern;
 
 import com.microsoft.tfs.core.clients.versioncontrol.specs.version.DateVersionSpec;
+import com.microsoft.tfs.core.clients.versioncontrol.specs.version.VersionSpec;
 import hudson.util.Secret;
 import net.sf.json.JSONObject;
 
@@ -225,11 +226,17 @@ public class TeamFoundationServerScm extends SCM {
     }
 
     void recordWorkspaceChangesetVersion(final AbstractBuild<?, ?> build, final BuildListener listener, final Project project, final String projectPath, final String singleVersionSpec) throws IOException, InterruptedException {
+        final VersionSpec workspaceVersion;
+        if (!StringUtils.isEmpty(singleVersionSpec)) {
+            workspaceVersion = VersionSpec.parseSingleVersionFromSpec(singleVersionSpec, null);
+        }
+        else {
+            workspaceVersion = new DateVersionSpec(build.getTimestamp());
+        }
         int buildChangeset;
         try {
             setWorkspaceChangesetVersion(null);
-            // TODO: even better would be to call this first, then use the changeset when calling checkout
-            buildChangeset = project.getRemoteChangesetVersion(new DateVersionSpec(build.getTimestamp()));
+            buildChangeset = project.getRemoteChangesetVersion(workspaceVersion);
             setWorkspaceChangesetVersion(Integer.toString(buildChangeset, 10));
 
             // by adding this action, we prevent calcRevisionsFromBuild() from being called

--- a/src/main/java/hudson/plugins/tfs/TeamFoundationServerScm.java
+++ b/src/main/java/hudson/plugins/tfs/TeamFoundationServerScm.java
@@ -12,6 +12,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
 
+import com.microsoft.tfs.core.clients.versioncontrol.specs.version.DateVersionSpec;
 import hudson.util.Secret;
 import net.sf.json.JSONObject;
 
@@ -204,7 +205,7 @@ public class TeamFoundationServerScm extends SCM {
                 String projectPath = workspaceConfiguration.getProjectPath();
                 Project project = server.getProject(projectPath);
                 // TODO: even better would be to call this first, then use the changeset when calling checkout
-                buildChangeset = project.getRemoteChangesetVersion(build.getTimestamp());
+                buildChangeset = project.getRemoteChangesetVersion(new DateVersionSpec(build.getTimestamp()));
                 setWorkspaceChangesetVersion(Integer.toString(buildChangeset, 10));
 
                 // by adding this action, we prevent calcRevisionsFromBuild() from being called

--- a/src/main/java/hudson/plugins/tfs/actions/CheckoutAction.java
+++ b/src/main/java/hudson/plugins/tfs/actions/CheckoutAction.java
@@ -41,11 +41,11 @@ public class CheckoutAction {
         return new ArrayList<ChangeSet>();
     }
 
-    public List<ChangeSet> checkoutByLabel(Server server, FilePath workspacePath, String label) throws IOException, InterruptedException {
-    	Project project = getProject(server, workspacePath);
-    	project.getFiles(localFolder, label);
-    	
-    	return project.getDetailedHistory(label);
+    public List<ChangeSet> checkoutBySingleVersionSpec(Server server, FilePath workspacePath, String singleVersionSpec) throws IOException, InterruptedException {
+        Project project = getProject(server, workspacePath);
+        project.getFiles(localFolder, singleVersionSpec);
+
+        return project.getDetailedHistory(singleVersionSpec);
     }
 
     private Project getProject(Server server, FilePath workspacePath)

--- a/src/main/java/hudson/plugins/tfs/commands/AbstractCommand.java
+++ b/src/main/java/hudson/plugins/tfs/commands/AbstractCommand.java
@@ -22,14 +22,6 @@ public abstract class AbstractCommand implements Command {
         return result;
     }
 
-    protected static Calendar getExclusiveToTimestamp(Calendar toTimestamp) {
-        // The to timestamp is exclusive, ie it will only show history before the to timestamp.
-        // This command should be inclusive.
-        Calendar result = (Calendar) toTimestamp.clone();
-        result.add(Calendar.SECOND, 1);
-        return result;
-    }
-
     private final ServerConfigurationProvider config;
     
     public AbstractCommand(ServerConfigurationProvider configurationProvider) {

--- a/src/main/java/hudson/plugins/tfs/commands/AbstractCommand.java
+++ b/src/main/java/hudson/plugins/tfs/commands/AbstractCommand.java
@@ -9,19 +9,6 @@ import hudson.util.ArgumentListBuilder;
 
 public abstract class AbstractCommand implements Command {
 
-    protected static String getRangeSpecification(Calendar timestamp, int changeset) {
-        String result;
-        if(timestamp != null)
-        {
-            result = String.format("D%s", DateUtil.TFS_DATETIME_FORMATTER.get().format(timestamp.getTime()));
-        }
-        else
-        {
-            result = String.format("C%d", changeset); 
-        }
-        return result;
-    }
-
     private final ServerConfigurationProvider config;
     
     public AbstractCommand(ServerConfigurationProvider configurationProvider) {

--- a/src/main/java/hudson/plugins/tfs/commands/RemoteChangesetVersionCommand.java
+++ b/src/main/java/hudson/plugins/tfs/commands/RemoteChangesetVersionCommand.java
@@ -1,6 +1,8 @@
 package hudson.plugins.tfs.commands;
 
+import com.google.common.base.Strings;
 import com.microsoft.tfs.core.clients.versioncontrol.specs.version.DateVersionSpec;
+import com.microsoft.tfs.core.clients.versioncontrol.specs.version.LabelVersionSpec;
 import com.microsoft.tfs.core.clients.versioncontrol.specs.version.VersionSpec;
 import hudson.plugins.tfs.util.DateUtil;
 import hudson.plugins.tfs.util.MaskedArgumentListBuilder;
@@ -50,6 +52,20 @@ public class RemoteChangesetVersionCommand extends AbstractChangesetVersionComma
         if (adjustedVersionSpec instanceof DateVersionSpec){
             final DateVersionSpec dateVersionSpec = (DateVersionSpec) adjustedVersionSpec;
             return DateUtil.toString(dateVersionSpec);
+        }
+        else if (adjustedVersionSpec instanceof LabelVersionSpec) {
+            final LabelVersionSpec labelVersionSpec = (LabelVersionSpec) adjustedVersionSpec;
+            // TODO: It seems to me LabelVersionSpec.toString() should emit "Lfoo" when its scope is null
+            final String label = labelVersionSpec.getLabel();
+            final String scope = labelVersionSpec.getScope();
+            final StringBuilder sb = new StringBuilder(1 + label.length() + Strings.nullToEmpty(scope).length());
+            sb.append('L');
+            sb.append(label);
+            if (!Strings.isNullOrEmpty(scope)) {
+                sb.append('@');
+                sb.append(scope);
+            }
+            return sb.toString();
         }
         return adjustedVersionSpec.toString();
     }

--- a/src/main/java/hudson/plugins/tfs/commands/RemoteChangesetVersionCommand.java
+++ b/src/main/java/hudson/plugins/tfs/commands/RemoteChangesetVersionCommand.java
@@ -16,13 +16,6 @@ import java.util.Calendar;
 public class RemoteChangesetVersionCommand extends AbstractChangesetVersionCommand {
 
     private final VersionSpec versionSpec;
-    
-    public RemoteChangesetVersionCommand(
-            ServerConfigurationProvider configurationProvider, String remotePath, Calendar toTimestamp) {
-        super(configurationProvider, remotePath);
-
-        this.versionSpec = new DateVersionSpec(toTimestamp);
-    }
 
     public RemoteChangesetVersionCommand(
             ServerConfigurationProvider configurationProvider, String remotePath, VersionSpec versionSpec) {

--- a/src/main/java/hudson/plugins/tfs/commands/RemoteChangesetVersionCommand.java
+++ b/src/main/java/hudson/plugins/tfs/commands/RemoteChangesetVersionCommand.java
@@ -21,7 +21,7 @@ public class RemoteChangesetVersionCommand extends AbstractChangesetVersionComma
             ServerConfigurationProvider configurationProvider, String remotePath, Calendar toTimestamp) {
         super(configurationProvider, remotePath);
 
-        this.versionSpec = new DateVersionSpec(getExclusiveToTimestamp(toTimestamp));
+        this.versionSpec = new DateVersionSpec(toTimestamp);
     }
 
     public RemoteChangesetVersionCommand(
@@ -40,11 +40,24 @@ public class RemoteChangesetVersionCommand extends AbstractChangesetVersionComma
     
     @Override
     String getVersionSpecification() {
-        // TODO: just call versionSpec.toString() once DateVersionSpec.toString() uses ISO 8601 format
-        if (versionSpec instanceof DateVersionSpec){
+        final VersionSpec adjustedVersionSpec;
+        if (versionSpec instanceof DateVersionSpec) {
+            // The to timestamp is exclusive, ie it will only show history before the to timestamp.
+            // This command should be inclusive.
             final DateVersionSpec dateVersionSpec = (DateVersionSpec) versionSpec;
+            final Calendar calendar = dateVersionSpec.getDate();
+            final Calendar adjustedCalendar = (Calendar) calendar.clone();
+            adjustedCalendar.add(Calendar.SECOND, 1);
+            adjustedVersionSpec = new DateVersionSpec(adjustedCalendar);
+        }
+        else {
+            adjustedVersionSpec = versionSpec;
+        }
+        // TODO: just call adjustedVersionSpec.toString() once DateVersionSpec.toString() uses ISO 8601 format
+        if (adjustedVersionSpec instanceof DateVersionSpec){
+            final DateVersionSpec dateVersionSpec = (DateVersionSpec) adjustedVersionSpec;
             return DateUtil.toString(dateVersionSpec);
         }
-        return versionSpec.toString();
+        return adjustedVersionSpec.toString();
     }
 }

--- a/src/main/java/hudson/plugins/tfs/commands/RemoteChangesetVersionCommand.java
+++ b/src/main/java/hudson/plugins/tfs/commands/RemoteChangesetVersionCommand.java
@@ -1,5 +1,8 @@
 package hudson.plugins.tfs.commands;
 
+import com.microsoft.tfs.core.clients.versioncontrol.specs.version.DateVersionSpec;
+import com.microsoft.tfs.core.clients.versioncontrol.specs.version.VersionSpec;
+import hudson.plugins.tfs.util.DateUtil;
 import hudson.plugins.tfs.util.MaskedArgumentListBuilder;
 
 import java.util.Calendar;
@@ -12,13 +15,13 @@ import java.util.Calendar;
  */
 public class RemoteChangesetVersionCommand extends AbstractChangesetVersionCommand {
 
-    private final Calendar toTimestamp;
+    private final VersionSpec versionSpec;
     
     public RemoteChangesetVersionCommand(
             ServerConfigurationProvider configurationProvider, String remotePath, Calendar toTimestamp) {
         super(configurationProvider, remotePath);
 
-        this.toTimestamp = getExclusiveToTimestamp(toTimestamp);
+        this.versionSpec = new DateVersionSpec(getExclusiveToTimestamp(toTimestamp));
     }
 
     @Override
@@ -30,6 +33,11 @@ public class RemoteChangesetVersionCommand extends AbstractChangesetVersionComma
     
     @Override
     String getVersionSpecification() {
-        return String.format("%s", AbstractCommand.getRangeSpecification(toTimestamp, 0));
+        // TODO: just call versionSpec.toString() once DateVersionSpec.toString() uses ISO 8601 format
+        if (versionSpec instanceof DateVersionSpec){
+            final DateVersionSpec dateVersionSpec = (DateVersionSpec) versionSpec;
+            return DateUtil.toString(dateVersionSpec);
+        }
+        return versionSpec.toString();
     }
 }

--- a/src/main/java/hudson/plugins/tfs/commands/RemoteChangesetVersionCommand.java
+++ b/src/main/java/hudson/plugins/tfs/commands/RemoteChangesetVersionCommand.java
@@ -24,6 +24,13 @@ public class RemoteChangesetVersionCommand extends AbstractChangesetVersionComma
         this.versionSpec = new DateVersionSpec(getExclusiveToTimestamp(toTimestamp));
     }
 
+    public RemoteChangesetVersionCommand(
+            ServerConfigurationProvider configurationProvider, String remotePath, VersionSpec versionSpec) {
+        super(configurationProvider, remotePath);
+
+        this.versionSpec = versionSpec;
+    }
+
     @Override
     public MaskedArgumentListBuilder getArguments() {
         MaskedArgumentListBuilder arguments = super.getArguments();

--- a/src/main/java/hudson/plugins/tfs/model/Project.java
+++ b/src/main/java/hudson/plugins/tfs/model/Project.java
@@ -92,7 +92,7 @@ public class Project {
         try {
             final Changeset[] serverChangesets = vcc.queryHistory(
                     projectPath,
-                    fromVersion,
+                    fromVersion != null ? fromVersion : toVersion,
                     0 /* deletionId */,
                     RecursionType.FULL,
                     null /* user */,
@@ -131,8 +131,8 @@ public class Project {
     }
     
     public List<ChangeSet> getDetailedHistory(String singleVersionSpec) {
-        final VersionSpec fromVersion = VersionSpec.parseSingleVersionFromSpec(singleVersionSpec, null);
-        return getVCCHistory(fromVersion, null, true);
+        final VersionSpec toVersion = VersionSpec.parseSingleVersionFromSpec(singleVersionSpec, null);
+        return getVCCHistory(null, toVersion, true);
     }
 
     /**

--- a/src/main/java/hudson/plugins/tfs/model/Project.java
+++ b/src/main/java/hudson/plugins/tfs/model/Project.java
@@ -1,6 +1,7 @@
 package hudson.plugins.tfs.model;
 
 import hudson.model.User;
+import hudson.plugins.tfs.commands.AbstractChangesetVersionCommand;
 import hudson.plugins.tfs.commands.GetFilesToWorkFolderCommand;
 import hudson.plugins.tfs.commands.RemoteChangesetVersionCommand;
 import hudson.plugins.tfs.commands.WorkspaceChangesetVersionCommand;
@@ -208,6 +209,11 @@ public class Project {
     public int getRemoteChangesetVersion(String remotePath, Calendar toTimestamp)
             throws IOException, InterruptedException, ParseException {
         RemoteChangesetVersionCommand command = new RemoteChangesetVersionCommand(server, remotePath, toTimestamp);
+        return extractChangesetNumber(command);
+    }
+
+    int extractChangesetNumber(final AbstractChangesetVersionCommand command)
+            throws IOException, InterruptedException, ParseException {
         Reader reader = null;
         try {
             reader = server.execute(command.getArguments());

--- a/src/main/java/hudson/plugins/tfs/model/Project.java
+++ b/src/main/java/hudson/plugins/tfs/model/Project.java
@@ -212,6 +212,19 @@ public class Project {
         return extractChangesetNumber(command);
     }
 
+    /**
+     * Gets remote changeset version for specified remote path, as of versionSpec.
+     *
+     * @param remotePath for which to get latest changeset version
+     * @param versionSpec a version specification to convert to a changeset number
+     * @return changeset version for specified remote path
+     */
+    public int getRemoteChangesetVersion(final String remotePath, final VersionSpec versionSpec)
+            throws IOException, InterruptedException, ParseException {
+        RemoteChangesetVersionCommand command = new RemoteChangesetVersionCommand(server, remotePath, versionSpec);
+        return extractChangesetNumber(command);
+    }
+
     int extractChangesetNumber(final AbstractChangesetVersionCommand command)
             throws IOException, InterruptedException, ParseException {
         Reader reader = null;
@@ -234,7 +247,18 @@ public class Project {
             throws IOException, InterruptedException, ParseException {
         return getRemoteChangesetVersion(projectPath, toTimestamp);
     }
-    
+
+    /**
+     * Gets remote changeset version for the project's remote path, as of versionSpec.
+     *
+     * @param versionSpec a version specification to convert to a changeset number
+     * @return changeset version for the project's remote path
+     */
+    public int getRemoteChangesetVersion(final VersionSpec versionSpec)
+            throws IOException, InterruptedException, ParseException {
+        return getRemoteChangesetVersion(projectPath, versionSpec);
+    }
+
     @Override
     public int hashCode() {
         return new HashCodeBuilder(13, 27).append(projectPath).toHashCode();

--- a/src/main/java/hudson/plugins/tfs/model/Project.java
+++ b/src/main/java/hudson/plugins/tfs/model/Project.java
@@ -129,10 +129,10 @@ public class Project {
         return getVCCHistory(fromVersion, toVersion, true);
     }
     
-	public List<ChangeSet> getDetailedHistory(String label) {
-		LabelVersionSpec fromVersion = new LabelVersionSpec(new LabelSpec(label, null));
-		return getVCCHistory(fromVersion, null, true);
-	}
+    public List<ChangeSet> getDetailedHistory(String singleVersionSpec) {
+        final VersionSpec fromVersion = VersionSpec.parseSingleVersionFromSpec(singleVersionSpec, null);
+        return getVCCHistory(fromVersion, null, true);
+    }
 
     /**
      * Returns a list of change sets not containing the modified items.

--- a/src/main/java/hudson/plugins/tfs/model/Project.java
+++ b/src/main/java/hudson/plugins/tfs/model/Project.java
@@ -200,19 +200,6 @@ public class Project {
     }
 
     /**
-     * Gets remote changeset version for specified remote path, as of toTimestamp.
-     * 
-     * @param remotePath for which to get latest changeset version
-     * @param toTimestamp the date/time of the last build
-     * @return changeset version for specified remote path
-     */
-    public int getRemoteChangesetVersion(String remotePath, Calendar toTimestamp)
-            throws IOException, InterruptedException, ParseException {
-        RemoteChangesetVersionCommand command = new RemoteChangesetVersionCommand(server, remotePath, toTimestamp);
-        return extractChangesetNumber(command);
-    }
-
-    /**
      * Gets remote changeset version for specified remote path, as of versionSpec.
      *
      * @param remotePath for which to get latest changeset version
@@ -235,17 +222,6 @@ public class Project {
         } finally {
             IOUtils.closeQuietly(reader);
         }
-    }
-
-    /**
-     * Gets remote changeset version for the project's remote path, as of toTimestamp.
-     * 
-     * @param toTimestamp the date/time of the last build
-     * @return changeset version for the project's remote path
-     */
-    public int getRemoteChangesetVersion(Calendar toTimestamp)
-            throws IOException, InterruptedException, ParseException {
-        return getRemoteChangesetVersion(projectPath, toTimestamp);
     }
 
     /**

--- a/src/main/java/hudson/plugins/tfs/util/DateUtil.java
+++ b/src/main/java/hudson/plugins/tfs/util/DateUtil.java
@@ -1,6 +1,9 @@
 package hudson.plugins.tfs.util;
 
+import com.microsoft.tfs.core.clients.versioncontrol.specs.version.DateVersionSpec;
+
 import java.text.DateFormat;
+import java.text.FieldPosition;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -23,7 +26,18 @@ public class DateUtil {
             return dateFormat;
         }
     };
-    
+
+    public static String toString(final DateVersionSpec dateVersionSpec) {
+        final Date dateTime = dateVersionSpec.getDate().getTime();
+        final FieldPosition fieldPosition = new FieldPosition(-1);
+        final SimpleDateFormat simpleDateFormat = TFS_DATETIME_FORMATTER.get();
+        final StringBuffer sb = new StringBuffer();
+        sb.append('D');
+        simpleDateFormat.format(dateTime, sb, fieldPosition);
+        final String result = sb.toString();
+        return result;
+    }
+
     public static Date parseDate(String dateString) throws ParseException {
         return parseDate(dateString, Locale.getDefault(), TimeZone.getDefault());
     }

--- a/src/main/java/hudson/plugins/tfs/util/DateUtil.java
+++ b/src/main/java/hudson/plugins/tfs/util/DateUtil.java
@@ -7,6 +7,7 @@ import java.text.FieldPosition;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
 import java.util.Locale;
@@ -28,7 +29,16 @@ public class DateUtil {
     };
 
     public static String toString(final DateVersionSpec dateVersionSpec) {
-        final Date dateTime = dateVersionSpec.getDate().getTime();
+        final Calendar calendar = dateVersionSpec.getDate();
+        return toString(calendar);
+    }
+
+    public static String toString(final Calendar calendar) {
+        final Date dateTime = calendar.getTime();
+        return toString(dateTime);
+    }
+
+    public static String toString(Date dateTime) {
         final FieldPosition fieldPosition = new FieldPosition(-1);
         final SimpleDateFormat simpleDateFormat = TFS_DATETIME_FORMATTER.get();
         final StringBuffer sb = new StringBuffer();

--- a/src/main/java/hudson/plugins/tfs/util/DateUtil.java
+++ b/src/main/java/hudson/plugins/tfs/util/DateUtil.java
@@ -43,7 +43,7 @@ public class DateUtil {
     public static String toString(final Date dateTime) {
         final FieldPosition fieldPosition = new FieldPosition(-1);
         final SimpleDateFormat simpleDateFormat = TFS_DATETIME_FORMATTER.get();
-        final StringBuffer sb = new StringBuffer();
+        final StringBuffer sb = new StringBuffer(1 + ISO_8601_DATE_TIME_MINUS_FRACTIONS.length());
         sb.append('D');
         simpleDateFormat.format(dateTime, sb, fieldPosition);
         final String result = sb.toString();

--- a/src/main/java/hudson/plugins/tfs/util/DateUtil.java
+++ b/src/main/java/hudson/plugins/tfs/util/DateUtil.java
@@ -38,7 +38,7 @@ public class DateUtil {
         return toString(dateTime);
     }
 
-    public static String toString(Date dateTime) {
+    public static String toString(final Date dateTime) {
         final FieldPosition fieldPosition = new FieldPosition(-1);
         final SimpleDateFormat simpleDateFormat = TFS_DATETIME_FORMATTER.get();
         final StringBuffer sb = new StringBuffer();

--- a/src/main/java/hudson/plugins/tfs/util/DateUtil.java
+++ b/src/main/java/hudson/plugins/tfs/util/DateUtil.java
@@ -19,10 +19,12 @@ public class DateUtil {
     private DateUtil() {        
     }
 
+    private static final String ISO_8601_DATE_TIME_MINUS_FRACTIONS = "yyyy-MM-dd'T'HH:mm:ss'Z'";
+
     public static final ThreadLocal<SimpleDateFormat> TFS_DATETIME_FORMATTER = new ThreadLocal<SimpleDateFormat>() {
         @Override
         protected SimpleDateFormat initialValue() {
-            SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+            SimpleDateFormat dateFormat = new SimpleDateFormat(ISO_8601_DATE_TIME_MINUS_FRACTIONS);
             dateFormat.setTimeZone(new SimpleTimeZone(0,"GMT"));
             return dateFormat;
         }

--- a/src/test/java/hudson/plugins/tfs/TeamFoundationServerScmTest.java
+++ b/src/test/java/hudson/plugins/tfs/TeamFoundationServerScmTest.java
@@ -10,18 +10,22 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import java.io.File;
+import java.util.GregorianCalendar;
 import java.util.HashMap;
 import java.util.Map;
 
+import com.microsoft.tfs.core.clients.versioncontrol.specs.version.VersionSpec;
 import com.thoughtworks.xstream.XStream;
 import hudson.FilePath;
 import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
+import hudson.model.BuildListener;
 import hudson.model.Computer;
 import hudson.model.Hudson;
 import hudson.model.Node;
 import hudson.model.ParametersAction;
 
+import hudson.plugins.tfs.model.Project;
 import hudson.util.Secret;
 import hudson.util.TextFile;
 import hudson.util.XStream2;
@@ -257,6 +261,23 @@ public class TeamFoundationServerScmTest {
         Map<String, String> env = new HashMap<String, String>();
         scm.buildEnvVars(mock(AbstractBuild.class), env );        
         assertEquals("Workspace changeset version was not null", null, env.get(TeamFoundationServerScm.WORKSPACE_CHANGESET_ENV_STR));
+    }
+
+    @Test public void recordWorkspaceChangesetVersion() throws Exception {
+        final TeamFoundationServerScm scm = new TeamFoundationServerScm("serverUrl", "projectPath", "localPath", false, "workspace", "userName", "password");
+        final AbstractBuild build = mock(AbstractBuild.class);
+        when(build.getTimestamp()).thenReturn(new GregorianCalendar(2015, 03, 28, 22, 04));
+        final BuildListener listener = null;
+        final Project project = mock(Project.class);
+        when(project.getRemoteChangesetVersion(isA(VersionSpec.class))).thenReturn(42);
+        final String projectPath = "projectPath";
+        final String singleVersionSpec = null;
+
+        scm.recordWorkspaceChangesetVersion(build, listener, project, projectPath, singleVersionSpec);
+
+        final Map<String, String> env = new HashMap<String, String>();
+        scm.buildEnvVars(build, env);
+        assertEquals("42", env.get(TeamFoundationServerScm.WORKSPACE_CHANGESET_ENV_STR));
     }
 
     /**

--- a/src/test/java/hudson/plugins/tfs/TeamFoundationServerScmTest.java
+++ b/src/test/java/hudson/plugins/tfs/TeamFoundationServerScmTest.java
@@ -280,6 +280,22 @@ public class TeamFoundationServerScmTest {
         assertEquals("42", env.get(TeamFoundationServerScm.WORKSPACE_CHANGESET_ENV_STR));
     }
 
+    @Test public void recordWorkspaceChangesetVersionWithSingleVersionSpec() throws Exception {
+        final TeamFoundationServerScm scm = new TeamFoundationServerScm("serverUrl", "projectPath", "localPath", false, "workspace", "userName", "password");
+        final AbstractBuild build = mock(AbstractBuild.class);
+        final BuildListener listener = null;
+        final Project project = mock(Project.class);
+        when(project.getRemoteChangesetVersion(isA(VersionSpec.class))).thenReturn(42);
+        final String projectPath = "projectPath";
+        final String singleVersionSpec = "Lfoo";
+
+        scm.recordWorkspaceChangesetVersion(build, listener, project, projectPath, singleVersionSpec);
+
+        final Map<String, String> env = new HashMap<String, String>();
+        scm.buildEnvVars(build, env);
+        assertEquals("42", env.get(TeamFoundationServerScm.WORKSPACE_CHANGESET_ENV_STR));
+    }
+
     /**
      * Workspace name must be less than 64 characters, cannot end with a space or period, and cannot contain any of the following characters: "/:<>|*?
      */

--- a/src/test/java/hudson/plugins/tfs/actions/CheckoutActionTest.java
+++ b/src/test/java/hudson/plugins/tfs/actions/CheckoutActionTest.java
@@ -44,14 +44,14 @@ public class CheckoutActionTest {
     }
     
     @Test
-    public void assertFirstCheckoutByLabelNotUsingUpdate() throws Exception {
+    public void assertFirstCheckoutBySingleVersionSpecNotUsingUpdate() throws Exception {
     	when(server.getWorkspaces()).thenReturn(workspaces);
     	when(server.getProject("project")).thenReturn(project);
     	when(workspaces.exists("workspace")).thenReturn(true).thenReturn(false);
     	when(workspaces.newWorkspace("workspace")).thenReturn(workspace);
     	when(workspaces.getWorkspace("workspace")).thenReturn(workspace);
     	
-    	new CheckoutAction("workspace", "project", ".", false).checkoutByLabel(server, hudsonWs,MY_LABEL);
+    	new CheckoutAction("workspace", "project", ".", false).checkoutBySingleVersionSpec(server, hudsonWs, MY_LABEL);
     	
     	verify(workspaces).newWorkspace("workspace");
     	verify(workspace).mapWorkfolder(project, hudsonWs.getRemote());
@@ -76,13 +76,13 @@ public class CheckoutActionTest {
     }
 
     @Test
-    public void assertFirstCheckoutByLabelUsingUpdate() throws Exception {
+    public void assertFirstCheckoutBySingleVersionSpecUsingUpdate() throws Exception {
         when(server.getWorkspaces()).thenReturn(workspaces);
         when(server.getProject("project")).thenReturn(project);
         when(workspaces.exists(new Workspace(server, "workspace"))).thenReturn(false);
         when(workspaces.newWorkspace("workspace")).thenReturn(workspace);
         
-        new CheckoutAction("workspace", "project", ".", true).checkoutByLabel(server, hudsonWs, MY_LABEL);
+        new CheckoutAction("workspace", "project", ".", true).checkoutBySingleVersionSpec(server, hudsonWs, MY_LABEL);
         
         verify(workspaces).newWorkspace("workspace");
         verify(workspace).mapWorkfolder(project, hudsonWs.getRemote());
@@ -106,7 +106,7 @@ public class CheckoutActionTest {
     }
     
     @Test
-    public void assertSecondCheckoutByLabelUsingUpdate() throws Exception {
+    public void assertSecondCheckoutBySingleVersionSpecUsingUpdate() throws Exception {
         when(server.getWorkspaces()).thenReturn(workspaces);
         when(server.getProject("project")).thenReturn(project);
         when(workspaces.exists("workspace")).thenReturn(true);
@@ -114,7 +114,7 @@ public class CheckoutActionTest {
         when(server.getLocalHostname()).thenReturn("LocalComputer");
         when(workspace.getComputer()).thenReturn("LocalComputer");
         
-        new CheckoutAction("workspace", "project", ".", true).checkoutByLabel(server, hudsonWs, MY_LABEL);
+        new CheckoutAction("workspace", "project", ".", true).checkoutBySingleVersionSpec(server, hudsonWs, MY_LABEL);
 
         verify(project).getFiles(".", MY_LABEL);
         verify(workspaces, never()).newWorkspace("workspace");
@@ -140,14 +140,14 @@ public class CheckoutActionTest {
     }
 
     @Test
-    public void assertSecondCheckoutByLabelNotUsingUpdate() throws Exception {
+    public void assertSecondCheckoutBySingleVersionSpecNotUsingUpdate() throws Exception {
         when(server.getWorkspaces()).thenReturn(workspaces);
         when(server.getProject("project")).thenReturn(project);
         when(workspaces.exists("workspace")).thenReturn(true).thenReturn(false);
         when(workspaces.newWorkspace("workspace")).thenReturn(workspace);
         when(workspaces.getWorkspace("workspace")).thenReturn(workspace);
         
-        new CheckoutAction("workspace", "project", ".", false).checkoutByLabel(server, hudsonWs, MY_LABEL);
+        new CheckoutAction("workspace", "project", ".", false).checkoutBySingleVersionSpec(server, hudsonWs, MY_LABEL);
 
         verify(workspaces).newWorkspace("workspace");
         verify(workspace).mapWorkfolder(project, hudsonWs.getRemote());
@@ -180,7 +180,7 @@ public class CheckoutActionTest {
         when(server.getLocalHostname()).thenReturn("LocalComputer");
         when(workspace.getComputer()).thenReturn("LocalComputer");
         
-        new CheckoutAction("workspace", "project", ".", true).checkoutByLabel(server, hudsonWs, MY_LABEL);
+        new CheckoutAction("workspace", "project", ".", true).checkoutBySingleVersionSpec(server, hudsonWs, MY_LABEL);
         
         verify(project, never()).getDetailedHistory(isA(Calendar.class), isA(Calendar.class));
     }
@@ -211,7 +211,7 @@ public class CheckoutActionTest {
         when(project.getDetailedHistory(isA(String.class))).thenReturn(list);
         
         CheckoutAction action = new CheckoutAction("workspace", "project", ".", true);
-        List<ChangeSet> actualList = action.checkoutByLabel(server, hudsonWs, MY_LABEL);
+        List<ChangeSet> actualList = action.checkoutBySingleVersionSpec(server, hudsonWs, MY_LABEL);
         assertSame("The list from the detailed history, was not the same as returned from checkout", list, actualList);
         
         verify(project).getDetailedHistory(isA(String.class));
@@ -266,7 +266,7 @@ public class CheckoutActionTest {
         when(workspaces.exists(new Workspace(server, "workspace"))).thenReturn(false);
         when(workspaces.newWorkspace("workspace")).thenReturn(workspace);
         
-        new CheckoutAction("workspace", "project", "tfs-ws", false).checkoutByLabel(server, hudsonWs, MY_LABEL);
+        new CheckoutAction("workspace", "project", "tfs-ws", false).checkoutBySingleVersionSpec(server, hudsonWs, MY_LABEL);
         
         assertTrue("The local folder was removed", tfsWs.exists());
         assertEquals("The local TFS folder was not cleaned", 0, tfsWs.list((FileFilter)null).size());
@@ -294,14 +294,14 @@ public class CheckoutActionTest {
     
     @Bug(3882)
     @Test
-    public void assertCheckoutByLabelDeletesWorkspaceAtStartIfNotUsingUpdate() throws Exception {
+    public void assertCheckoutBySingleVersionSpecDeletesWorkspaceAtStartIfNotUsingUpdate() throws Exception {
         when(server.getWorkspaces()).thenReturn(workspaces);
         when(workspaces.exists("workspace")).thenReturn(true).thenReturn(false);
         when(workspaces.getWorkspace("workspace")).thenReturn(workspace);
         when(server.getProject("project")).thenReturn(project);
         when(workspaces.newWorkspace("workspace")).thenReturn(workspace);
         
-        new CheckoutAction("workspace", "project", ".", false).checkoutByLabel(server, hudsonWs, MY_LABEL);
+        new CheckoutAction("workspace", "project", ".", false).checkoutBySingleVersionSpec(server, hudsonWs, MY_LABEL);
         
         verify(server).getWorkspaces();
         verify(workspaces, times(2)).exists("workspace");
@@ -348,13 +348,13 @@ public class CheckoutActionTest {
     
     @Bug(3882)
     @Test
-    public void assertCheckoutByLabelDoesNotDeleteWorkspaceAtStartIfUsingUpdate() throws Exception {
+    public void assertCheckoutBySingleVersionSpecDoesNotDeleteWorkspaceAtStartIfUsingUpdate() throws Exception {
         when(server.getWorkspaces()).thenReturn(workspaces);
         when(workspaces.exists("workspace")).thenReturn(true).thenReturn(true);
         when(workspaces.getWorkspace("workspace")).thenReturn(workspace);
         when(server.getProject("project")).thenReturn(project);
         
-        new CheckoutAction("workspace", "project", ".", true).checkoutByLabel(server, hudsonWs, MY_LABEL);
+        new CheckoutAction("workspace", "project", ".", true).checkoutBySingleVersionSpec(server, hudsonWs, MY_LABEL);
         
         verify(server).getWorkspaces();
         verify(workspaces, times(2)).exists("workspace");
@@ -380,13 +380,13 @@ public class CheckoutActionTest {
     
     @Bug(3882)
     @Test
-    public void assertCheckoutByLabelDoesNotDeleteWorkspaceIfNotUsingUpdateAndThereIsNoWorkspace() throws Exception {
+    public void assertCheckoutBySingleVersionSpecDoesNotDeleteWorkspaceIfNotUsingUpdateAndThereIsNoWorkspace() throws Exception {
         when(server.getWorkspaces()).thenReturn(workspaces);
         when(workspaces.exists("workspace")).thenReturn(false).thenReturn(false);
         when(workspaces.newWorkspace("workspace")).thenReturn(workspace);
         when(server.getProject("project")).thenReturn(project);
         
-        new CheckoutAction("workspace", "project", ".", false).checkoutByLabel(server, hudsonWs, MY_LABEL);
+        new CheckoutAction("workspace", "project", ".", false).checkoutBySingleVersionSpec(server, hudsonWs, MY_LABEL);
         
         verify(server).getWorkspaces();
         verify(workspaces, times(2)).exists("workspace");

--- a/src/test/java/hudson/plugins/tfs/commands/RemoteChangesetVersionCommandTest.java
+++ b/src/test/java/hudson/plugins/tfs/commands/RemoteChangesetVersionCommandTest.java
@@ -4,6 +4,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+
+import com.microsoft.tfs.core.clients.versioncontrol.specs.version.ChangesetVersionSpec;
 import hudson.plugins.tfs.Util;
 import hudson.plugins.tfs.util.MaskedArgumentListBuilder;
 
@@ -26,6 +28,18 @@ public class RemoteChangesetVersionCommandTest {
         MaskedArgumentListBuilder arguments = new RemoteChangesetVersionCommand(config, "$/tfsandbox", fixedPointInTime).getArguments();
         assertNotNull("Arguments were null", arguments);
         assertEquals("history $/tfsandbox -recursive -stopafter:1 -noprompt -version:D2013-07-02T15:40:51Z -format:brief -login:snd\\user_cp,password -server:https://tfs02.codeplex.com", arguments.toStringWithQuote());
+    }
+
+    @Test
+    public void assertVersionSpec() {
+        ServerConfigurationProvider config = mock(ServerConfigurationProvider.class);
+        when(config.getUrl()).thenReturn("https://tfs02.codeplex.com");
+        when(config.getUserName()).thenReturn("snd\\user_cp");
+        when(config.getUserPassword()).thenReturn("password");
+
+        MaskedArgumentListBuilder arguments = new RemoteChangesetVersionCommand(config, "$/tfsandbox", new ChangesetVersionSpec(42)).getArguments();
+        assertNotNull("Arguments were null", arguments);
+        assertEquals("history $/tfsandbox -recursive -stopafter:1 -noprompt -version:C42 -format:brief -login:snd\\user_cp,password -server:https://tfs02.codeplex.com", arguments.toStringWithQuote());
     }
 
     @Test

--- a/src/test/java/hudson/plugins/tfs/commands/RemoteChangesetVersionCommandTest.java
+++ b/src/test/java/hudson/plugins/tfs/commands/RemoteChangesetVersionCommandTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.microsoft.tfs.core.clients.versioncontrol.specs.version.ChangesetVersionSpec;
+import com.microsoft.tfs.core.clients.versioncontrol.specs.version.DateVersionSpec;
 import hudson.plugins.tfs.Util;
 import hudson.plugins.tfs.util.MaskedArgumentListBuilder;
 
@@ -16,7 +17,7 @@ import org.junit.Test;
 
 public class RemoteChangesetVersionCommandTest {
 
-    private static final Calendar fixedPointInTime = Util.getCalendar(2013, 07, 02, 15, 40, 50);
+    private static final DateVersionSpec fixedPointInTime = new DateVersionSpec(Util.getCalendar(2013, 07, 02, 15, 40, 50));
     
     @Test
     public void assertArguments() {

--- a/src/test/java/hudson/plugins/tfs/commands/RemoteChangesetVersionCommandTest.java
+++ b/src/test/java/hudson/plugins/tfs/commands/RemoteChangesetVersionCommandTest.java
@@ -5,8 +5,10 @@ import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.microsoft.tfs.core.clients.versioncontrol.specs.LabelSpec;
 import com.microsoft.tfs.core.clients.versioncontrol.specs.version.ChangesetVersionSpec;
 import com.microsoft.tfs.core.clients.versioncontrol.specs.version.DateVersionSpec;
+import com.microsoft.tfs.core.clients.versioncontrol.specs.version.LabelVersionSpec;
 import hudson.plugins.tfs.Util;
 import hudson.plugins.tfs.util.MaskedArgumentListBuilder;
 
@@ -94,6 +96,37 @@ public class RemoteChangesetVersionCommandTest {
         RemoteChangesetVersionCommand command = new RemoteChangesetVersionCommand(mock(ServerConfigurationProvider.class), "$/tfsandbox", fixedPointInTime);
         String changesetNumber = command.parse(reader);
         assertEquals("Change set number was incorrect", "12497", changesetNumber);
-    }    
+    }
 
+    @Test public void getVersionSpecificationWhenDateVersionSpec() {
+        final RemoteChangesetVersionCommand command = new RemoteChangesetVersionCommand(null, null, fixedPointInTime);
+
+        final String actual = command.getVersionSpecification();
+
+        assertEquals("D2013-07-02T15:40:51Z", actual);
+    }
+
+    @Test public void getVersionSpecificationWhenChangesetVersionSpec() {
+        final RemoteChangesetVersionCommand command = new RemoteChangesetVersionCommand(null, null, new ChangesetVersionSpec(42));
+
+        final String actual = command.getVersionSpecification();
+
+        assertEquals("C42", actual);
+    }
+
+    @Test public void getVersionSpecificationWhenLabelVersionSpecWithoutScope() {
+        final RemoteChangesetVersionCommand command = new RemoteChangesetVersionCommand(null, null, new LabelVersionSpec(new LabelSpec("Foo", null)));
+
+        final String actual = command.getVersionSpecification();
+
+        assertEquals("LFoo", actual);
+    }
+
+    @Test public void getVersionSpecificationWhenLabelVersionSpecWithScope() {
+        final RemoteChangesetVersionCommand command = new RemoteChangesetVersionCommand(null, null, new LabelVersionSpec(new LabelSpec("Foo", "Bar")));
+
+        final String actual = command.getVersionSpecification();
+
+        assertEquals("LFoo@Bar", actual);
+    }
 }

--- a/src/test/java/hudson/plugins/tfs/util/DateUtilTest.java
+++ b/src/test/java/hudson/plugins/tfs/util/DateUtilTest.java
@@ -6,14 +6,30 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.Calendar;
+import java.util.Date;
 
 public class DateUtilTest {
 
     private static final Calendar fixedPointInTime = Util.getCalendar(2013, 07, 02, 15, 40, 50);
+    private static final DateVersionSpec dateVersionSpec = new DateVersionSpec(fixedPointInTime);
 
     @Test
-    public void toString_fixedPointInTime() throws Exception {
-        final String actual = DateUtil.toString(new DateVersionSpec(fixedPointInTime));
+    public void toString_date() throws Exception {
+        final String actual = DateUtil.toString(new Date(1372779650000L));
+
+        Assert.assertEquals("D2013-07-02T15:40:50Z", actual);
+    }
+
+    @Test
+    public void toString_calendar() throws Exception {
+        final String actual = DateUtil.toString(fixedPointInTime);
+
+        Assert.assertEquals("D2013-07-02T15:40:50Z", actual);
+    }
+
+    @Test
+    public void toString_dateVersionSpec() throws Exception {
+        final String actual = DateUtil.toString(dateVersionSpec);
 
         Assert.assertEquals("D2013-07-02T15:40:50Z", actual);
     }

--- a/src/test/java/hudson/plugins/tfs/util/DateUtilTest.java
+++ b/src/test/java/hudson/plugins/tfs/util/DateUtilTest.java
@@ -1,0 +1,21 @@
+package hudson.plugins.tfs.util;
+
+import com.microsoft.tfs.core.clients.versioncontrol.specs.version.DateVersionSpec;
+import hudson.plugins.tfs.Util;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Calendar;
+
+public class DateUtilTest {
+
+    private static final Calendar fixedPointInTime = Util.getCalendar(2013, 07, 02, 15, 40, 50);
+
+    @Test
+    public void toString_fixedPointInTime() throws Exception {
+        final String actual = DateUtil.toString(new DateVersionSpec(fixedPointInTime));
+
+        Assert.assertEquals("D2013-07-02T15:40:50Z", actual);
+    }
+
+}


### PR DESCRIPTION
Two defects were discovered in the implementation of pull request #24:

1. The value of `VERSION_SPEC` was incorrectly applied.
2. The reported SCM changes between builds by version spec was incorrectly querying TFVC.

Outstanding weirdness/defect:
-------------------------------

I created a job with polling, then added the `VERSION_SPEC` parameter with a default value of `LFoo` (a label that pointed to changeset 4).  Running a build indeed got the source from changeset 4, but then subsequent polling would detect that a changeset newer than 4 existed and queue a build.  The build would again obtain changeset 4 and the loop repeated itself until I turned off polling or removed the default value.

Part of the problem was due to configuration error (it probably doesn't make sense to supply a default value to a `VERSION_SPEC` parameter - I only did it because I'm testing the feature), but a configuration error should NOT cause a build loop. The loop itself is difficult to cause for most users, since the "checkout by label" feature isn't [yet] documented nor easily discoverable, so it might not be a very big deal.