### PR TITLE
Add Visual Studio Online support, part 1.

### DIFF
--- a/src/main/java/hudson/plugins/tfs/commands/LabelCommand.java
+++ b/src/main/java/hudson/plugins/tfs/commands/LabelCommand.java
@@ -1,5 +1,6 @@
 package hudson.plugins.tfs.commands;
 
+import com.microsoft.tfs.core.clients.versioncontrol.VersionControlConstants;
 import com.microsoft.tfs.core.clients.versioncontrol.soapextensions.LabelChildOption;
 import com.microsoft.tfs.core.clients.versioncontrol.soapextensions.LabelResult;
 import com.microsoft.tfs.core.clients.versioncontrol.soapextensions.RecursionType;
@@ -53,7 +54,7 @@ public class LabelCommand extends AbstractCallableCommand implements Callable<Vo
         final MockableVersionControlClient vcc = server.getVersionControlClient();
         final TaskListener listener = server.getListener();
         final PrintStream logger = listener.getLogger();
-        final String userName = server.getUserName();
+        final String userName = VersionControlConstants.AUTHENTICATED_USER;
 
         final String creatingMessage = String.format(CreatingTemplate, labelName, projectPath, workspaceName);
         logger.println(creatingMessage);

--- a/src/test/java/hudson/plugins/tfs/AbstractIntegrationTest.java
+++ b/src/test/java/hudson/plugins/tfs/AbstractIntegrationTest.java
@@ -16,7 +16,7 @@ import java.net.URISyntaxException;
 import java.net.UnknownHostException;
 import java.util.Enumeration;
 
-public abstract class AbstractIntegrationTest {
+public class AbstractIntegrationTest {
 
     public static final String TeamProjectCollection = "jenkins-tfs-plugin";
     public static final String TeamProjectPrefix = "$/FunctionalTests";

--- a/src/test/java/hudson/plugins/tfs/AbstractIntegrationTest.java
+++ b/src/test/java/hudson/plugins/tfs/AbstractIntegrationTest.java
@@ -33,6 +33,10 @@ public abstract class AbstractIntegrationTest {
     public static String buildTfsServerUrl() throws URISyntaxException {
         final String tfs_server_name = getTfsServerName();
         Assert.assertNotNull("The 'tfs_server_name' property was not provided a [non-empty] value.", tfs_server_name);
+        return buildServerUrl(tfs_server_name);
+    }
+
+    public static String buildServerUrl(final String tfs_server_name) throws URISyntaxException {
         final URI serverUri = URIUtils.createURI("http", tfs_server_name, 8080, "tfs/" + TeamProjectCollection, null, null);
         return serverUri.toString();
     }

--- a/src/test/java/hudson/plugins/tfs/EndToEndTfs.java
+++ b/src/test/java/hudson/plugins/tfs/EndToEndTfs.java
@@ -83,7 +83,7 @@ public @interface EndToEndTfs {
             final String workspaceName = "Hudson-${JOB_NAME}-${COMPUTERNAME}";
             XmlHelper.pokeValue(configXmlFile, "/project/scm/workspaceName", workspaceName);
 
-            final String userName = IntegrationTestHelper.TestUserName;
+            final String userName = helper.getUserName();
             XmlHelper.pokeValue(configXmlFile, "/project/scm/userName", userName);
         }
     }
@@ -119,7 +119,7 @@ public @interface EndToEndTfs {
             final File currentFolder = new File("").getAbsoluteFile();
             final File workspaces = new File(currentFolder, "workspaces");
             // TODO: Consider NOT using the Server class
-            server = new Server(new TfTool(null, null, null, null), serverUrl, IntegrationTestHelper.TestUserName, IntegrationTestHelper.TestUserPassword);
+            server = new Server(new TfTool(null, null, null, null), serverUrl, helper.getUserName(), helper.getUserPassword());
 
             final MockableVersionControlClient vcc = server.getVersionControlClient();
 

--- a/src/test/java/hudson/plugins/tfs/EndToEndTfs.java
+++ b/src/test/java/hudson/plugins/tfs/EndToEndTfs.java
@@ -50,6 +50,7 @@ public @interface EndToEndTfs {
      */
     class StubRunner extends JenkinsRecipe.Runner<EndToEndTfs> {
         private RunnerImpl parent;
+        private IntegrationTestHelper helper;
 
         protected RunnerImpl getParent() {
             return parent;
@@ -57,6 +58,14 @@ public @interface EndToEndTfs {
 
         private void setParent(final RunnerImpl parent) {
             this.parent = parent;
+        }
+
+        protected IntegrationTestHelper getHelper() {
+            return helper;
+        }
+
+        private void setHelper(final IntegrationTestHelper helper) {
+            this.helper = helper;
         }
 
         @Override
@@ -83,6 +92,7 @@ public @interface EndToEndTfs {
 
         private static final String workspaceComment = "Created by the Jenkins tfs-plugin functional tests.";
 
+        private final IntegrationTestHelper helper;
         private final String serverUrl;
 
         private File localBaseFolderFile;
@@ -95,7 +105,8 @@ public @interface EndToEndTfs {
         private Workspace workspace;
 
         public RunnerImpl() throws URISyntaxException {
-            serverUrl = IntegrationTestHelper.buildTfsServerUrl();
+            helper = new IntegrationTestHelper();
+            serverUrl = helper.getServerUrl();
         }
 
         @Override
@@ -153,6 +164,7 @@ public @interface EndToEndTfs {
             if (runnerClass != null) {
                 runner = runnerClass.newInstance();
                 runner.setParent(this);
+                runner.setHelper(this.helper);
                 runner.setup(jenkinsRule, recipe);
             }
         }

--- a/src/test/java/hudson/plugins/tfs/EndToEndTfs.java
+++ b/src/test/java/hudson/plugins/tfs/EndToEndTfs.java
@@ -65,7 +65,7 @@ public @interface EndToEndTfs {
             final String configXmlPath = jobFolder + "config.xml";
             final File configXmlFile = new File(home, configXmlPath);
 
-            final String tfsServerUrl = AbstractIntegrationTest.buildTfsServerUrl();
+            final String tfsServerUrl = IntegrationTestHelper.buildTfsServerUrl();
             XmlHelper.pokeValue(configXmlFile, "/project/scm/serverUrl", tfsServerUrl);
 
             final String projectPath = parent.getPathInTfvc();
@@ -74,7 +74,7 @@ public @interface EndToEndTfs {
             final String workspaceName = "Hudson-${JOB_NAME}-${COMPUTERNAME}";
             XmlHelper.pokeValue(configXmlFile, "/project/scm/workspaceName", workspaceName);
 
-            final String userName = AbstractIntegrationTest.TestUserName;
+            final String userName = IntegrationTestHelper.TestUserName;
             XmlHelper.pokeValue(configXmlFile, "/project/scm/userName", userName);
         }
     }
@@ -95,7 +95,7 @@ public @interface EndToEndTfs {
         private Workspace workspace;
 
         public RunnerImpl() throws URISyntaxException {
-            serverUrl = AbstractIntegrationTest.buildTfsServerUrl();
+            serverUrl = IntegrationTestHelper.buildTfsServerUrl();
         }
 
         @Override
@@ -104,11 +104,11 @@ public @interface EndToEndTfs {
             final Class clazz = testDescription.getTestClass();
             testClassName = clazz.getSimpleName();
             testCaseName = testDescription.getMethodName();
-            final String hostName = AbstractIntegrationTest.tryToDetermineHostName();
+            final String hostName = IntegrationTestHelper.tryToDetermineHostName();
             final File currentFolder = new File("").getAbsoluteFile();
             final File workspaces = new File(currentFolder, "workspaces");
             // TODO: Consider NOT using the Server class
-            server = new Server(new TfTool(null, null, null, null), serverUrl, AbstractIntegrationTest.TestUserName, AbstractIntegrationTest.TestUserPassword);
+            server = new Server(new TfTool(null, null, null, null), serverUrl, IntegrationTestHelper.TestUserName, IntegrationTestHelper.TestUserPassword);
 
             final MockableVersionControlClient vcc = server.getVersionControlClient();
 
@@ -116,7 +116,7 @@ public @interface EndToEndTfs {
             workspaceName = hostName + "-" + testCaseName;
             workspace = createWorkspace(vcc, workspaceName);
 
-            pathInTfvc = AbstractIntegrationTest.determinePathInTfvcForTestCase(testDescription);
+            pathInTfvc = IntegrationTestHelper.determinePathInTfvcForTestCase(testDescription);
             final File localTestClassFolder = new File(workspaces, testClassName);
             localBaseFolderFile = new File(localTestClassFolder, testCaseName);
             //noinspection ResultOfMethodCallIgnored

--- a/src/test/java/hudson/plugins/tfs/EndToEndTfs.java
+++ b/src/test/java/hudson/plugins/tfs/EndToEndTfs.java
@@ -74,7 +74,7 @@ public @interface EndToEndTfs {
             final String configXmlPath = jobFolder + "config.xml";
             final File configXmlFile = new File(home, configXmlPath);
 
-            final String tfsServerUrl = IntegrationTestHelper.buildTfsServerUrl();
+            final String tfsServerUrl = helper.getServerUrl();
             XmlHelper.pokeValue(configXmlFile, "/project/scm/serverUrl", tfsServerUrl);
 
             final String projectPath = parent.getPathInTfvc();

--- a/src/test/java/hudson/plugins/tfs/EndToEndTfs.java
+++ b/src/test/java/hudson/plugins/tfs/EndToEndTfs.java
@@ -107,7 +107,11 @@ public @interface EndToEndTfs {
                     // ignore
                 }
             }
-            XmlHelper.pokeValue(configXmlFile, "/project/scm/password", encryptedPassword);
+            final String projectScmPassword = "/project/scm/password";
+            final String currentPassword = XmlHelper.peekValue(configXmlFile, projectScmPassword);
+            if (currentPassword != null) {
+                XmlHelper.pokeValue(configXmlFile, projectScmPassword, encryptedPassword);
+            }
         }
     }
 

--- a/src/test/java/hudson/plugins/tfs/FunctionalTest.java
+++ b/src/test/java/hudson/plugins/tfs/FunctionalTest.java
@@ -165,7 +165,7 @@ public class FunctionalTest {
         Assert.assertEquals(0, changeSet.getItems().length);
         final TFSRevisionState revisionState = build.getAction(TFSRevisionState.class);
         Assert.assertEquals(latestChangesetID, revisionState.changesetVersion);
-        final String owner = IntegrationTestHelper.TestUserName;
+        final String owner = server.getUserName();
         final ChangesetVersionSpec spec = new ChangesetVersionSpec(latestChangesetID);
         final VersionControlLabel[] labels = vcc.queryLabels(generatedLabelName, null, owner, false, null, spec);
         Assert.assertEquals(1, labels.length);

--- a/src/test/java/hudson/plugins/tfs/FunctionalTest.java
+++ b/src/test/java/hudson/plugins/tfs/FunctionalTest.java
@@ -387,7 +387,7 @@ public class FunctionalTest {
             final File lastBuildXmlFile = new File(home, lastBuildXmlPath);
 
             final String projectPath = parent.getPathInTfvc();
-            final String serverUrl = parent.getServerUrl();
+            final String serverUrl = getHelper().getServerUrl();
             final Server server = parent.getServer();
             final MockableVersionControlClient vcc = server.getVersionControlClient();
             final int latestChangesetID = vcc.getLatestChangesetID();

--- a/src/test/java/hudson/plugins/tfs/FunctionalTest.java
+++ b/src/test/java/hudson/plugins/tfs/FunctionalTest.java
@@ -2,6 +2,7 @@ package hudson.plugins.tfs;
 
 import com.microsoft.tfs.core.clients.versioncontrol.GetOptions;
 import com.microsoft.tfs.core.clients.versioncontrol.PendChangesOptions;
+import com.microsoft.tfs.core.clients.versioncontrol.VersionControlConstants;
 import com.microsoft.tfs.core.clients.versioncontrol.soapextensions.LockLevel;
 import com.microsoft.tfs.core.clients.versioncontrol.soapextensions.VersionControlLabel;
 import com.microsoft.tfs.core.clients.versioncontrol.soapextensions.Workspace;
@@ -166,7 +167,7 @@ public class FunctionalTest {
         Assert.assertEquals(0, changeSet.getItems().length);
         final TFSRevisionState revisionState = build.getAction(TFSRevisionState.class);
         Assert.assertEquals(latestChangesetID, revisionState.changesetVersion);
-        final String owner = server.getUserName();
+        final String owner = VersionControlConstants.AUTHENTICATED_USER;
         final ChangesetVersionSpec spec = new ChangesetVersionSpec(latestChangesetID);
         final VersionControlLabel[] labels = vcc.queryLabels(generatedLabelName, null, owner, false, null, spec);
         Assert.assertEquals(1, labels.length);

--- a/src/test/java/hudson/plugins/tfs/FunctionalTest.java
+++ b/src/test/java/hudson/plugins/tfs/FunctionalTest.java
@@ -165,7 +165,7 @@ public class FunctionalTest {
         Assert.assertEquals(0, changeSet.getItems().length);
         final TFSRevisionState revisionState = build.getAction(TFSRevisionState.class);
         Assert.assertEquals(latestChangesetID, revisionState.changesetVersion);
-        final String owner = AbstractIntegrationTest.TestUserName;
+        final String owner = IntegrationTestHelper.TestUserName;
         final ChangesetVersionSpec spec = new ChangesetVersionSpec(latestChangesetID);
         final VersionControlLabel[] labels = vcc.queryLabels(generatedLabelName, null, owner, false, null, spec);
         Assert.assertEquals(1, labels.length);

--- a/src/test/java/hudson/plugins/tfs/IntegrationTestHelper.java
+++ b/src/test/java/hudson/plugins/tfs/IntegrationTestHelper.java
@@ -22,6 +22,8 @@ public class IntegrationTestHelper {
     public static final String TestUserPassword = "for-test-only";
 
     private final String serverUrl;
+    private final String userName;
+    private final String userPassword;
 
     public IntegrationTestHelper() throws URISyntaxException {
         this(getTfsServerName());
@@ -31,18 +33,29 @@ public class IntegrationTestHelper {
         final URI serverUri;
         if ("vso".equals(tfsServerName)) {
             serverUri = URIUtils.createURI("https", "automated-testing.visualstudio.com", 443, "DefaultCollection", null, null);
+            this.userName = "TODO";
+            this.userPassword = "TODO";
         } else {
             serverUri = URIUtils.createURI("http", tfsServerName, 8080, "tfs/" + "jenkins-tfs-plugin", null, null);
+            this.userName = TestUserName;
+            this.userPassword = TestUserPassword;
         }
         serverUrl = serverUri.toString();
     }
-
 
     /**
      * A string representing the URL to a VSO account or a default TFS server installation.
      */
     public String getServerUrl() {
         return serverUrl;
+    }
+
+    public String getUserName() {
+        return userName;
+    }
+
+    public String getUserPassword() {
+        return userPassword;
     }
 
     public static String getTfsServerName() {

--- a/src/test/java/hudson/plugins/tfs/IntegrationTestHelper.java
+++ b/src/test/java/hudson/plugins/tfs/IntegrationTestHelper.java
@@ -23,6 +23,16 @@ public class IntegrationTestHelper {
     public static final String TestUserName = "jenkins-tfs-plugin";
     public static final String TestUserPassword = "for-test-only";
 
+    private final String serverUrl;
+
+    public IntegrationTestHelper() throws URISyntaxException {
+        serverUrl = buildTfsServerUrl();
+    }
+
+    public String getServerUrl() {
+        return serverUrl;
+    }
+
     /**
      * Creates a string representing the URL to a VSO account or a default TFS server installation,
      * based on the <code>tfs_server_name</code> property.

--- a/src/test/java/hudson/plugins/tfs/IntegrationTestHelper.java
+++ b/src/test/java/hudson/plugins/tfs/IntegrationTestHelper.java
@@ -29,15 +29,15 @@ public class IntegrationTestHelper {
 
     public IntegrationTestHelper(final String tfsServerName) throws URISyntaxException {
         final URI serverUri;
+        final String tfsUserName = hudson.Util.fixEmptyAndTrim(System.getProperty("tfs_user_name"));
+        final String tfsUserPassword = hudson.Util.fixEmptyAndTrim(System.getProperty("tfs_user_password"));
         if ("vso".equals(tfsServerName)) {
             serverUri = URIUtils.createURI("https", "automated-testing.visualstudio.com", 443, "DefaultCollection", null, null);
-            this.userName = "TODO";
-            this.userPassword = "TODO";
+            this.userName = tfsUserName;
+            this.userPassword = tfsUserPassword;
         } else {
             serverUri = URIUtils.createURI("http", tfsServerName, 8080, "tfs/" + "jenkins-tfs-plugin", null, null);
-            final String tfsUserName = hudson.Util.fixEmptyAndTrim(System.getProperty("tfs_user_name"));
             this.userName = (tfsUserName != null) ? tfsUserName : "jenkins-tfs-plugin";
-            final String tfsUserPassword = hudson.Util.fixEmptyAndTrim(System.getProperty("tfs_user_password"));
             this.userPassword = (tfsUserPassword != null) ? tfsUserPassword : "for-test-only";
         }
         serverUrl = serverUri.toString();

--- a/src/test/java/hudson/plugins/tfs/IntegrationTestHelper.java
+++ b/src/test/java/hudson/plugins/tfs/IntegrationTestHelper.java
@@ -18,8 +18,6 @@ import java.util.Enumeration;
 
 public class IntegrationTestHelper {
 
-    public static final String TeamProjectCollection = "jenkins-tfs-plugin";
-    public static final String TeamProjectPrefix = "$/FunctionalTests";
     public static final String TestUserName = "jenkins-tfs-plugin";
     public static final String TestUserPassword = "for-test-only";
 
@@ -34,7 +32,7 @@ public class IntegrationTestHelper {
         if ("vso".equals(tfsServerName)) {
             serverUri = URIUtils.createURI("https", "automated-testing.visualstudio.com", 443, "DefaultCollection", null, null);
         } else {
-            serverUri = URIUtils.createURI("http", tfsServerName, 8080, "tfs/" + TeamProjectCollection, null, null);
+            serverUri = URIUtils.createURI("http", tfsServerName, 8080, "tfs/" + "jenkins-tfs-plugin", null, null);
         }
         serverUrl = serverUri.toString();
     }
@@ -64,7 +62,7 @@ public class IntegrationTestHelper {
         final Class clazz = testDescription.getTestClass();
         final String testClassName = clazz.getSimpleName();
         final String testCaseName = testDescription.getMethodName();
-        return TeamProjectPrefix + "/" + testClassName + "/" + testCaseName;
+        return "$/FunctionalTests" + "/" + testClassName + "/" + testCaseName;
     }
 
     // Adapted from http://stackoverflow.com/a/20793241

--- a/src/test/java/hudson/plugins/tfs/IntegrationTestHelper.java
+++ b/src/test/java/hudson/plugins/tfs/IntegrationTestHelper.java
@@ -18,9 +18,6 @@ import java.util.Enumeration;
 
 public class IntegrationTestHelper {
 
-    public static final String TestUserName = "jenkins-tfs-plugin";
-    public static final String TestUserPassword = "for-test-only";
-
     private final String serverUrl;
     private final String userName;
     private final String userPassword;
@@ -37,8 +34,8 @@ public class IntegrationTestHelper {
             this.userPassword = "TODO";
         } else {
             serverUri = URIUtils.createURI("http", tfsServerName, 8080, "tfs/" + "jenkins-tfs-plugin", null, null);
-            this.userName = TestUserName;
-            this.userPassword = TestUserPassword;
+            this.userName = "jenkins-tfs-plugin";
+            this.userPassword = "for-test-only";
         }
         serverUrl = serverUri.toString();
     }

--- a/src/test/java/hudson/plugins/tfs/IntegrationTestHelper.java
+++ b/src/test/java/hudson/plugins/tfs/IntegrationTestHelper.java
@@ -30,28 +30,21 @@ public class IntegrationTestHelper {
     }
 
     public IntegrationTestHelper(final String tfsServerName) throws URISyntaxException {
-        serverUrl = buildServerUrl(tfsServerName);
-    }
-
-    public String getServerUrl() {
-        return serverUrl;
-    }
-
-    /**
-     * Creates a string representing the URL to a VSO account or a default TFS server installation,
-     * based on the <code>tfs_server_name</code> property.
-     *
-     * @return a string representing a URL to a VSO or TFS server.
-     * @throws URISyntaxException
-     */
-    public static String buildServerUrl(final String tfs_server_name) throws URISyntaxException {
         final URI serverUri;
-        if ("vso".equals(tfs_server_name)) {
+        if ("vso".equals(tfsServerName)) {
             serverUri = URIUtils.createURI("https", "automated-testing.visualstudio.com", 443, "DefaultCollection", null, null);
         } else {
-            serverUri = URIUtils.createURI("http", tfs_server_name, 8080, "tfs/" + TeamProjectCollection, null, null);
+            serverUri = URIUtils.createURI("http", tfsServerName, 8080, "tfs/" + TeamProjectCollection, null, null);
         }
-        return serverUri.toString();
+        serverUrl = serverUri.toString();
+    }
+
+
+    /**
+     * A string representing the URL to a VSO account or a default TFS server installation.
+     */
+    public String getServerUrl() {
+        return serverUrl;
     }
 
     public static String getTfsServerName() {

--- a/src/test/java/hudson/plugins/tfs/IntegrationTestHelper.java
+++ b/src/test/java/hudson/plugins/tfs/IntegrationTestHelper.java
@@ -26,7 +26,11 @@ public class IntegrationTestHelper {
     private final String serverUrl;
 
     public IntegrationTestHelper() throws URISyntaxException {
-        serverUrl = buildTfsServerUrl();
+        this(getTfsServerName());
+    }
+
+    public IntegrationTestHelper(final String tfsServerName) throws URISyntaxException {
+        serverUrl = buildServerUrl(tfsServerName);
     }
 
     public String getServerUrl() {
@@ -40,13 +44,8 @@ public class IntegrationTestHelper {
      * @return a string representing a URL to a VSO or TFS server.
      * @throws URISyntaxException
      */
-    public static String buildTfsServerUrl() throws URISyntaxException {
-        final String tfs_server_name = getTfsServerName();
-        Assert.assertNotNull("The 'tfs_server_name' property was not provided a [non-empty] value.", tfs_server_name);
-        return buildServerUrl(tfs_server_name);
-    }
-
     public static String buildServerUrl(final String tfs_server_name) throws URISyntaxException {
+        Assert.assertNotNull("The 'tfs_server_name' property was not provided a [non-empty] value.", tfs_server_name);
         final URI serverUri;
         if ("vso".equals(tfs_server_name)) {
             serverUri = URIUtils.createURI("https", "automated-testing.visualstudio.com", 443, "DefaultCollection", null, null);

--- a/src/test/java/hudson/plugins/tfs/IntegrationTestHelper.java
+++ b/src/test/java/hudson/plugins/tfs/IntegrationTestHelper.java
@@ -24,10 +24,10 @@ public class IntegrationTestHelper {
     public static final String TestUserPassword = "for-test-only";
 
     /**
-     * Creates a string representing the URL to a default TFS server installation, based on the
-     * <code>tfs_server_name</code> property.
+     * Creates a string representing the URL to a VSO account or a default TFS server installation,
+     * based on the <code>tfs_server_name</code> property.
      *
-     * @return a string of the form <code>http://${tfs_server_name}:8080/tfs/jenkins-tfs-plugin</code>
+     * @return a string representing a URL to a VSO or TFS server.
      * @throws URISyntaxException
      */
     public static String buildTfsServerUrl() throws URISyntaxException {
@@ -37,7 +37,12 @@ public class IntegrationTestHelper {
     }
 
     public static String buildServerUrl(final String tfs_server_name) throws URISyntaxException {
-        final URI serverUri = URIUtils.createURI("http", tfs_server_name, 8080, "tfs/" + TeamProjectCollection, null, null);
+        final URI serverUri;
+        if ("vso".equals(tfs_server_name)) {
+            serverUri = URIUtils.createURI("https", "automated-testing.visualstudio.com", 443, "DefaultCollection", null, null);
+        } else {
+            serverUri = URIUtils.createURI("http", tfs_server_name, 8080, "tfs/" + TeamProjectCollection, null, null);
+        }
         return serverUri.toString();
     }
 

--- a/src/test/java/hudson/plugins/tfs/IntegrationTestHelper.java
+++ b/src/test/java/hudson/plugins/tfs/IntegrationTestHelper.java
@@ -45,7 +45,6 @@ public class IntegrationTestHelper {
      * @throws URISyntaxException
      */
     public static String buildServerUrl(final String tfs_server_name) throws URISyntaxException {
-        Assert.assertNotNull("The 'tfs_server_name' property was not provided a [non-empty] value.", tfs_server_name);
         final URI serverUri;
         if ("vso".equals(tfs_server_name)) {
             serverUri = URIUtils.createURI("https", "automated-testing.visualstudio.com", 443, "DefaultCollection", null, null);
@@ -56,7 +55,9 @@ public class IntegrationTestHelper {
     }
 
     public static String getTfsServerName() {
-        return hudson.Util.fixEmptyAndTrim(System.getProperty("tfs_server_name"));
+        final String result = hudson.Util.fixEmptyAndTrim(System.getProperty("tfs_server_name"));
+        Assert.assertNotNull("The 'tfs_server_name' property was not provided a [non-empty] value.", result);
+        return result;
     }
 
     /**

--- a/src/test/java/hudson/plugins/tfs/IntegrationTestHelper.java
+++ b/src/test/java/hudson/plugins/tfs/IntegrationTestHelper.java
@@ -1,5 +1,6 @@
 package hudson.plugins.tfs;
 
+import hudson.*;
 import org.apache.commons.lang.StringUtils;
 import org.apache.maven.wagon.providers.http.httpclient.client.utils.URIUtils;
 import org.junit.Assert;
@@ -34,8 +35,10 @@ public class IntegrationTestHelper {
             this.userPassword = "TODO";
         } else {
             serverUri = URIUtils.createURI("http", tfsServerName, 8080, "tfs/" + "jenkins-tfs-plugin", null, null);
-            this.userName = "jenkins-tfs-plugin";
-            this.userPassword = "for-test-only";
+            final String tfsUserName = hudson.Util.fixEmptyAndTrim(System.getProperty("tfs_user_name"));
+            this.userName = (tfsUserName != null) ? tfsUserName : "jenkins-tfs-plugin";
+            final String tfsUserPassword = hudson.Util.fixEmptyAndTrim(System.getProperty("tfs_user_password"));
+            this.userPassword = (tfsUserPassword != null) ? tfsUserPassword : "for-test-only";
         }
         serverUrl = serverUri.toString();
     }

--- a/src/test/java/hudson/plugins/tfs/IntegrationTestHelper.java
+++ b/src/test/java/hudson/plugins/tfs/IntegrationTestHelper.java
@@ -31,8 +31,8 @@ public class IntegrationTestHelper {
         final URI serverUri;
         final String tfsUserName = hudson.Util.fixEmptyAndTrim(System.getProperty("tfs_user_name"));
         final String tfsUserPassword = hudson.Util.fixEmptyAndTrim(System.getProperty("tfs_user_password"));
-        if ("vso".equals(tfsServerName)) {
-            serverUri = URIUtils.createURI("https", "automated-testing.visualstudio.com", 443, "DefaultCollection", null, null);
+        if (tfsServerName.endsWith(".visualstudio.com")) {
+            serverUri = URIUtils.createURI("https", tfsServerName, 443, "DefaultCollection", null, null);
             this.userName = tfsUserName;
             this.userPassword = tfsUserPassword;
         } else {

--- a/src/test/java/hudson/plugins/tfs/IntegrationTestHelper.java
+++ b/src/test/java/hudson/plugins/tfs/IntegrationTestHelper.java
@@ -16,7 +16,7 @@ import java.net.URISyntaxException;
 import java.net.UnknownHostException;
 import java.util.Enumeration;
 
-public class AbstractIntegrationTest {
+public class IntegrationTestHelper {
 
     public static final String TeamProjectCollection = "jenkins-tfs-plugin";
     public static final String TeamProjectPrefix = "$/FunctionalTests";

--- a/src/test/java/hudson/plugins/tfs/IntegrationTestHelperTest.java
+++ b/src/test/java/hudson/plugins/tfs/IntegrationTestHelperTest.java
@@ -6,13 +6,17 @@ import org.junit.Test;
 public class IntegrationTestHelperTest {
 
     @Test public void buildServerUrl_onPremiseTfsServer() throws Exception {
-        final String actual = IntegrationTestHelper.buildServerUrl("tfs2013");
+        final IntegrationTestHelper cut = new IntegrationTestHelper("tfs2013");
+
+        final String actual = cut.getServerUrl();
 
         Assert.assertEquals("http://tfs2013:8080/tfs/jenkins-tfs-plugin", actual);
     }
 
     @Test public void buildServerUrl_designatedVsoAccount() throws Exception {
-        final String actual = IntegrationTestHelper.buildServerUrl("vso");
+        final IntegrationTestHelper cut = new IntegrationTestHelper("vso");
+
+        final String actual = cut.getServerUrl();
 
         Assert.assertEquals("https://automated-testing.visualstudio.com:443/DefaultCollection", actual);
     }

--- a/src/test/java/hudson/plugins/tfs/IntegrationTestHelperTest.java
+++ b/src/test/java/hudson/plugins/tfs/IntegrationTestHelperTest.java
@@ -11,4 +11,10 @@ public class IntegrationTestHelperTest {
         Assert.assertEquals("http://tfs2013:8080/tfs/jenkins-tfs-plugin", actual);
     }
 
+    @Test public void buildServerUrl_designatedVsoAccount() throws Exception {
+        final String actual = IntegrationTestHelper.buildServerUrl("vso");
+
+        Assert.assertEquals("https://automated-testing.visualstudio.com:443/DefaultCollection", actual);
+    }
+
 }

--- a/src/test/java/hudson/plugins/tfs/IntegrationTestHelperTest.java
+++ b/src/test/java/hudson/plugins/tfs/IntegrationTestHelperTest.java
@@ -1,0 +1,14 @@
+package hudson.plugins.tfs;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class IntegrationTestHelperTest {
+
+    @Test public void buildServerUrl_onPremiseTfsServer() throws Exception {
+        final String actual = IntegrationTestHelper.buildServerUrl("tfs2013");
+
+        Assert.assertEquals("http://tfs2013:8080/tfs/jenkins-tfs-plugin", actual);
+    }
+
+}

--- a/src/test/java/hudson/plugins/tfs/IntegrationTestHelperTest.java
+++ b/src/test/java/hudson/plugins/tfs/IntegrationTestHelperTest.java
@@ -14,7 +14,7 @@ public class IntegrationTestHelperTest {
     }
 
     @Test public void buildServerUrl_designatedVsoAccount() throws Exception {
-        final IntegrationTestHelper cut = new IntegrationTestHelper("vso");
+        final IntegrationTestHelper cut = new IntegrationTestHelper("automated-testing.visualstudio.com");
 
         final String actual = cut.getServerUrl();
 

--- a/src/test/java/hudson/plugins/tfs/TeamFoundationServerScmIntegrationTest.java
+++ b/src/test/java/hudson/plugins/tfs/TeamFoundationServerScmIntegrationTest.java
@@ -19,7 +19,8 @@ public class TeamFoundationServerScmIntegrationTest {
 
     @Before
     public void connectToTfs() throws URISyntaxException {
-        final String serverUrl = IntegrationTestHelper.buildTfsServerUrl();
+        final IntegrationTestHelper helper = new IntegrationTestHelper();
+        final String serverUrl = helper.getServerUrl();
         scm = new TeamFoundationServerScm(serverUrl, "projectPath", "localPath", false, "workspaceName", null, (Secret) null);
     }
 

--- a/src/test/java/hudson/plugins/tfs/TeamFoundationServerScmIntegrationTest.java
+++ b/src/test/java/hudson/plugins/tfs/TeamFoundationServerScmIntegrationTest.java
@@ -19,7 +19,7 @@ public class TeamFoundationServerScmIntegrationTest {
 
     @Before
     public void connectToTfs() throws URISyntaxException {
-        final String serverUrl = AbstractIntegrationTest.buildTfsServerUrl();
+        final String serverUrl = IntegrationTestHelper.buildTfsServerUrl();
         scm = new TeamFoundationServerScm(serverUrl, "projectPath", "localPath", false, "workspaceName", null, (Secret) null);
     }
 

--- a/src/test/java/hudson/plugins/tfs/TeamFoundationServerScmIntegrationTest.java
+++ b/src/test/java/hudson/plugins/tfs/TeamFoundationServerScmIntegrationTest.java
@@ -13,13 +13,13 @@ import java.net.URISyntaxException;
  * These are so-called integration (L2) tests.
  */
 @Category(IntegrationTests.class)
-public class TeamFoundationServerScmIntegrationTest extends AbstractIntegrationTest {
+public class TeamFoundationServerScmIntegrationTest {
 
     private TeamFoundationServerScm scm;
 
     @Before
     public void connectToTfs() throws URISyntaxException {
-        final String serverUrl = buildTfsServerUrl();
+        final String serverUrl = AbstractIntegrationTest.buildTfsServerUrl();
         scm = new TeamFoundationServerScm(serverUrl, "projectPath", "localPath", false, "workspaceName", null, (Secret) null);
     }
 

--- a/src/test/java/hudson/plugins/tfs/TeamFoundationServerScmTest.java
+++ b/src/test/java/hudson/plugins/tfs/TeamFoundationServerScmTest.java
@@ -54,7 +54,7 @@ public class TeamFoundationServerScmTest {
     @Test public void upgradeFromScrambledPassword() {
         SecretOverride secretOverride = null;
         try {
-            secretOverride = new SecretOverride("5e2422dc868f119d5033f4619a6f223d71d132a17f8a63f1056c9a1f57c65006");
+            secretOverride = new SecretOverride();
             final String xmlString =
                     "<scm class='hudson.plugins.tfs.TeamFoundationServerScm' plugin='tfs@3.1.1'>\n" +
                     "    <serverUrl>http://example.tfs.server.invalid:8080/tfs</serverUrl>\n" +

--- a/src/test/java/hudson/plugins/tfs/commands/ListWorkspacesCommandTest.java
+++ b/src/test/java/hudson/plugins/tfs/commands/ListWorkspacesCommandTest.java
@@ -39,7 +39,8 @@ public class ListWorkspacesCommandTest extends AbstractCallableCommandTest {
 
     @Category(IntegrationTests.class)
     @Test public void assertLoggingWithComputer() throws Exception {
-        final String serverUrl = IntegrationTestHelper.buildTfsServerUrl();
+        final IntegrationTestHelper helper = new IntegrationTestHelper();
+        final String serverUrl = helper.getServerUrl();
         final URI serverUri = URI.create(serverUrl);
         Server.ensureNativeLibrariesConfigured();
         final UsernamePasswordCredentials credentials = new UsernamePasswordCredentials(
@@ -80,7 +81,8 @@ public class ListWorkspacesCommandTest extends AbstractCallableCommandTest {
 
     @Category(IntegrationTests.class)
     @Test public void assertLoggingWithoutComputer() throws Exception {
-        final String serverUrl = IntegrationTestHelper.buildTfsServerUrl();
+        final IntegrationTestHelper helper = new IntegrationTestHelper();
+        final String serverUrl = helper.getServerUrl();
         final URI serverUri = URI.create(serverUrl);
         Server.ensureNativeLibrariesConfigured();
         final UsernamePasswordCredentials credentials = new UsernamePasswordCredentials(

--- a/src/test/java/hudson/plugins/tfs/commands/ListWorkspacesCommandTest.java
+++ b/src/test/java/hudson/plugins/tfs/commands/ListWorkspacesCommandTest.java
@@ -44,7 +44,7 @@ public class ListWorkspacesCommandTest extends AbstractCallableCommandTest {
         final URI serverUri = URI.create(serverUrl);
         Server.ensureNativeLibrariesConfigured();
         final UsernamePasswordCredentials credentials = new UsernamePasswordCredentials(
-                IntegrationTestHelper.TestUserName, IntegrationTestHelper.TestUserPassword);
+                helper.getUserName(), helper.getUserPassword());
         final TFSTeamProjectCollection tpc = new TFSTeamProjectCollection(serverUri, credentials);
 
         try {
@@ -86,7 +86,7 @@ public class ListWorkspacesCommandTest extends AbstractCallableCommandTest {
         final URI serverUri = URI.create(serverUrl);
         Server.ensureNativeLibrariesConfigured();
         final UsernamePasswordCredentials credentials = new UsernamePasswordCredentials(
-                IntegrationTestHelper.TestUserName, IntegrationTestHelper.TestUserPassword);
+                helper.getUserName(), helper.getUserPassword());
         final TFSTeamProjectCollection tpc = new TFSTeamProjectCollection(serverUri, credentials);
 
         try {

--- a/src/test/java/hudson/plugins/tfs/commands/ListWorkspacesCommandTest.java
+++ b/src/test/java/hudson/plugins/tfs/commands/ListWorkspacesCommandTest.java
@@ -15,7 +15,7 @@ import com.microsoft.tfs.core.clients.versioncontrol.VersionControlClient;
 import com.microsoft.tfs.core.clients.versioncontrol.WorkspaceLocation;
 import com.microsoft.tfs.core.clients.versioncontrol.WorkspacePermissions;
 import com.microsoft.tfs.core.httpclient.UsernamePasswordCredentials;
-import hudson.plugins.tfs.AbstractIntegrationTest;
+import hudson.plugins.tfs.IntegrationTestHelper;
 import hudson.plugins.tfs.IntegrationTests;
 import hudson.plugins.tfs.commands.ListWorkspacesCommand.WorkspaceFactory;
 import hudson.plugins.tfs.model.Server;
@@ -39,11 +39,11 @@ public class ListWorkspacesCommandTest extends AbstractCallableCommandTest {
 
     @Category(IntegrationTests.class)
     @Test public void assertLoggingWithComputer() throws Exception {
-        final String serverUrl = AbstractIntegrationTest.buildTfsServerUrl();
+        final String serverUrl = IntegrationTestHelper.buildTfsServerUrl();
         final URI serverUri = URI.create(serverUrl);
         Server.ensureNativeLibrariesConfigured();
         final UsernamePasswordCredentials credentials = new UsernamePasswordCredentials(
-                AbstractIntegrationTest.TestUserName, AbstractIntegrationTest.TestUserPassword);
+                IntegrationTestHelper.TestUserName, IntegrationTestHelper.TestUserPassword);
         final TFSTeamProjectCollection tpc = new TFSTeamProjectCollection(serverUri, credentials);
 
         try {
@@ -80,11 +80,11 @@ public class ListWorkspacesCommandTest extends AbstractCallableCommandTest {
 
     @Category(IntegrationTests.class)
     @Test public void assertLoggingWithoutComputer() throws Exception {
-        final String serverUrl = AbstractIntegrationTest.buildTfsServerUrl();
+        final String serverUrl = IntegrationTestHelper.buildTfsServerUrl();
         final URI serverUri = URI.create(serverUrl);
         Server.ensureNativeLibrariesConfigured();
         final UsernamePasswordCredentials credentials = new UsernamePasswordCredentials(
-                AbstractIntegrationTest.TestUserName, AbstractIntegrationTest.TestUserPassword);
+                IntegrationTestHelper.TestUserName, IntegrationTestHelper.TestUserPassword);
         final TFSTeamProjectCollection tpc = new TFSTeamProjectCollection(serverUri, credentials);
 
         try {

--- a/src/test/java/hudson/util/SecretOverride.java
+++ b/src/test/java/hudson/util/SecretOverride.java
@@ -14,6 +14,10 @@ public class SecretOverride implements Closeable {
         Secret.SECRET = secretKey;
     }
 
+    public SecretOverride() {
+        this("5e2422dc868f119d5033f4619a6f223d71d132a17f8a63f1056c9a1f57c65006");
+    }
+
     public SecretOverride(final String secretKey) {
         set(secretKey);
     }


### PR DESCRIPTION
These changes make it possible to set-up automated integration testing against _any_ VSO account, similar to how we can run those tests against on-premises TFS servers.