### PR TITLE
Helpers to facilitate transition to Java TFS SDK

### DIFF
--- a/src/main/java/hudson/plugins/tfs/commands/AbstractCallableCommand.java
+++ b/src/main/java/hudson/plugins/tfs/commands/AbstractCallableCommand.java
@@ -1,0 +1,20 @@
+package hudson.plugins.tfs.commands;
+
+import hudson.plugins.tfs.model.Server;
+
+import java.util.concurrent.Callable;
+
+public abstract class AbstractCallableCommand {
+
+    private final Server server;
+
+    protected AbstractCallableCommand(final Server server) {
+        this.server = server;
+    }
+
+    public Server getServer() {
+        return server;
+    }
+
+    public abstract <T> Callable<T> getCallable();
+}

--- a/src/main/java/hudson/plugins/tfs/model/MockableVersionControlClient.java
+++ b/src/main/java/hudson/plugins/tfs/model/MockableVersionControlClient.java
@@ -1,0 +1,20 @@
+package hudson.plugins.tfs.model;
+
+import com.microsoft.tfs.core.clients.versioncontrol.VersionControlClient;
+import com.microsoft.tfs.util.Closable;
+
+/**
+ * A non-final wrapper over {@link com.microsoft.tfs.core.clients.versioncontrol.VersionControlClient}
+ */
+public class MockableVersionControlClient implements Closable {
+
+    private final VersionControlClient vcc;
+
+    public MockableVersionControlClient(final VersionControlClient vcc) {
+        this.vcc = vcc;
+    }
+
+    public void close() {
+        vcc.close();
+    }
+}

--- a/src/main/java/hudson/plugins/tfs/model/MockableVersionControlClient.java
+++ b/src/main/java/hudson/plugins/tfs/model/MockableVersionControlClient.java
@@ -1,6 +1,12 @@
 package hudson.plugins.tfs.model;
 
 import com.microsoft.tfs.core.clients.versioncontrol.VersionControlClient;
+import com.microsoft.tfs.core.clients.versioncontrol.WorkspaceLocation;
+import com.microsoft.tfs.core.clients.versioncontrol.WorkspaceOptions;
+import com.microsoft.tfs.core.clients.versioncontrol.exceptions.ServerPathFormatException;
+import com.microsoft.tfs.core.clients.versioncontrol.soapextensions.*;
+import com.microsoft.tfs.core.clients.versioncontrol.soapextensions.Workspace;
+import com.microsoft.tfs.core.clients.versioncontrol.specs.version.VersionSpec;
 import com.microsoft.tfs.util.Closable;
 
 /**
@@ -16,5 +22,65 @@ public class MockableVersionControlClient implements Closable {
 
     public void close() {
         vcc.close();
+    }
+
+    public Workspace createWorkspace(
+            final WorkingFolder[] workingFolders,
+            final String workspaceName,
+            final String owner,
+            final String ownerDisplayName,
+            final String comment,
+            final WorkspaceLocation location,
+            final WorkspaceOptions options) {
+        return vcc.createWorkspace(
+                workingFolders,
+                workspaceName,
+                owner,
+                ownerDisplayName,
+                comment,
+                location,
+                options
+        );
+    }
+
+    public void deleteWorkspace(final Workspace workspace) {
+        vcc.deleteWorkspace(workspace);
+    }
+
+    public Workspace getLocalWorkspace(final String workspaceName, final String workspaceOwner) {
+        return vcc.getLocalWorkspace(workspaceName, workspaceOwner);
+    }
+
+    public int getLatestChangesetID() {
+        return vcc.getLatestChangesetID();
+    }
+
+    public Changeset[] queryHistory(
+            final String serverOrLocalPath,
+            final VersionSpec version,
+            final int deletionID,
+            final RecursionType recursion,
+            final String user,
+            final VersionSpec versionFrom,
+            final VersionSpec versionTo,
+            final int maxCount,
+            final boolean includeFileDetails,
+            final boolean slotMode,
+            final boolean includeDownloadInfo,
+            final boolean sortAscending) throws ServerPathFormatException {
+        return vcc.queryHistory(
+                serverOrLocalPath,
+                version,
+                deletionID,
+                recursion,
+                user,
+                versionFrom,
+                versionTo,
+                maxCount,
+                includeFileDetails,
+                slotMode,
+                includeDownloadInfo,
+                sortAscending
+        );
     }
 }

--- a/src/main/java/hudson/plugins/tfs/model/MockableVersionControlClient.java
+++ b/src/main/java/hudson/plugins/tfs/model/MockableVersionControlClient.java
@@ -83,4 +83,8 @@ public class MockableVersionControlClient implements Closable {
                 sortAscending
         );
     }
+
+    public Workspace queryWorkspace(final String name, final String owner) {
+        return vcc.queryWorkspace(name, owner);
+    }
 }

--- a/src/main/java/hudson/plugins/tfs/model/Project.java
+++ b/src/main/java/hudson/plugins/tfs/model/Project.java
@@ -78,10 +78,9 @@ public class Project {
      * @return a list of change sets
      */
     private List<ChangeSet> getVCCHistory(VersionSpec fromVersion, VersionSpec toVersion, boolean includeFileDetails) {
-        final TFSTeamProjectCollection tpc = server.getTeamProjectCollection();
         final IIdentityManagementService ims = server.createIdentityManagementService();
         final UserLookup userLookup = new TfsUserLookup(ims);
-        final VersionControlClient vcc = tpc.getVersionControlClient();
+        final MockableVersionControlClient vcc = server.getVersionControlClient();
         try {
             final Changeset[] serverChangesets = vcc.queryHistory(
                     projectPath,

--- a/src/main/java/hudson/plugins/tfs/model/Project.java
+++ b/src/main/java/hudson/plugins/tfs/model/Project.java
@@ -30,8 +30,6 @@ import com.microsoft.tfs.core.clients.versioncontrol.specs.version.DateVersionSp
 import com.microsoft.tfs.core.clients.versioncontrol.specs.version.LabelVersionSpec;
 import com.microsoft.tfs.core.clients.versioncontrol.specs.version.VersionSpec;
 import com.microsoft.tfs.core.clients.webservices.IIdentityManagementService;
-import com.microsoft.tfs.core.clients.webservices.IdentityManagementException;
-import com.microsoft.tfs.core.clients.webservices.IdentityManagementService;
 
 public class Project {
 
@@ -81,12 +79,7 @@ public class Project {
      */
     private List<ChangeSet> getVCCHistory(VersionSpec fromVersion, VersionSpec toVersion, boolean includeFileDetails) {
         final TFSTeamProjectCollection tpc = server.getTeamProjectCollection();
-        IIdentityManagementService ims;
-        try {
-            ims = new IdentityManagementService(tpc);
-        } catch (IdentityManagementException e) {
-            ims = new LegacyIdentityManagementService();
-        }
+        final IIdentityManagementService ims = server.createIdentityManagementService();
         final UserLookup userLookup = new TfsUserLookup(ims);
         final VersionControlClient vcc = tpc.getVersionControlClient();
         try {

--- a/src/main/java/hudson/plugins/tfs/model/Project.java
+++ b/src/main/java/hudson/plugins/tfs/model/Project.java
@@ -19,8 +19,6 @@ import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
 
-import com.microsoft.tfs.core.TFSTeamProjectCollection;
-import com.microsoft.tfs.core.clients.versioncontrol.VersionControlClient;
 import com.microsoft.tfs.core.clients.versioncontrol.soapextensions.Change;
 import com.microsoft.tfs.core.clients.versioncontrol.soapextensions.Changeset;
 import com.microsoft.tfs.core.clients.versioncontrol.soapextensions.RecursionType;

--- a/src/main/java/hudson/plugins/tfs/model/Server.java
+++ b/src/main/java/hudson/plugins/tfs/model/Server.java
@@ -17,6 +17,7 @@ import java.security.CodeSource;
 import java.security.ProtectionDomain;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.Callable;
 
 import com.microsoft.tfs.core.TFSTeamProjectCollection;
 import com.microsoft.tfs.core.httpclient.Credentials;
@@ -120,6 +121,15 @@ public class Server implements ServerConfigurationProvider, Closable {
     
     public Reader execute(MaskedArgumentListBuilder arguments) throws IOException, InterruptedException {
         return tool.execute(arguments.toCommandArray(), arguments.toMaskArray());
+    }
+
+    public <T> T execute(final Callable<T> callable) {
+        try {
+            return callable.call();
+        } catch (final Exception e) {
+            // convert from checked to unchecked exception
+            throw new RuntimeException(e);
+        }
     }
 
     public String getUrl() {

--- a/src/main/java/hudson/plugins/tfs/model/Server.java
+++ b/src/main/java/hudson/plugins/tfs/model/Server.java
@@ -1,6 +1,9 @@
 package hudson.plugins.tfs.model;
 
 import com.microsoft.tfs.core.TFSConfigurationServer;
+import com.microsoft.tfs.core.clients.webservices.IIdentityManagementService;
+import com.microsoft.tfs.core.clients.webservices.IdentityManagementException;
+import com.microsoft.tfs.core.clients.webservices.IdentityManagementService;
 import hudson.model.TaskListener;
 import hudson.plugins.tfs.TfTool;
 import hudson.plugins.tfs.commands.ServerConfigurationProvider;
@@ -174,5 +177,15 @@ public class Server implements ServerConfigurationProvider, Closable {
             this.tpc.close();
         }
         
+    }
+
+    public IIdentityManagementService createIdentityManagementService() {
+        IIdentityManagementService ims;
+        try {
+            ims = new IdentityManagementService(tpc);
+        } catch (IdentityManagementException e) {
+            ims = new LegacyIdentityManagementService();
+        }
+        return ims;
     }
 }

--- a/src/main/java/hudson/plugins/tfs/model/Server.java
+++ b/src/main/java/hudson/plugins/tfs/model/Server.java
@@ -1,6 +1,7 @@
 package hudson.plugins.tfs.model;
 
 import com.microsoft.tfs.core.TFSConfigurationServer;
+import com.microsoft.tfs.core.clients.versioncontrol.VersionControlClient;
 import com.microsoft.tfs.core.clients.webservices.IIdentityManagementService;
 import com.microsoft.tfs.core.clients.webservices.IdentityManagementException;
 import com.microsoft.tfs.core.clients.webservices.IdentityManagementService;
@@ -40,6 +41,7 @@ public class Server implements ServerConfigurationProvider, Closable {
     private Map<String, Project> projects = new HashMap<String, Project>();
     private final TfTool tool;
     private final TFSTeamProjectCollection tpc;
+    private MockableVersionControlClient mockableVcc;
 
     public Server(TfTool tool, String url, String username, String password) {
         this.tool = tool;
@@ -121,7 +123,19 @@ public class Server implements ServerConfigurationProvider, Closable {
         }
         return workspaces;
     }
-    
+
+    public MockableVersionControlClient getVersionControlClient() {
+        if (mockableVcc == null) {
+            synchronized (this) {
+                if (mockableVcc == null) {
+                    final VersionControlClient vcc = tpc.getVersionControlClient();
+                    mockableVcc = new MockableVersionControlClient(vcc);
+                }
+            }
+        }
+        return mockableVcc;
+    }
+
     public Reader execute(MaskedArgumentListBuilder arguments) throws IOException, InterruptedException {
         return tool.execute(arguments.toCommandArray(), arguments.toMaskArray());
     }

--- a/src/main/java/hudson/plugins/tfs/model/Server.java
+++ b/src/main/java/hudson/plugins/tfs/model/Server.java
@@ -1,6 +1,7 @@
 package hudson.plugins.tfs.model;
 
 import com.microsoft.tfs.core.TFSConfigurationServer;
+import hudson.model.TaskListener;
 import hudson.plugins.tfs.TfTool;
 import hudson.plugins.tfs.commands.ServerConfigurationProvider;
 import hudson.plugins.tfs.util.MaskedArgumentListBuilder;
@@ -135,6 +136,11 @@ public class Server implements ServerConfigurationProvider, Closable {
 
     public String getLocalHostname() throws IOException, InterruptedException {
         return tool.getHostname();
+    }
+
+    public TaskListener getListener() {
+        // TODO: rip out TfTool and accept the TaskListener in our constructor
+        return tool.getListener();
     }
 
     public synchronized void close() {

--- a/src/main/java/hudson/plugins/tfs/model/Server.java
+++ b/src/main/java/hudson/plugins/tfs/model/Server.java
@@ -111,12 +111,7 @@ public class Server implements ServerConfigurationProvider, Closable {
         }
         return projects.get(projectPath);
     }
-    
-    public TFSTeamProjectCollection getTeamProjectCollection()
-    {
-        return this.tpc;
-    }
-    
+
     public Workspaces getWorkspaces() {
         if (workspaces == null) {
             workspaces = new Workspaces(this);

--- a/src/test/java/hudson/plugins/tfs/EndToEndTfs.java
+++ b/src/test/java/hudson/plugins/tfs/EndToEndTfs.java
@@ -12,6 +12,7 @@ import com.microsoft.tfs.core.clients.versioncontrol.soapextensions.PendingSet;
 import com.microsoft.tfs.core.clients.versioncontrol.soapextensions.RecursionType;
 import com.microsoft.tfs.core.clients.versioncontrol.soapextensions.WorkingFolder;
 import com.microsoft.tfs.core.clients.versioncontrol.soapextensions.Workspace;
+import hudson.plugins.tfs.model.MockableVersionControlClient;
 import hudson.plugins.tfs.model.Server;
 import hudson.plugins.tfs.util.XmlHelper;
 import org.apache.commons.io.FileUtils;
@@ -104,8 +105,7 @@ public @interface EndToEndTfs {
             // TODO: Consider NOT using the Server class
             server = new Server(new TfTool(null, null, null, null), serverUrl, AbstractIntegrationTest.TestUserName, AbstractIntegrationTest.TestUserPassword);
 
-            final TFSTeamProjectCollection tpc = server.getTeamProjectCollection();
-            final VersionControlClient vcc = tpc.getVersionControlClient();
+            final MockableVersionControlClient vcc = server.getVersionControlClient();
 
             // workspaceName MUST be unique across computers hitting the same server
             workspaceName = hostName + "-" + testCaseName;
@@ -204,7 +204,7 @@ public @interface EndToEndTfs {
             return result;
         }
 
-        static Workspace createWorkspace(final VersionControlClient vcc, final String workspaceName) {
+        static Workspace createWorkspace(final MockableVersionControlClient vcc, final String workspaceName) {
             deleteWorkspace(vcc, workspaceName);
 
             final Workspace workspace = vcc.createWorkspace(
@@ -218,7 +218,7 @@ public @interface EndToEndTfs {
             return workspace;
         }
 
-        static void deleteWorkspace(final VersionControlClient vcc, final String workspaceName) {
+        static void deleteWorkspace(final MockableVersionControlClient vcc, final String workspaceName) {
             final Workspace workspace = vcc.getLocalWorkspace(workspaceName, ".");
             if (workspace != null) {
                 for (WorkingFolder workingFolder : workspace.getFolders()) {
@@ -244,8 +244,7 @@ public @interface EndToEndTfs {
             if (runner != null) {
                 runner.tearDown(jenkinsRule, recipe);
             }
-            final TFSTeamProjectCollection tpc = server.getTeamProjectCollection();
-            final VersionControlClient vcc = tpc.getVersionControlClient();
+            final MockableVersionControlClient vcc = server.getVersionControlClient();
             deleteWorkspace(vcc, workspaceName);
             if (server != null) {
                 server.close();

--- a/src/test/java/hudson/plugins/tfs/EndToEndTfs.java
+++ b/src/test/java/hudson/plugins/tfs/EndToEndTfs.java
@@ -1,9 +1,7 @@
 package hudson.plugins.tfs;
 
-import com.microsoft.tfs.core.TFSTeamProjectCollection;
 import com.microsoft.tfs.core.clients.versioncontrol.GetOptions;
 import com.microsoft.tfs.core.clients.versioncontrol.PendChangesOptions;
-import com.microsoft.tfs.core.clients.versioncontrol.VersionControlClient;
 import com.microsoft.tfs.core.clients.versioncontrol.WorkspaceLocation;
 import com.microsoft.tfs.core.clients.versioncontrol.WorkspaceOptions;
 import com.microsoft.tfs.core.clients.versioncontrol.soapextensions.LockLevel;

--- a/src/test/java/hudson/plugins/tfs/FunctionalTest.java
+++ b/src/test/java/hudson/plugins/tfs/FunctionalTest.java
@@ -12,6 +12,7 @@ import hudson.model.Project;
 import hudson.model.Queue;
 import hudson.model.Result;
 import hudson.model.TaskListener;
+import hudson.plugins.tfs.model.MockableVersionControlClient;
 import hudson.plugins.tfs.model.Server;
 import hudson.plugins.tfs.util.XmlHelper;
 import hudson.scm.ChangeLogSet;
@@ -126,8 +127,7 @@ public class FunctionalTest {
         final EndToEndTfs.RunnerImpl tfsRunner = j.getTfsRunner();
         final Workspace workspace = tfsRunner.getWorkspace();
         final Server server = tfsRunner.getServer();
-        final TFSTeamProjectCollection tpc = server.getTeamProjectCollection();
-        final VersionControlClient vcc = tpc.getVersionControlClient();
+        final MockableVersionControlClient vcc = server.getVersionControlClient();
         final List<Project> projects = jenkins.getProjects();
         final Project project = projects.get(0);
         int latestChangesetID;
@@ -279,8 +279,7 @@ public class FunctionalTest {
             final String projectPath = parent.getPathInTfvc();
             final String serverUrl = parent.getServerUrl();
             final Server server = parent.getServer();
-            final TFSTeamProjectCollection tpc = server.getTeamProjectCollection();
-            final VersionControlClient vcc = tpc.getVersionControlClient();
+            final MockableVersionControlClient vcc = server.getVersionControlClient();
             final int latestChangesetID = vcc.getLatestChangesetID();
             final String changesetVersion = String.valueOf(latestChangesetID);
 

--- a/src/test/java/hudson/plugins/tfs/FunctionalTest.java
+++ b/src/test/java/hudson/plugins/tfs/FunctionalTest.java
@@ -1,9 +1,7 @@
 package hudson.plugins.tfs;
 
-import com.microsoft.tfs.core.TFSTeamProjectCollection;
 import com.microsoft.tfs.core.clients.versioncontrol.GetOptions;
 import com.microsoft.tfs.core.clients.versioncontrol.PendChangesOptions;
-import com.microsoft.tfs.core.clients.versioncontrol.VersionControlClient;
 import com.microsoft.tfs.core.clients.versioncontrol.soapextensions.LockLevel;
 import com.microsoft.tfs.core.clients.versioncontrol.soapextensions.Workspace;
 import hudson.model.AbstractBuild;

--- a/src/test/java/hudson/plugins/tfs/commands/AbstractCallableCommandTest.java
+++ b/src/test/java/hudson/plugins/tfs/commands/AbstractCallableCommandTest.java
@@ -1,0 +1,59 @@
+package hudson.plugins.tfs.commands;
+
+import hudson.model.TaskListener;
+import hudson.plugins.tfs.model.MockableVersionControlClient;
+import hudson.plugins.tfs.model.Server;
+import org.apache.commons.collections.IteratorUtils;
+import org.junit.Assert;
+import org.junit.Before;
+
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.PrintStream;
+import java.util.Iterator;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public abstract class AbstractCallableCommandTest {
+
+    protected Server server;
+    protected MockableVersionControlClient vcc;
+    protected TaskListener listener;
+    protected ByteArrayOutputStream outputStream;
+
+    @Before
+    public void configureDefaultMocks() {
+        server = mock(Server.class);
+        vcc = mock(MockableVersionControlClient.class);
+        listener = mock(TaskListener.class);
+        outputStream = new ByteArrayOutputStream();
+
+        when(server.getVersionControlClient()).thenReturn(vcc);
+        when(server.getListener()).thenReturn(listener);
+        when(listener.getLogger()).thenReturn(new PrintStream(outputStream));
+    }
+
+    protected void assertLog(final String... expectedLines) throws IOException {
+        final byte[] outputBytes = outputStream.toByteArray();
+        final ByteArrayInputStream inputStream = new ByteArrayInputStream(outputBytes);
+        final InputStreamReader inputStreamReader = new InputStreamReader(inputStream);
+        final BufferedReader bufferedReader = new BufferedReader(inputStreamReader);
+        final Iterator<String> expectedIterator = IteratorUtils.arrayIterator(expectedLines);
+
+        String line;
+        int lineCounter = 1;
+        while ((line = bufferedReader.readLine()) != null) {
+            if (expectedIterator.hasNext()) {
+                final String expected = expectedIterator.next();
+                Assert.assertEquals("Lines differ at line #" + lineCounter + ".", expected, line);
+            } else {
+                Assert.fail("Log contained more lines than expected.");
+            }
+        }
+        Assert.assertFalse("Log contained less lines than expected.", expectedIterator.hasNext());
+    }
+}

--- a/src/test/java/hudson/plugins/tfs/model/ServerIntegrationTest.java
+++ b/src/test/java/hudson/plugins/tfs/model/ServerIntegrationTest.java
@@ -20,8 +20,7 @@ public class ServerIntegrationTest {
     public void canFindTfsSdkNativeLibraries() {
         final Server server = new Server(null, "http://tfs.invalid:8080/tfs", "username", "password");
         try {
-            final TFSTeamProjectCollection tpc = server.getTeamProjectCollection();
-            tpc.getVersionControlClient();
+            server.getVersionControlClient();
         } finally {
             server.close();
         }


### PR DESCRIPTION
In preparation of replacing the use of tf[.cmd|.exe] with the TFS SDK for Java, these abstractions will allow us to keep many of the existing tests, with minor modifications.

These changes were made while prototyping the transition for `DeleteWorkspaceCommand` and `NewWorkspaceCommand`.