### PR TITLE
Fix issue with single changeset syncing

### DIFF
--- a/src/main/java/hudson/plugins/tfs/model/Project.java
+++ b/src/main/java/hudson/plugins/tfs/model/Project.java
@@ -26,6 +26,7 @@ import com.microsoft.tfs.core.clients.versioncontrol.specs.version.ChangesetVers
 import com.microsoft.tfs.core.clients.versioncontrol.specs.version.DateVersionSpec;
 import com.microsoft.tfs.core.clients.versioncontrol.specs.version.LabelVersionSpec;
 import com.microsoft.tfs.core.clients.versioncontrol.specs.version.VersionSpec;
+import com.microsoft.tfs.core.clients.versioncontrol.specs.version.LatestVersionSpec;
 import com.microsoft.tfs.core.clients.webservices.IIdentityManagementService;
 
 public class Project {
@@ -81,7 +82,7 @@ public class Project {
         final MockableVersionControlClient vcc = server.getVersionControlClient();
         final Changeset[] serverChangesets = vcc.queryHistory(
                 projectPath,
-                fromVersion != null ? fromVersion : toVersion,
+                LatestVersionSpec.INSTANCE,
                 0 /* deletionId */,
                 RecursionType.FULL,
                 null /* user */,
@@ -117,7 +118,7 @@ public class Project {
     
     public List<ChangeSet> getDetailedHistory(String singleVersionSpec) {
         final VersionSpec toVersion = VersionSpec.parseSingleVersionFromSpec(singleVersionSpec, null);
-        return getVCCHistory(null, toVersion, true, Integer.MAX_VALUE);
+        return getVCCHistory(toVersion, toVersion, true, Integer.MAX_VALUE);
     }
 
     /**


### PR DESCRIPTION
When syncing a single changeset, the plugin would attempt to get history for every change leading up to that changeset