### PR TITLE
Clean up after TF CLC -> SDK switchover

### DIFF
--- a/src/main/java/hudson/plugins/tfs/TeamFoundationServerScm.java
+++ b/src/main/java/hudson/plugins/tfs/TeamFoundationServerScm.java
@@ -408,7 +408,7 @@ public class TeamFoundationServerScm extends SCM {
         public static final Pattern USER_AT_DOMAIN_REGEX = Pattern.compile("^([^\\/\\\\\"\\[\\]:|<>+=;,\\*@]+)@([a-z][a-z0-9.-]+)$", Pattern.CASE_INSENSITIVE);
         public static final Pattern DOMAIN_SLASH_USER_REGEX = Pattern.compile("^([a-z][a-z0-9.-]+)\\\\([^\\/\\\\\"\\[\\]:|<>+=;,\\*@]+)$", Pattern.CASE_INSENSITIVE);
         public static final Pattern PROJECT_PATH_REGEX = Pattern.compile("^\\$\\/.*", Pattern.CASE_INSENSITIVE);
-        private String tfExecutable;
+        private transient String tfExecutable;
         
         public DescriptorImpl() {
             super(TeamFoundationServerScm.class, TeamFoundationServerRepositoryBrowser.class);
@@ -471,7 +471,6 @@ public class TeamFoundationServerScm extends SCM {
         
         @Override
         public boolean configure(StaplerRequest req, JSONObject formData) throws FormException {
-            tfExecutable = Util.fixEmpty(req.getParameter("tfs.tfExecutable").trim());
             save();
             return true;
         }

--- a/src/main/java/hudson/plugins/tfs/TeamFoundationServerScm.java
+++ b/src/main/java/hudson/plugins/tfs/TeamFoundationServerScm.java
@@ -415,23 +415,11 @@ public class TeamFoundationServerScm extends SCM {
             load();
         }
 
-        public String getTfExecutable() {
-            if (tfExecutable == null) {
-                return "tf";
-            } else {
-                return tfExecutable;
-            }
-        }
-        
         @Override
         public SCM newInstance(StaplerRequest req, JSONObject formData) throws FormException {
             TeamFoundationServerScm scm = (TeamFoundationServerScm) super.newInstance(req, formData);
             scm.repositoryBrowser = RepositoryBrowsers.createInstance(TeamFoundationServerRepositoryBrowser.class,req,formData,"browser");
             return scm;
-        }
-        
-        public FormValidation doExecutableCheck(@QueryParameter final String value) {
-            return FormValidation.validateExecutable(value);
         }
 
         private FormValidation doRegexCheck(final Pattern[] regexArray,

--- a/src/main/resources/hudson/plugins/tfs/TeamFoundationServerScm/global.jelly
+++ b/src/main/resources/hudson/plugins/tfs/TeamFoundationServerScm/global.jelly
@@ -1,9 +1,4 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <f:section title="Team Foundation Server">
-    <f:entry title="TF command line executable"  help="/plugin/tfs/tfExecutable.html">
-      <f:textbox name="tfs.tfExecutable" value="${descriptor.tfExecutable}"
-                 checkUrl="'${rootURL}/scm/TeamFoundationServerScm/executableCheck?value='+escape(this.value)"/>
-    </f:entry>
-  </f:section>
+
 </j:jelly>
 

--- a/src/main/webapp/tfExecutable.html
+++ b/src/main/webapp/tfExecutable.html
@@ -1,6 +1,0 @@
-<div>
-  <p>
-	If your Team Foundation command line binary exists outside your PATH, specify the absolute 
-	path to the executable. If you just specify "tf", Hudson will try to find tf from the PATH.
-  </p>
-</div>

--- a/src/test/resources/hudson/plugins/tfs/FunctionalTest/agent/hudson.plugins.tfs.TeamFoundationServerScm.xml
+++ b/src/test/resources/hudson/plugins/tfs/FunctionalTest/agent/hudson.plugins.tfs.TeamFoundationServerScm.xml
@@ -1,5 +1,4 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <hudson.plugins.tfs.TeamFoundationServerScm_-DescriptorImpl plugin="tfs@3.2.0">
   <generation>2</generation>
-  <tfExecutable>tf.cmd</tfExecutable>
 </hudson.plugins.tfs.TeamFoundationServerScm_-DescriptorImpl>

--- a/src/test/resources/hudson/plugins/tfs/FunctionalTest/createLabel/hudson.plugins.tfs.TeamFoundationServerScm.xml
+++ b/src/test/resources/hudson/plugins/tfs/FunctionalTest/createLabel/hudson.plugins.tfs.TeamFoundationServerScm.xml
@@ -1,5 +1,4 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <hudson.plugins.tfs.TeamFoundationServerScm_-DescriptorImpl plugin="tfs@3.2.0">
   <generation>2</generation>
-  <tfExecutable>tf.cmd</tfExecutable>
 </hudson.plugins.tfs.TeamFoundationServerScm_-DescriptorImpl>

--- a/src/test/resources/hudson/plugins/tfs/FunctionalTest/newJob/hudson.plugins.tfs.TeamFoundationServerScm.xml
+++ b/src/test/resources/hudson/plugins/tfs/FunctionalTest/newJob/hudson.plugins.tfs.TeamFoundationServerScm.xml
@@ -1,5 +1,4 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <hudson.plugins.tfs.TeamFoundationServerScm_-DescriptorImpl plugin="tfs@3.2.0">
   <generation>2</generation>
-  <tfExecutable>tf.cmd</tfExecutable>
 </hudson.plugins.tfs.TeamFoundationServerScm_-DescriptorImpl>


### PR DESCRIPTION
Now that the plugin no longer needs the TFS command-line-client (CLC), let's remove it from the configuration.