### PR TITLE
Need native libraries to check for default creds.

### DIFF
--- a/src/main/java/hudson/plugins/tfs/model/Server.java
+++ b/src/main/java/hudson/plugins/tfs/model/Server.java
@@ -43,6 +43,8 @@ public class Server implements ServerConfigurationProvider, Closable {
         this.userPassword = password;
         final URI uri = URIUtils.newURI(url);
 
+        ensureNativeLibrariesConfigured();
+
         Credentials credentials = null;
         // In case no user name is provided and the current platform supports
         // default credentials, use default credentials
@@ -54,7 +56,6 @@ public class Server implements ServerConfigurationProvider, Closable {
         }
 
         if (credentials != null) {
-            ensureNativeLibrariesConfigured();
             this.tpc = new TFSTeamProjectCollection(uri, credentials);
         }
         else {


### PR DESCRIPTION
This fixes a defect whereby the first instance of Server would think
default NT credentials are not supported and fail miserably unless
credentials were provided.  Subsequent instances would be fine.