### PR TITLE
Handle switching the user account.

### DIFF
--- a/src/test/java/hudson/plugins/tfs/commands/DeleteWorkspaceCommandTest.java
+++ b/src/test/java/hudson/plugins/tfs/commands/DeleteWorkspaceCommandTest.java
@@ -1,10 +1,13 @@
 package hudson.plugins.tfs.commands;
 
+import com.microsoft.tfs.core.clients.versioncontrol.WorkspacePermissions;
 import com.microsoft.tfs.core.clients.versioncontrol.soapextensions.Workspace;
 import org.junit.Test;
+import org.mockito.Matchers;
 
 import java.util.concurrent.Callable;
 
+import static org.mockito.Matchers.anyObject;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.isA;
 import static org.mockito.Mockito.when;
@@ -15,16 +18,16 @@ public class DeleteWorkspaceCommandTest extends AbstractCallableCommandTest {
     @Test
     public void assertLogging() throws Exception {
         when(server.getUserName()).thenReturn("snd\\user_cp");
-        when(vcc.queryWorkspace(isA(String.class), isA(String.class))).thenReturn(null);
-        doNothing().when(vcc).deleteWorkspace(isA(Workspace.class));
-        final DeleteWorkspaceCommand command = new DeleteWorkspaceCommand(server, "TheWorkspaceName");
+        final Workspace[] emptyWorkspaceList = new Workspace[0];
+        when(vcc.queryWorkspaces(isA(String.class), Matchers.<String>anyObject(), isA(String.class), isA(WorkspacePermissions.class))).thenReturn(emptyWorkspaceList);
+        final DeleteWorkspaceCommand command = new DeleteWorkspaceCommand(server, "TheWorkspaceName", "computerName");
         final Callable<Void> callable = command.getCallable();
 
         callable.call();
 
         assertLog(
-                "Deleting workspace 'TheWorkspaceName' owned by 'snd\\user_cp'...",
-                "Deleted workspace 'TheWorkspaceName'."
+                "Deleting workspaces named 'TheWorkspaceName'...",
+                "Deleted 0 workspace(s) named 'TheWorkspaceName'."
         );
     }
 }


### PR DESCRIPTION
This is a corner case that used to fail when attempting to delete a workspace owned by the previous user but queried using the current user's name.  Now we query for all workspaces with the name and attempt to delete them.  The new user must have the "Administer" permision on the previous user's workspace to be able to delete it, though.