### PR TITLE
TFSLabeler: Using getRootProject and getRootBuild to get Scm and Workspace

### DIFF
--- a/src/main/java/hudson/plugins/tfs/TFSLabeler.java
+++ b/src/main/java/hudson/plugins/tfs/TFSLabeler.java
@@ -59,13 +59,13 @@ public class TFSLabeler extends Notifier {
 
     @Override
     public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
-        SCM scm = build.getProject().getScm();
+        SCM scm = build.getProject().getRootProject().getScm();
         if (!(scm instanceof TeamFoundationServerScm)) {
             listener.getLogger().println("Labels are only supported for projects using TFS SCM");
             return false;
         }
 
-        FilePath workspace = build.getWorkspace();
+        FilePath workspace = build.getRootBuild().getWorkspace();
 
         TeamFoundationServerScm tfsScm = (TeamFoundationServerScm) scm;
 
@@ -76,11 +76,11 @@ public class TFSLabeler extends Notifier {
 
             final Launcher localLauncher = launcher != null ? launcher : new Launcher.LocalLauncher(listener);
             final TfTool tool = new TfTool(tfsScm.getDescriptor().getTfExecutable(), localLauncher, listener, workspace);
-            Server server = new Server(tool, tfsScm.getServerUrl(build), tfsScm.getUserName(), tfsScm.getUserPassword());
+            Server server = new Server(tool, tfsScm.getServerUrl(build.getRootBuild()), tfsScm.getUserName(), tfsScm.getUserPassword());
 
             Computer computer = Computer.currentComputer();
             String normalizedLabelName = computeDynamicValue(build, getLabelName());
-            String tfsWorkspace = tfsScm.getWorkspaceName(build, computer);
+            String tfsWorkspace = tfsScm.getWorkspaceName(build.getRootBuild(), computer);
 
             try {
                 logger.info(String.format("Create label '%s' on workspace '%s'", normalizedLabelName, tfsWorkspace));


### PR DESCRIPTION
When using the plugin together with Promoted Builds plugin, label creation fails cause it can not find the Scm or the Workspace since those are defined on the root build/project.

Using getRootProject and getRootBuild methods fixes the issue. I manually tested a normal build and a Promoted build without any issue. Also all test are passing.

Hope it helps!