### PR TITLE
Checkout and history now go by the changeset number

### DIFF
--- a/src/main/java/hudson/plugins/tfs/TeamFoundationServerScm.java
+++ b/src/main/java/hudson/plugins/tfs/TeamFoundationServerScm.java
@@ -216,7 +216,7 @@ public class TeamFoundationServerScm extends SCM {
                 list = action.checkoutBySingleVersionSpec(server, workspaceFilePath, singleVersionSpec);
             }
             else {
-                final VersionSpec previousBuildVersionSpec = determineVersionSpecFromBuild(previousBuild, 1);
+                final VersionSpec previousBuildVersionSpec = determineVersionSpecFromBuild(previousBuild, 1, changeSet);
                 final ChangesetVersionSpec currentBuildVersionSpec = new ChangesetVersionSpec(changeSet);
                 list = action.checkout(server, workspaceFilePath, previousBuildVersionSpec, currentBuildVersionSpec);
             }
@@ -228,13 +228,17 @@ public class TeamFoundationServerScm extends SCM {
         return true;
     }
 
-    static VersionSpec determineVersionSpecFromBuild(final AbstractBuild<?, ?> build, final int offset) {
+    static VersionSpec determineVersionSpecFromBuild(final AbstractBuild<?, ?> build, final int offset, final int maximumChangeSetNumber) {
         final VersionSpec result;
         if (build != null) {
             final TFSRevisionState revisionState = build.getAction(TFSRevisionState.class);
             if (revisionState != null) {
                 final int changeSetNumber = revisionState.changesetVersion + offset;
-                result = new ChangesetVersionSpec(changeSetNumber);
+                if (changeSetNumber <= maximumChangeSetNumber) {
+                    result = new ChangesetVersionSpec(changeSetNumber);
+                } else {
+                    result = null;
+                }
             } else {
                 result = null;
             }

--- a/src/main/java/hudson/plugins/tfs/TeamFoundationServerScm.java
+++ b/src/main/java/hudson/plugins/tfs/TeamFoundationServerScm.java
@@ -12,6 +12,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
 
+import com.microsoft.tfs.core.clients.versioncontrol.specs.version.ChangesetVersionSpec;
 import com.microsoft.tfs.core.clients.versioncontrol.specs.version.DateVersionSpec;
 import com.microsoft.tfs.core.clients.versioncontrol.specs.version.VersionSpec;
 import hudson.util.Secret;
@@ -207,30 +208,44 @@ public class TeamFoundationServerScm extends SCM {
             String singleVersionSpec = buildVariableResolver.resolve(VERSION_SPEC);
             final String projectPath = workspaceConfiguration.getProjectPath();
             final Project project = server.getProject(projectPath);
-            recordWorkspaceChangesetVersion(build, listener, project, projectPath, singleVersionSpec);
+            final int changeSet = recordWorkspaceChangesetVersion(build, listener, project, projectPath, singleVersionSpec);
 
             CheckoutAction action = new CheckoutAction(workspaceConfiguration.getWorkspaceName(), workspaceConfiguration.getProjectPath(), workspaceConfiguration.getWorkfolder(), isUseUpdate());
-            try {
-                List<ChangeSet> list;
-                if (StringUtils.isNotEmpty(singleVersionSpec)) {
-                    list = action.checkoutBySingleVersionSpec(server, workspaceFilePath, singleVersionSpec);
-                }
-                else {
-                    list = action.checkout(server, workspaceFilePath, (previousBuild != null ? previousBuild.getTimestamp() : null), build.getTimestamp());
-                }
-                ChangeSetWriter writer = new ChangeSetWriter();
-                writer.write(list, changelogFile);
-            } catch (ParseException pe) {
-                listener.fatalError(pe.getMessage());
-                throw new AbortException();
+            List<ChangeSet> list;
+            if (StringUtils.isNotEmpty(singleVersionSpec)) {
+                list = action.checkoutBySingleVersionSpec(server, workspaceFilePath, singleVersionSpec);
             }
+            else {
+                final VersionSpec previousBuildVersionSpec = determineVersionSpecFromBuild(previousBuild, 1);
+                final ChangesetVersionSpec currentBuildVersionSpec = new ChangesetVersionSpec(changeSet);
+                list = action.checkout(server, workspaceFilePath, previousBuildVersionSpec, currentBuildVersionSpec);
+            }
+            ChangeSetWriter writer = new ChangeSetWriter();
+            writer.write(list, changelogFile);
         } finally {
             server.close();
         }
         return true;
     }
 
-    void recordWorkspaceChangesetVersion(final AbstractBuild<?, ?> build, final BuildListener listener, final Project project, final String projectPath, final String singleVersionSpec) throws IOException, InterruptedException {
+    static VersionSpec determineVersionSpecFromBuild(final AbstractBuild<?, ?> build, final int offset) {
+        final VersionSpec result;
+        if (build != null) {
+            final TFSRevisionState revisionState = build.getAction(TFSRevisionState.class);
+            if (revisionState != null) {
+                final int changeSetNumber = revisionState.changesetVersion + offset;
+                result = new ChangesetVersionSpec(changeSetNumber);
+            } else {
+                result = null;
+            }
+        }
+        else {
+            result = null;
+        }
+        return result;
+    }
+
+    int recordWorkspaceChangesetVersion(final AbstractBuild<?, ?> build, final BuildListener listener, final Project project, final String projectPath, final String singleVersionSpec) throws IOException, InterruptedException {
         final VersionSpec workspaceVersion;
         if (!StringUtils.isEmpty(singleVersionSpec)) {
             workspaceVersion = VersionSpec.parseSingleVersionFromSpec(singleVersionSpec, null);
@@ -246,6 +261,8 @@ public class TeamFoundationServerScm extends SCM {
 
             // by adding this action, we prevent calcRevisionsFromBuild() from being called
             build.addAction(new TFSRevisionState(buildChangeset, projectPath));
+
+            return buildChangeset;
         } catch (ParseException pe) {
             listener.fatalError(pe.getMessage());
             throw new AbortException();

--- a/src/main/java/hudson/plugins/tfs/TeamFoundationServerScm.java
+++ b/src/main/java/hudson/plugins/tfs/TeamFoundationServerScm.java
@@ -188,9 +188,10 @@ public class TeamFoundationServerScm extends SCM {
         try {
             WorkspaceConfiguration workspaceConfiguration = new WorkspaceConfiguration(server.getUrl(), getWorkspaceName(build, Computer.currentComputer()), getProjectPath(build), getLocalPath());
             
+            final AbstractBuild<?, ?> previousBuild = build.getPreviousBuild();
             // Check if the configuration has changed
-            if (build.getPreviousBuild() != null) {
-                BuildWorkspaceConfiguration nodeConfiguration = new BuildWorkspaceConfigurationRetriever().getLatestForNode(build.getBuiltOn(), build.getPreviousBuild());
+            if (previousBuild != null) {
+                BuildWorkspaceConfiguration nodeConfiguration = new BuildWorkspaceConfigurationRetriever().getLatestForNode(build.getBuiltOn(), previousBuild);
                 if ((nodeConfiguration != null) &&
                         nodeConfiguration.workspaceExists() 
                         && (! workspaceConfiguration.equals(nodeConfiguration))) {
@@ -215,7 +216,7 @@ public class TeamFoundationServerScm extends SCM {
                     list = action.checkoutBySingleVersionSpec(server, workspaceFilePath, singleVersionSpec);
                 }
                 else {
-                    list = action.checkout(server, workspaceFilePath, (build.getPreviousBuild() != null ? build.getPreviousBuild().getTimestamp() : null), build.getTimestamp());
+                    list = action.checkout(server, workspaceFilePath, (previousBuild != null ? previousBuild.getTimestamp() : null), build.getTimestamp());
                 }
                 ChangeSetWriter writer = new ChangeSetWriter();
                 writer.write(list, changelogFile);

--- a/src/main/java/hudson/plugins/tfs/commands/RemoteChangesetVersionCommand.java
+++ b/src/main/java/hudson/plugins/tfs/commands/RemoteChangesetVersionCommand.java
@@ -56,14 +56,14 @@ public class RemoteChangesetVersionCommand extends AbstractChangesetVersionComma
         return toString(adjustedVersionSpec);
     }
 
-    public static String toString(final VersionSpec adjustedVersionSpec) {
-        // TODO: just call adjustedVersionSpec.toString() once DateVersionSpec.toString() uses ISO 8601 format
-        if (adjustedVersionSpec instanceof DateVersionSpec){
-            final DateVersionSpec dateVersionSpec = (DateVersionSpec) adjustedVersionSpec;
+    public static String toString(final VersionSpec versionSpec) {
+        // TODO: just call versionSpec.toString() once DateVersionSpec.toString() uses ISO 8601 format
+        if (versionSpec instanceof DateVersionSpec){
+            final DateVersionSpec dateVersionSpec = (DateVersionSpec) versionSpec;
             return DateUtil.toString(dateVersionSpec);
         }
-        else if (adjustedVersionSpec instanceof LabelVersionSpec) {
-            final LabelVersionSpec labelVersionSpec = (LabelVersionSpec) adjustedVersionSpec;
+        else if (versionSpec instanceof LabelVersionSpec) {
+            final LabelVersionSpec labelVersionSpec = (LabelVersionSpec) versionSpec;
             // TODO: It seems to me LabelVersionSpec.toString() should emit "Lfoo" when its scope is null
             final String label = labelVersionSpec.getLabel();
             final String scope = labelVersionSpec.getScope();
@@ -76,6 +76,6 @@ public class RemoteChangesetVersionCommand extends AbstractChangesetVersionComma
             }
             return sb.toString();
         }
-        return adjustedVersionSpec.toString();
+        return versionSpec.toString();
     }
 }

--- a/src/main/java/hudson/plugins/tfs/commands/RemoteChangesetVersionCommand.java
+++ b/src/main/java/hudson/plugins/tfs/commands/RemoteChangesetVersionCommand.java
@@ -33,8 +33,7 @@ public class RemoteChangesetVersionCommand extends AbstractChangesetVersionComma
         return arguments;
     }
     
-    @Override
-    String getVersionSpecification() {
+    static VersionSpec adjustVersionSpec(final VersionSpec versionSpec) {
         final VersionSpec adjustedVersionSpec;
         if (versionSpec instanceof DateVersionSpec) {
             // The to timestamp is exclusive, ie it will only show history before the to timestamp.
@@ -48,6 +47,12 @@ public class RemoteChangesetVersionCommand extends AbstractChangesetVersionComma
         else {
             adjustedVersionSpec = versionSpec;
         }
+        return adjustedVersionSpec;
+    }
+
+    @Override
+    String getVersionSpecification() {
+        final VersionSpec adjustedVersionSpec = adjustVersionSpec(versionSpec);
         // TODO: just call adjustedVersionSpec.toString() once DateVersionSpec.toString() uses ISO 8601 format
         if (adjustedVersionSpec instanceof DateVersionSpec){
             final DateVersionSpec dateVersionSpec = (DateVersionSpec) adjustedVersionSpec;

--- a/src/main/java/hudson/plugins/tfs/commands/RemoteChangesetVersionCommand.java
+++ b/src/main/java/hudson/plugins/tfs/commands/RemoteChangesetVersionCommand.java
@@ -32,7 +32,7 @@ public class RemoteChangesetVersionCommand extends AbstractChangesetVersionComma
         addServerArgument(arguments);
         return arguments;
     }
-    
+
     static VersionSpec adjustVersionSpec(final VersionSpec versionSpec) {
         final VersionSpec adjustedVersionSpec;
         if (versionSpec instanceof DateVersionSpec) {
@@ -53,6 +53,10 @@ public class RemoteChangesetVersionCommand extends AbstractChangesetVersionComma
     @Override
     String getVersionSpecification() {
         final VersionSpec adjustedVersionSpec = adjustVersionSpec(versionSpec);
+        return toString(adjustedVersionSpec);
+    }
+
+    public static String toString(final VersionSpec adjustedVersionSpec) {
         // TODO: just call adjustedVersionSpec.toString() once DateVersionSpec.toString() uses ISO 8601 format
         if (adjustedVersionSpec instanceof DateVersionSpec){
             final DateVersionSpec dateVersionSpec = (DateVersionSpec) adjustedVersionSpec;

--- a/src/main/java/hudson/plugins/tfs/model/Project.java
+++ b/src/main/java/hudson/plugins/tfs/model/Project.java
@@ -75,7 +75,7 @@ public class Project {
      * @param includeFileDetails whether or not to include details of modified items
      * @return a list of change sets
      */
-    private List<ChangeSet> getVCCHistory(VersionSpec fromVersion, VersionSpec toVersion, boolean includeFileDetails) {
+    public List<ChangeSet> getVCCHistory(VersionSpec fromVersion, VersionSpec toVersion, boolean includeFileDetails) {
         final IIdentityManagementService ims = server.createIdentityManagementService();
         final UserLookup userLookup = new TfsUserLookup(ims);
         final MockableVersionControlClient vcc = server.getVersionControlClient();

--- a/src/test/java/hudson/plugins/tfs/FunctionalTest.java
+++ b/src/test/java/hudson/plugins/tfs/FunctionalTest.java
@@ -93,6 +93,12 @@ public class FunctionalTest {
         final SCMTrigger.Runner runner = scmTrigger.new Runner();
         runner.run();
 
+        final AbstractBuild build = waitForQueuedBuild(project);
+        return build;
+    }
+
+    static AbstractBuild waitForQueuedBuild(final Project project)
+            throws InterruptedException, ExecutionException {
         final Jenkins jenkins = (Jenkins) project.getParent();
         final Queue queue = jenkins.getQueue();
         final Queue.Item[] items = queue.getItems();

--- a/src/test/java/hudson/plugins/tfs/FunctionalTest.java
+++ b/src/test/java/hudson/plugins/tfs/FunctionalTest.java
@@ -4,6 +4,7 @@ import com.microsoft.tfs.core.clients.versioncontrol.GetOptions;
 import com.microsoft.tfs.core.clients.versioncontrol.PendChangesOptions;
 import com.microsoft.tfs.core.clients.versioncontrol.soapextensions.LockLevel;
 import com.microsoft.tfs.core.clients.versioncontrol.soapextensions.Workspace;
+import hudson.FilePath;
 import hudson.model.AbstractBuild;
 import hudson.model.Cause;
 import hudson.model.Project;
@@ -177,6 +178,11 @@ public class FunctionalTest {
         Assert.assertEquals(1, secondCauses.size());
         final Cause secondCause = secondCauses.get(0);
         Assert.assertTrue(secondCause instanceof SCMTrigger.SCMTriggerCause);
+        final FilePath jenkinsWorkspace = secondBuild.getWorkspace();
+        final FilePath[] workspaceFiles = jenkinsWorkspace.list("*.*", "$tf");
+        Assert.assertEquals(1, workspaceFiles.length);
+        final FilePath workspaceFile = workspaceFiles[0];
+        Assert.assertEquals("TODO.txt", workspaceFile.getName());
     }
 
     /**

--- a/src/test/java/hudson/plugins/tfs/FunctionalTest.java
+++ b/src/test/java/hudson/plugins/tfs/FunctionalTest.java
@@ -81,9 +81,6 @@ public class FunctionalTest {
      */
     public static AbstractBuild runScmPollTrigger(final Project project)
             throws InterruptedException, ExecutionException {
-        final Jenkins jenkins = (Jenkins) project.getParent();
-        final Queue queue = jenkins.getQueue();
-
         final SCMTrigger scmTrigger = (SCMTrigger) project.getTrigger(SCMTrigger.class);
         // This is a roundabout way of calling SCMTrigger#run(),
         // because if we set SCMTrigger#synchronousPolling to true
@@ -96,6 +93,8 @@ public class FunctionalTest {
         final SCMTrigger.Runner runner = scmTrigger.new Runner();
         runner.run();
 
+        final Jenkins jenkins = (Jenkins) project.getParent();
+        final Queue queue = jenkins.getQueue();
         final Queue.Item[] items = queue.getItems();
         final boolean buildQueued = items.length == 1;
         final AbstractBuild build;

--- a/src/test/java/hudson/plugins/tfs/FunctionalTest.java
+++ b/src/test/java/hudson/plugins/tfs/FunctionalTest.java
@@ -188,6 +188,27 @@ public class FunctionalTest {
         Assert.assertEquals(1, workspaceFiles.length);
         final FilePath workspaceFile = workspaceFiles[0];
         Assert.assertEquals("TODO.txt", workspaceFile.getName());
+
+        // force a build via a manual trigger
+        final Cause.UserIdCause cause = new Cause.UserIdCause();
+        project.scheduleBuild(cause);
+        final AbstractBuild thirdBuild = waitForQueuedBuild(project);
+
+        Assert.assertNotNull(thirdBuild);
+        Assert.assertEquals(Result.SUCCESS, thirdBuild.getResult());
+        final ChangeLogSet thirdChangeSet = thirdBuild.getChangeSet();
+        Assert.assertEquals(0, thirdChangeSet.getItems().length);
+        final TFSRevisionState thirdRevisionState = thirdBuild.getAction(TFSRevisionState.class);
+        Assert.assertEquals(latestChangesetID, thirdRevisionState.changesetVersion);
+        final List<Cause> thirdCauses = thirdBuild.getCauses();
+        Assert.assertEquals(1, thirdCauses.size());
+        final Cause thirdCause = thirdCauses.get(0);
+        Assert.assertTrue(thirdCause instanceof Cause.UserIdCause);
+        final FilePath thirdBuildWorkspace = thirdBuild.getWorkspace();
+        final FilePath[] thirdBuildWorkspaceFiles = thirdBuildWorkspace.list("*.*", "$tf");
+        Assert.assertEquals(1, thirdBuildWorkspaceFiles.length);
+        final FilePath thirdBuildWorkspaceFile = thirdBuildWorkspaceFiles[0];
+        Assert.assertEquals("TODO.txt", thirdBuildWorkspaceFile.getName());
     }
 
     /**

--- a/src/test/java/hudson/plugins/tfs/TeamFoundationServerScmTest.java
+++ b/src/test/java/hudson/plugins/tfs/TeamFoundationServerScmTest.java
@@ -30,6 +30,7 @@ import hudson.util.Secret;
 import hudson.util.SecretOverride;
 import hudson.util.XStream2;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Test;
 
 
@@ -267,8 +268,9 @@ public class TeamFoundationServerScmTest {
         final String projectPath = "projectPath";
         final String singleVersionSpec = null;
 
-        scm.recordWorkspaceChangesetVersion(build, listener, project, projectPath, singleVersionSpec);
+        final int actual = scm.recordWorkspaceChangesetVersion(build, listener, project, projectPath, singleVersionSpec);
 
+        Assert.assertEquals(42, actual);
         final Map<String, String> env = new HashMap<String, String>();
         scm.buildEnvVars(build, env);
         assertEquals("42", env.get(TeamFoundationServerScm.WORKSPACE_CHANGESET_ENV_STR));
@@ -283,8 +285,9 @@ public class TeamFoundationServerScmTest {
         final String projectPath = "projectPath";
         final String singleVersionSpec = "Lfoo";
 
-        scm.recordWorkspaceChangesetVersion(build, listener, project, projectPath, singleVersionSpec);
+        final int actual = scm.recordWorkspaceChangesetVersion(build, listener, project, projectPath, singleVersionSpec);
 
+        Assert.assertEquals(42, actual);
         final Map<String, String> env = new HashMap<String, String>();
         scm.buildEnvVars(build, env);
         assertEquals("42", env.get(TeamFoundationServerScm.WORKSPACE_CHANGESET_ENV_STR));

--- a/src/test/java/hudson/plugins/tfs/actions/CheckoutActionTest.java
+++ b/src/test/java/hudson/plugins/tfs/actions/CheckoutActionTest.java
@@ -407,10 +407,12 @@ public class CheckoutActionTest {
         when(project.getDetailedHistory(isA(Calendar.class), isA(Calendar.class))).thenReturn(list);
         
         CheckoutAction action = new CheckoutAction("workspace", "project", ".", true);
-        List<ChangeSet> actualList = action.checkout(server, hudsonWs, Util.getCalendar(2008, 9, 24), Util.getCalendar(2009, 9, 24));
+        final Calendar startDate = Util.getCalendar(2008, 9, 24);
+        final Calendar endDate = Util.getCalendar(2009, 9, 24);
+        List<ChangeSet> actualList = action.checkout(server, hudsonWs, startDate, endDate);
         assertSame("The list from the detailed history, was not the same as returned from checkout", list, actualList);
         
-        verify(project).getDetailedHistory(eq(Util.getCalendar(2008, 9, 24)), eq(Util.getCalendar(2009, 9, 24)));
+        verify(project).getDetailedHistory(eq(startDate), eq(endDate));
         verify(project).getFiles(".", "D2009-09-24T00:00:00Z");
     }
 }

--- a/src/test/java/hudson/plugins/tfs/actions/CheckoutActionTest.java
+++ b/src/test/java/hudson/plugins/tfs/actions/CheckoutActionTest.java
@@ -8,6 +8,8 @@ import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.List;
 
+import com.microsoft.tfs.core.clients.versioncontrol.specs.version.DateVersionSpec;
+import com.microsoft.tfs.core.clients.versioncontrol.specs.version.VersionSpec;
 import hudson.FilePath;
 import hudson.plugins.tfs.Util;
 import hudson.plugins.tfs.model.ChangeSet;
@@ -16,6 +18,7 @@ import hudson.plugins.tfs.model.Server;
 import hudson.plugins.tfs.model.Workspace;
 import hudson.plugins.tfs.model.Workspaces;
 
+import org.hamcrest.CustomMatcher;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -226,7 +229,7 @@ public class CheckoutActionTest {
         when(workspaces.getWorkspace("workspace")).thenReturn(workspace);
         when(server.getLocalHostname()).thenReturn("LocalComputer");
         when(workspace.getComputer()).thenReturn("LocalComputer");
-        when(project.getDetailedHistory(isA(Calendar.class), isA(Calendar.class))).thenReturn(list);
+        when(project.getVCCHistory(isA(VersionSpec.class), isA(VersionSpec.class), anyBoolean())).thenReturn(list);
         
         CheckoutAction action = new CheckoutAction("workspace", "project", ".", true);
         final Calendar startDate = Util.getCalendar(2008, 9, 24);
@@ -234,7 +237,8 @@ public class CheckoutActionTest {
         List<ChangeSet> actualList = action.checkout(server, hudsonWs, startDate, endDate);
         assertSame("The list from the detailed history, was not the same as returned from checkout", list, actualList);
         
-        verify(project).getDetailedHistory(eq(startDate), isA(Calendar.class));
+        final DateVersionSpec startDateVersionSpec = new DateVersionSpec(startDate);
+        verify(project).getVCCHistory(argThat(new DateVersionSpecMatcher(startDateVersionSpec)), isA(VersionSpec.class), eq(true));
     }
     
     @Test
@@ -406,15 +410,42 @@ public class CheckoutActionTest {
         when(workspaces.getWorkspace("workspace")).thenReturn(workspace);
         when(server.getLocalHostname()).thenReturn("LocalComputer");
         when(workspace.getComputer()).thenReturn("LocalComputer");
-        when(project.getDetailedHistory(isA(Calendar.class), isA(Calendar.class))).thenReturn(list);
+        when(project.getVCCHistory(isA(VersionSpec.class), isA(VersionSpec.class), anyBoolean())).thenReturn(list);
         
         CheckoutAction action = new CheckoutAction("workspace", "project", ".", true);
         final Calendar startDate = Util.getCalendar(2008, 9, 24);
         final Calendar endDate = Util.getCalendar(2009, 9, 24);
         List<ChangeSet> actualList = action.checkout(server, hudsonWs, startDate, endDate);
         assertSame("The list from the detailed history, was not the same as returned from checkout", list, actualList);
-        
-        verify(project).getDetailedHistory(eq(startDate), eq(endDate));
+
+        final DateVersionSpec startDateVersionSpec = new DateVersionSpec(startDate);
+        final DateVersionSpec endDateVersionSpec = new DateVersionSpec(endDate);
+        verify(project).getVCCHistory(
+                argThat(new DateVersionSpecMatcher(startDateVersionSpec)),
+                argThat(new DateVersionSpecMatcher(endDateVersionSpec)), eq(true));
         verify(project).getFiles(".", "D2009-09-24T00:00:00Z");
+    }
+
+    private static class DateVersionSpecMatcher extends CustomMatcher<DateVersionSpec> {
+
+        private final DateVersionSpec base;
+
+        public DateVersionSpecMatcher(final DateVersionSpec base) {
+            super(base == null ? "(null)" : base.toString());
+            this.base = base;
+        }
+
+        public boolean matches(final Object item) {
+            if (base == null) {
+                return item == null;
+            }
+            if (item != null && item instanceof DateVersionSpec) {
+                final DateVersionSpec candidate = (DateVersionSpec) item;
+                final Calendar baseDate = base.getDate();
+                final Calendar candidateDate = candidate.getDate();
+                return baseDate.equals(candidateDate);
+            }
+            return false;
+        }
     }
 }

--- a/src/test/java/hudson/plugins/tfs/actions/CheckoutActionTest.java
+++ b/src/test/java/hudson/plugins/tfs/actions/CheckoutActionTest.java
@@ -229,10 +229,12 @@ public class CheckoutActionTest {
         when(project.getDetailedHistory(isA(Calendar.class), isA(Calendar.class))).thenReturn(list);
         
         CheckoutAction action = new CheckoutAction("workspace", "project", ".", true);
-        List<ChangeSet> actualList = action.checkout(server, hudsonWs, Util.getCalendar(2008, 9, 24), Util.getCalendar(2008, 10, 24));
+        final Calendar startDate = Util.getCalendar(2008, 9, 24);
+        final Calendar endDate = Util.getCalendar(2008, 10, 24);
+        List<ChangeSet> actualList = action.checkout(server, hudsonWs, startDate, endDate);
         assertSame("The list from the detailed history, was not the same as returned from checkout", list, actualList);
         
-        verify(project).getDetailedHistory(eq(Util.getCalendar(2008, 9, 24)), isA(Calendar.class));
+        verify(project).getDetailedHistory(eq(startDate), isA(Calendar.class));
     }
     
     @Test


### PR DESCRIPTION
Previously, checking out (and subsequent history querying) was done using timestamps, which could lead to an inconsistency where the plugin, under certain circumstances (i.e. if the build was started on the same second as a check-in) could report the changeset associated with the build as **x** but the files actually fetched would be from changeset **x - 1**.

This pull request leverages the changeset number (already being recorded!) to perform the checkout and history querying with more precision and consistency.

Verification is mostly encoded in the `newJob()` test, although some validation also took place by manual inspection of build artifacts, such as logs.