### PR TITLE
Increase workspace resolution resiliency

### DIFF
--- a/src/main/java/hudson/plugins/tfs/commands/DeleteWorkspaceCommand.java
+++ b/src/main/java/hudson/plugins/tfs/commands/DeleteWorkspaceCommand.java
@@ -11,8 +11,8 @@ import java.util.concurrent.Callable;
 
 public class DeleteWorkspaceCommand extends AbstractCallableCommand {
 
-    private static final String DeletingTemplate = "Deleting workspace '%s;%s'...";
-    private static final String DeletedTemplate = "Deleted workspace '%s;%s'.";
+    private static final String DeletingTemplate = "Deleting workspace '%s' owned by '%s'...";
+    private static final String DeletedTemplate = "Deleted workspace '%s'.";
 
     private final String workspaceName;
 
@@ -36,7 +36,7 @@ public class DeleteWorkspaceCommand extends AbstractCallableCommand {
                 final Workspace innerWorkspace = vcc.queryWorkspace(workspaceName, VersionControlConstants.AUTHENTICATED_USER);
                 vcc.deleteWorkspace(innerWorkspace);
 
-                final String deletedMessage = String.format(DeletedTemplate, workspaceName, userName);
+                final String deletedMessage = String.format(DeletedTemplate, workspaceName);
                 logger.println(deletedMessage);
 
                 return null;

--- a/src/main/java/hudson/plugins/tfs/commands/DeleteWorkspaceCommand.java
+++ b/src/main/java/hudson/plugins/tfs/commands/DeleteWorkspaceCommand.java
@@ -1,5 +1,6 @@
 package hudson.plugins.tfs.commands;
 
+import com.microsoft.tfs.core.clients.versioncontrol.VersionControlConstants;
 import com.microsoft.tfs.core.clients.versioncontrol.soapextensions.Workspace;
 import hudson.model.TaskListener;
 import hudson.plugins.tfs.model.MockableVersionControlClient;
@@ -32,7 +33,7 @@ public class DeleteWorkspaceCommand extends AbstractCallableCommand {
                 final String deletingMessage = String.format(DeletingTemplate, workspaceName, userName);
                 logger.println(deletingMessage);
 
-                final Workspace innerWorkspace = vcc.queryWorkspace(workspaceName, server.getUserName());
+                final Workspace innerWorkspace = vcc.queryWorkspace(workspaceName, VersionControlConstants.AUTHENTICATED_USER);
                 vcc.deleteWorkspace(innerWorkspace);
 
                 final String deletedMessage = String.format(DeletedTemplate, workspaceName, userName);

--- a/src/main/java/hudson/plugins/tfs/commands/NewWorkspaceCommand.java
+++ b/src/main/java/hudson/plugins/tfs/commands/NewWorkspaceCommand.java
@@ -14,10 +14,10 @@ import java.util.concurrent.Callable;
 
 public class NewWorkspaceCommand extends AbstractCallableCommand {
 
-    private static final String CreatingTemplate = "Creating workspace '%s;%s'...";
-    private static final String CreatedTemplate = "Created workspace '%s;%s'.";
-    private static final String MappingTemplate = "Mapping '%s' to local folder '%s' in workspace '%s;%s'...";
-    private static final String MappedTemplate = "Mapped '%s' to local folder '%s' in workspace '%s;%s'.";
+    private static final String CreatingTemplate = "Creating workspace '%s' owned by '%s'...";
+    private static final String CreatedTemplate = "Created workspace '%s'.";
+    private static final String MappingTemplate = "Mapping '%s' to local folder '%s' in workspace '%s'...";
+    private static final String MappedTemplate = "Mapped '%s' to local folder '%s' in workspace '%s'.";
 
     private final String workspaceName;
     private final String serverPath;
@@ -52,16 +52,16 @@ public class NewWorkspaceCommand extends AbstractCallableCommand {
                         WorkspaceOptions.NONE
                 );
 
-                final String createdMessage = String.format(CreatedTemplate, workspaceName, userName);
+                final String createdMessage = String.format(CreatedTemplate, workspaceName);
                 logger.println(createdMessage);
 
                 if (serverPath != null && localPath != null) {
-                    final String mappingMessage = String.format(MappingTemplate, serverPath, localPath, workspaceName, userName);
+                    final String mappingMessage = String.format(MappingTemplate, serverPath, localPath, workspaceName);
                     logger.println(mappingMessage);
 
                     workspace.map(serverPath, localPath);
 
-                    final String mappedMessage = String.format(MappedTemplate, serverPath, localPath, workspaceName, userName);
+                    final String mappedMessage = String.format(MappedTemplate, serverPath, localPath, workspaceName);
                     logger.println(mappedMessage);
                 }
 

--- a/src/main/java/hudson/plugins/tfs/commands/NewWorkspaceCommand.java
+++ b/src/main/java/hudson/plugins/tfs/commands/NewWorkspaceCommand.java
@@ -1,5 +1,6 @@
 package hudson.plugins.tfs.commands;
 
+import com.microsoft.tfs.core.clients.versioncontrol.VersionControlConstants;
 import com.microsoft.tfs.core.clients.versioncontrol.WorkspaceLocation;
 import com.microsoft.tfs.core.clients.versioncontrol.WorkspaceOptions;
 import com.microsoft.tfs.core.clients.versioncontrol.soapextensions.Workspace;
@@ -44,8 +45,8 @@ public class NewWorkspaceCommand extends AbstractCallableCommand {
                 final Workspace workspace = vcc.createWorkspace(
                         null,
                         workspaceName,
-                        null,
-                        null,
+                        VersionControlConstants.AUTHENTICATED_USER,
+                        VersionControlConstants.AUTHENTICATED_USER,
                         null /* TODO: set comment to something nice/useful */,
                         WorkspaceLocation.SERVER /* TODO: pull request #33 adds LOCAL support */,
                         WorkspaceOptions.NONE

--- a/src/test/java/hudson/plugins/tfs/EndToEndTfs.java
+++ b/src/test/java/hudson/plugins/tfs/EndToEndTfs.java
@@ -2,6 +2,7 @@ package hudson.plugins.tfs;
 
 import com.microsoft.tfs.core.clients.versioncontrol.GetOptions;
 import com.microsoft.tfs.core.clients.versioncontrol.PendChangesOptions;
+import com.microsoft.tfs.core.clients.versioncontrol.VersionControlConstants;
 import com.microsoft.tfs.core.clients.versioncontrol.WorkspaceLocation;
 import com.microsoft.tfs.core.clients.versioncontrol.WorkspaceOptions;
 import com.microsoft.tfs.core.clients.versioncontrol.soapextensions.LockLevel;
@@ -218,8 +219,8 @@ public @interface EndToEndTfs {
             final Workspace workspace = vcc.createWorkspace(
                     null,
                     workspaceName,
-                    null,
-                    null,
+                    VersionControlConstants.AUTHENTICATED_USER,
+                    VersionControlConstants.AUTHENTICATED_USER,
                     workspaceComment,
                     WorkspaceLocation.LOCAL,
                     WorkspaceOptions.NONE);
@@ -227,7 +228,7 @@ public @interface EndToEndTfs {
         }
 
         static void deleteWorkspace(final MockableVersionControlClient vcc, final String workspaceName) {
-            final Workspace workspace = vcc.getLocalWorkspace(workspaceName, ".");
+            final Workspace workspace = vcc.getLocalWorkspace(workspaceName, VersionControlConstants.AUTHENTICATED_USER);
             if (workspace != null) {
                 for (WorkingFolder workingFolder : workspace.getFolders()) {
                     final String localItem = workingFolder.getLocalItem();

--- a/src/test/java/hudson/plugins/tfs/commands/DeleteWorkspaceCommandTest.java
+++ b/src/test/java/hudson/plugins/tfs/commands/DeleteWorkspaceCommandTest.java
@@ -23,8 +23,8 @@ public class DeleteWorkspaceCommandTest extends AbstractCallableCommandTest {
         callable.call();
 
         assertLog(
-                "Deleting workspace 'TheWorkspaceName;snd\\user_cp'...",
-                "Deleted workspace 'TheWorkspaceName;snd\\user_cp'."
+                "Deleting workspace 'TheWorkspaceName' owned by 'snd\\user_cp'...",
+                "Deleted workspace 'TheWorkspaceName'."
         );
     }
 }

--- a/src/test/java/hudson/plugins/tfs/commands/NewWorkspaceCommandTest.java
+++ b/src/test/java/hudson/plugins/tfs/commands/NewWorkspaceCommandTest.java
@@ -29,8 +29,8 @@ public class NewWorkspaceCommandTest extends AbstractCallableCommandTest {
         callable.call();
 
         assertLog(
-                "Creating workspace 'TheWorkspaceName;snd\\user_cp'...",
-                "Created workspace 'TheWorkspaceName;snd\\user_cp'."
+                "Creating workspace 'TheWorkspaceName' owned by 'snd\\user_cp'...",
+                "Created workspace 'TheWorkspaceName'."
         );
     }
 
@@ -50,10 +50,10 @@ public class NewWorkspaceCommandTest extends AbstractCallableCommandTest {
         callable.call();
 
         assertLog(
-                "Creating workspace 'TheWorkspaceName;snd\\user_cp'...",
-                "Created workspace 'TheWorkspaceName;snd\\user_cp'.",
-                "Mapping '$/Stuff' to local folder '/home/jenkins/jobs/stuff/workspace' in workspace 'TheWorkspaceName;snd\\user_cp'...",
-                "Mapped '$/Stuff' to local folder '/home/jenkins/jobs/stuff/workspace' in workspace 'TheWorkspaceName;snd\\user_cp'."
+                "Creating workspace 'TheWorkspaceName' owned by 'snd\\user_cp'...",
+                "Created workspace 'TheWorkspaceName'.",
+                "Mapping '$/Stuff' to local folder '/home/jenkins/jobs/stuff/workspace' in workspace 'TheWorkspaceName'...",
+                "Mapped '$/Stuff' to local folder '/home/jenkins/jobs/stuff/workspace' in workspace 'TheWorkspaceName'."
         );
     }
 }


### PR DESCRIPTION
There are some corner cases where attempting to find a workspace by a user's userName will fail if it was created using the user's display name.  The SDK has a concept for "whoever is authenticated" (i.e. the `AUTHENTICATED_USER` constant), so let's use that.

Testing
-------
The integration tests were successful against TFS 2012, 2013 and 2015.  A quick peek at one of the build logs revealed that the new log messages indeed look better.  Mission accomplished!