### PR TITLE
Fix multi configuration job

### DIFF
--- a/src/main/java/hudson/plugins/tfs/TFSLabeler.java
+++ b/src/main/java/hudson/plugins/tfs/TFSLabeler.java
@@ -80,6 +80,8 @@ public class TFSLabeler extends Notifier {
 
             Computer computer = Computer.currentComputer();
             String normalizedLabelName = computeDynamicValue(build, getLabelName());
+            normalizedLabelName = normalizedLabelName.replaceAll("[\"/:<>\\|\\*\\?]+", "_");
+            normalizedLabelName = normalizedLabelName.replaceAll("[\\.\\s]+$", "_");
             String tfsWorkspace = tfsScm.getWorkspaceName(build, computer);
 
             try {
@@ -102,18 +104,8 @@ public class TFSLabeler extends Notifier {
      */
     private String computeDynamicValue(AbstractBuild build, String parameterizedValue)
             throws IllegalStateException, InterruptedException, IOException {
-
-        final EnvVars envVars = build.getEnvironment(TaskListener.NULL);
-        final VariableResolver<String> environmentVariables = new VariableResolver<String>() {
-            public String resolve(String name) {
-                return envVars.get(name);
-            }
-
-        };
-        final BuildVariableResolver buildVariables = new BuildVariableResolver(build.getProject());
-        @SuppressWarnings("unchecked")
-        final Union<String> bothVariables = new VariableResolver.Union<String>(buildVariables, environmentVariables);
-        String value = Util.replaceMacro(parameterizedValue, bothVariables);
+        Computer computer = Computer.currentComputer();
+        String value = Util.replaceMacro(parameterizedValue, new BuildVariableResolver(build, computer));
 
         logger.fine("oldValue = " + parameterizedValue + "; newValue = " + value);
         return value;

--- a/src/test/java/hudson/plugins/tfs/TeamFoundationServerScmTest.java
+++ b/src/test/java/hudson/plugins/tfs/TeamFoundationServerScmTest.java
@@ -102,18 +102,7 @@ public class TeamFoundationServerScmTest {
             }
         }
     }
-
-    @Test
-    public void assertWorkspaceNameReplacesJobName() {
-        AbstractBuild build = mock(AbstractBuild.class);
-        AbstractProject project = mock(AbstractProject.class);
-        when(build.getProject()).thenReturn(project);
-        when(project.getName()).thenReturn("ThisIsAJob");
-
-        TeamFoundationServerScm scm = new TeamFoundationServerScm(null, null, ".", false, "erik_${JOB_NAME}");
-        assertEquals("Workspace name was incorrect", "erik_ThisIsAJob", scm.getWorkspaceName(build, mock(Computer.class)));
-    }
-    
+   
     @Test 
     public void assertDoUsernameCheckRegexWorks() {
         assertFalse(TeamFoundationServerScm.DescriptorImpl.DOMAIN_SLASH_USER_REGEX.matcher("redsolo").matches());
@@ -334,7 +323,7 @@ public class TeamFoundationServerScmTest {
         when(build.getAction(ParametersAction.class)).thenReturn(action);
 
         TeamFoundationServerScm scm = new TeamFoundationServerScm(null, "$/$PARAM/path", ".", false, "");
-        assertEquals("The project path wasnt resolved", "$/RESOLVED/path", scm.getProjectPath(build));
+        assertEquals("The project path wasnt resolved", "$/RESOLVED/path", scm.getProjectPath(build, mock(Computer.class)));
     }    
     
     @Test public void assertWorkspaceNameResolvesBuildVariables() {

--- a/src/test/java/hudson/plugins/tfs/util/BuildVariableResolverTest.java
+++ b/src/test/java/hudson/plugins/tfs/util/BuildVariableResolverTest.java
@@ -36,23 +36,7 @@ public class BuildVariableResolverTest {
         verifyZeroInteractions(project);
         verifyZeroInteractions(computer);
     }
-    
-    @Test public void assertJobNameIsResolved() {
-        when(project.getName()).thenReturn("ThisIsAJob");
-
-        BuildVariableResolver resolver = new BuildVariableResolver(project, computer);
-        assertEquals("Variable resolution was incorrect", "ThisIsAJob", resolver.resolve("JOB_NAME"));
-        verifyZeroInteractions(computer);
-    }
-    
-    @Test public void assertJobNameWithoutComputerIsResolved() {
-        when(project.getName()).thenReturn("ThisIsAJob");
-
-        BuildVariableResolver resolver = new BuildVariableResolver(project);
-        assertEquals("Variable resolution was incorrect", "ThisIsAJob", resolver.resolve("JOB_NAME"));
-        assertNull("Variable resolution was performed", resolver.resolve("NONE_EXISTING_KEY"));
-    }
-    
+   
     @Test public void assertComputerEnvVarIsResolved() throws Exception {
         EnvVars map = new EnvVars();
         map.put("ENV_VAR", "This is an env var");
@@ -74,32 +58,7 @@ public class BuildVariableResolverTest {
         assertEquals("Variable resolution was incorrect", "Other_user", resolver.resolve("USER_NAME"));
         verifyZeroInteractions(project);
     }
-    
-    @Test public void assertNodeNameIsResolved() {
-        when(computer.getName()).thenReturn("AKIRA");
-        
-        BuildVariableResolver resolver = new BuildVariableResolver(project, computer);
-        assertEquals("Variable resolution was incorrect", "AKIRA", resolver.resolve("NODE_NAME"));
-        verifyZeroInteractions(project);
-    }
-    
-    /**
-     * Asserts that NODE_NAME works on the master computer, as the MasterComputer.getName() returns null.
-     */
-    @Test public void assertMasterNodeNameIsResolved() {
-        when(computer.getName()).thenReturn("");
-        
-        BuildVariableResolver resolver = new BuildVariableResolver(project, computer);
-        assertEquals("Variable resolution was incorrect", "MASTER", resolver.resolve("NODE_NAME"));
-        verifyZeroInteractions(project);
-    }
-    
-    @Test public void assertNoComputeraDoesNotThrowNPEWhenResolvingNodeName() {
-        BuildVariableResolver resolver = new BuildVariableResolver(project);
-        assertNull("Variable resolution was incorrect", resolver.resolve("NODE_NAME"));
-        verifyZeroInteractions(project);
-    }
-    
+   
     @Test public void assertBuildEnvVarIsResolved() throws Exception {
         EnvVars map = new EnvVars();
         map.put("BUILD_ID", "121212");


### PR DESCRIPTION

This PR lays the groundwork to get a "Multi configuration Job" working.
Two problems. Workspaces with the same name on all builds, and workspace mapping that overlaps.

Use ${JOB_NAME} provided by the build environment to get a unique named workspace name. A Multi Configuration Job combines the job name with axis value. Example: Job name "MatrixJob" and one user defined axis with name "Axis" and values "value1", "value2". The ${JOB_NAME} will be "MatrixJob" for the flyweight, "MatrixJob/Axis=value1" for one axis build and "MatrixJob/Axis=value2" for the other.
While at it I removed ${NODE_LABEL} as well because its also provided by the build environment.

The overlapping workspaces is a different problem. One that we cannot fix, but it can be worked around.
With this PR the following mappings will be created.

> Flyweight
workspace: Hudson-MatrixJob-master
local: d:\GitHub\tfs-plugin\work\workspace\MatrixJob
Axis1
workspace: Hudson-MatrixJob_Axis=value1-master
local: d:\GitHub\tfs-plugin\work\workspace\MatrixJob\Axis\value1

tf will complain that for the axis build `The path d:\GitHub\tfs-plugin\work\workspace\MatrixJob is already mapped in workspace Hudson-MatrixJob-master.`
The workaround is to specify a `Local workfolder`, e.g. "matrix".

> Flyweight
workspace: Hudson-MatrixJob-master
local: d:\GitHub\tfs-plugin\work\workspace\MatrixJob\matrix
Axis1
workspace: Hudson-MatrixJob_Axis=value1-master
local: d:\GitHub\tfs-plugin\work\workspace\MatrixJob\Axis\value1\matrix

The axis build is no longer mapped directly in the flyweight workspace and tf is happy.