### PR TITLE
More efficient single version history

### DIFF
--- a/src/main/java/hudson/plugins/tfs/model/Project.java
+++ b/src/main/java/hudson/plugins/tfs/model/Project.java
@@ -127,9 +127,9 @@ public class Project {
         return getVCCHistory(fromVersion, toVersion, true, Integer.MAX_VALUE);
     }
     
-    public List<ChangeSet> getDetailedHistory(String singleVersionSpec) {
+    public List<ChangeSet> getDetailedHistory(final String singleVersionSpec) {
         final VersionSpec toVersion = VersionSpec.parseSingleVersionFromSpec(singleVersionSpec, null);
-        return getVCCHistory(null, toVersion, true, Integer.MAX_VALUE);
+        return getVCCHistory(toVersion, toVersion, true, 1);
     }
 
     /**


### PR DESCRIPTION
Originally raised through #53, this pull request includes an integration test that reproduces the issue and a minimal fix to the `getDetailedHistory(String)` method overload.