### PR TITLE
Fix Javadoc errors and enforce Javadoc verification

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,6 +91,19 @@
         </configuration>
       </plugin>
       <plugin>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <version>2.8</version>
+        <executions>
+          <execution>
+            <id>verify-javadoc</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <dependencies>

--- a/src/main/java/hudson/plugins/tfs/ChangeSetWriter.java
+++ b/src/main/java/hudson/plugins/tfs/ChangeSetWriter.java
@@ -24,6 +24,8 @@ public class ChangeSetWriter {
      * Writes the list of change sets to the file
      * @param changeSets list of change sets
      * @param changelogFile file to write change sets to
+     *
+     * @throws IOException If an I/O error occurs
      */
     public void write(List<ChangeSet> changeSets, File changelogFile) throws IOException {
         FileWriter writer = new FileWriter(changelogFile);

--- a/src/main/java/hudson/plugins/tfs/TeamFoundationServerScm.java
+++ b/src/main/java/hudson/plugins/tfs/TeamFoundationServerScm.java
@@ -258,19 +258,14 @@ public class TeamFoundationServerScm extends SCM {
             workspaceVersion = new DateVersionSpec(build.getTimestamp());
         }
         int buildChangeset;
-        try {
-            setWorkspaceChangesetVersion(null);
-            buildChangeset = project.getRemoteChangesetVersion(workspaceVersion);
-            setWorkspaceChangesetVersion(Integer.toString(buildChangeset, 10));
+        setWorkspaceChangesetVersion(null);
+        buildChangeset = project.getRemoteChangesetVersion(workspaceVersion);
+        setWorkspaceChangesetVersion(Integer.toString(buildChangeset, 10));
 
-            // by adding this action, we prevent calcRevisionsFromBuild() from being called
-            build.addAction(new TFSRevisionState(buildChangeset, projectPath));
+        // by adding this action, we prevent calcRevisionsFromBuild() from being called
+        build.addAction(new TFSRevisionState(buildChangeset, projectPath));
 
-            return buildChangeset;
-        } catch (ParseException pe) {
-            listener.fatalError(pe.getMessage());
-            throw new AbortException();
-        }
+        return buildChangeset;
     }
 
     void setWorkspaceChangesetVersion(String workspaceChangesetVersion) {

--- a/src/main/java/hudson/plugins/tfs/TeamFoundationServerScm.java
+++ b/src/main/java/hudson/plugins/tfs/TeamFoundationServerScm.java
@@ -289,9 +289,6 @@ public class TeamFoundationServerScm extends SCM {
                             lastRun.getTimestamp(), 
                             Calendar.getInstance()
                         ).size() > 0);
-            } catch (ParseException pe) {
-                listener.fatalError(pe.getMessage());
-                throw new AbortException();
             } finally {
                 server.close();
             }
@@ -516,9 +513,6 @@ public class TeamFoundationServerScm extends SCM {
                     ? Change.NONE
                     : Change.SIGNIFICANT;
             return new PollingResult(tfsBaseline, tfsRemote, change);
-        } catch (ParseException pe) {
-            listener.fatalError(pe.getMessage());
-            throw new AbortException();
         } finally {
             server.close();
         }

--- a/src/main/java/hudson/plugins/tfs/browsers/TeamFoundationServerRepositoryBrowser.java
+++ b/src/main/java/hudson/plugins/tfs/browsers/TeamFoundationServerRepositoryBrowser.java
@@ -17,6 +17,8 @@ public abstract class TeamFoundationServerRepositoryBrowser extends RepositoryBr
      * in the specified revision of {@link ChangeSet.Item} to its previous version.
      *
      * @return null if the browser doesn't have any URL for diff.
+     *
+     * @throws IOException If an I/O error occurs
      */
     public abstract URL getDiffLink(ChangeSet.Item item) throws IOException;
 
@@ -24,6 +26,8 @@ public abstract class TeamFoundationServerRepositoryBrowser extends RepositoryBr
      * Determines the link to a single file under TFS.
      *
      * @return null if the browser doesn't have any suitable URL.
+     *
+     * @throws IOException If an I/O error occurs
      */
     public abstract URL getFileLink(ChangeSet.Item item) throws IOException;
     

--- a/src/main/java/hudson/plugins/tfs/browsers/TeamFoundationServerRepositoryBrowser.java
+++ b/src/main/java/hudson/plugins/tfs/browsers/TeamFoundationServerRepositoryBrowser.java
@@ -16,6 +16,8 @@ public abstract class TeamFoundationServerRepositoryBrowser extends RepositoryBr
      * Determines the link to the diff between the version
      * in the specified revision of {@link ChangeSet.Item} to its previous version.
      *
+     * @param item the item for which a link to differences will be generated.
+     *
      * @return null if the browser doesn't have any URL for diff.
      *
      * @throws IOException If an I/O error occurs
@@ -24,6 +26,8 @@ public abstract class TeamFoundationServerRepositoryBrowser extends RepositoryBr
 
     /**
      * Determines the link to a single file under TFS.
+     *
+     * @param item the item for which a link to differences will be generated.
      *
      * @return null if the browser doesn't have any suitable URL.
      *

--- a/src/main/java/hudson/plugins/tfs/model/Project.java
+++ b/src/main/java/hudson/plugins/tfs/model/Project.java
@@ -121,7 +121,7 @@ public class Project {
      * @param toTimestamp the timestamp to get history to
      * @return a list of change sets
      */
-    public List<ChangeSet> getDetailedHistory(Calendar fromTimestamp, Calendar toTimestamp) throws IOException, InterruptedException, ParseException {
+    public List<ChangeSet> getDetailedHistory(Calendar fromTimestamp, Calendar toTimestamp) {
         final DateVersionSpec fromVersion = new DateVersionSpec(fromTimestamp);
         final DateVersionSpec toVersion = new DateVersionSpec(toTimestamp);
         return getVCCHistory(fromVersion, toVersion, true, Integer.MAX_VALUE);
@@ -138,7 +138,7 @@ public class Project {
      * @param toTimestamp the timestamp to get history to
      * @return a list of change sets
      */
-    public List<ChangeSet> getBriefHistory(Calendar fromTimestamp, Calendar toTimestamp) throws IOException, InterruptedException, ParseException {
+    public List<ChangeSet> getBriefHistory(Calendar fromTimestamp, Calendar toTimestamp) {
         final DateVersionSpec fromVersion = new DateVersionSpec(fromTimestamp);
         final DateVersionSpec toVersion = new DateVersionSpec(toTimestamp);
         return getVCCHistory(fromVersion, toVersion, false, Integer.MAX_VALUE);
@@ -150,7 +150,7 @@ public class Project {
      * @param toTimestamp the timestamp to get history to
      * @return a list of change sets
      */
-    public List<ChangeSet> getBriefHistory(int fromChangeset, Calendar toTimestamp) throws IOException, InterruptedException, ParseException {
+    public List<ChangeSet> getBriefHistory(int fromChangeset, Calendar toTimestamp) {
         final ChangesetVersionSpec fromVersion = new ChangesetVersionSpec(fromChangeset);
         final VersionSpec toVersion = new DateVersionSpec(toTimestamp);
         return getVCCHistory(fromVersion, toVersion, false, Integer.MAX_VALUE);
@@ -160,7 +160,7 @@ public class Project {
      * Returns the latest changeset at the project's path.
      * @return the {@link ChangeSet} instance representing the last entry in the history for the path
      */
-    public ChangeSet getLatestChangeset() throws IOException, InterruptedException, ParseException {
+    public ChangeSet getLatestChangeset() {
         final List<ChangeSet> changeSets = getVCCHistory(LatestVersionSpec.INSTANCE, null, false, 1);
         final ChangeSet result = changeSets.size() > 0 ? changeSets.get(0) : null;
         return result;
@@ -171,7 +171,7 @@ public class Project {
      * @param localPath the local path to get all files into
      * @param versionSpec the version spec to use when getting the files
      */
-    public void getFiles(String localPath, String versionSpec) throws IOException, InterruptedException {
+    public void getFiles(String localPath, String versionSpec) {
         GetFilesToWorkFolderCommand command = new GetFilesToWorkFolderCommand(server, localPath, versionSpec);
         server.execute(command.getCallable());
     }
@@ -183,14 +183,12 @@ public class Project {
      * @param versionSpec a version specification to convert to a changeset number
      * @return changeset version for specified remote path
      */
-    public int getRemoteChangesetVersion(final String remotePath, final VersionSpec versionSpec)
-            throws IOException, InterruptedException, ParseException {
+    public int getRemoteChangesetVersion(final String remotePath, final VersionSpec versionSpec) {
         RemoteChangesetVersionCommand command = new RemoteChangesetVersionCommand(server, remotePath, versionSpec);
         return extractChangesetNumber(command);
     }
 
-    int extractChangesetNumber(final RemoteChangesetVersionCommand command)
-            throws IOException, InterruptedException, ParseException {
+    int extractChangesetNumber(final RemoteChangesetVersionCommand command) {
         final Integer changeSet = server.execute(command.getCallable());
         final int result = changeSet;
         return result;
@@ -202,8 +200,7 @@ public class Project {
      * @param versionSpec a version specification to convert to a changeset number
      * @return changeset version for the project's remote path
      */
-    public int getRemoteChangesetVersion(final VersionSpec versionSpec)
-            throws IOException, InterruptedException, ParseException {
+    public int getRemoteChangesetVersion(final VersionSpec versionSpec) {
         return getRemoteChangesetVersion(projectPath, versionSpec);
     }
 

--- a/src/main/java/hudson/plugins/tfs/model/Project.java
+++ b/src/main/java/hudson/plugins/tfs/model/Project.java
@@ -73,7 +73,8 @@ public class Project {
      * @param fromVersion the version to get the history from
      * @param toVersion the version to get the history to
      * @param includeFileDetails whether or not to include details of modified items
-     * @param maxCount the maximum number of changes to return (pass Integer.MAX_VALUE for all available values). Must be > 0.
+     * @param maxCount the maximum number of changes to return (pass Integer.MAX_VALUE for all available values).
+     *                 {@literal Must be > 0.}
      * @return a list of change sets
      */
     public List<ChangeSet> getVCCHistory(VersionSpec fromVersion, VersionSpec toVersion, boolean includeFileDetails, int maxCount) {

--- a/src/main/java/hudson/plugins/tfs/model/UserLookup.java
+++ b/src/main/java/hudson/plugins/tfs/model/UserLookup.java
@@ -5,6 +5,8 @@ import hudson.model.User;
 public interface UserLookup {
     /**
      * @param accountName Windows NT account name: domain\alias.
+     *
+     * @return the Jenkins {@link User} object associated with the account name
      */
     User find(String accountName);
 }

--- a/src/main/java/hudson/plugins/tfs/model/Workspaces.java
+++ b/src/main/java/hudson/plugins/tfs/model/Workspaces.java
@@ -28,7 +28,7 @@ public class Workspaces implements ListWorkspacesCommand.WorkspaceFactory {
      * Get the list of workspaces from the server
      * @return the list of workspaces at the server
      */
-    private List<Workspace> getListFromServer() throws IOException, InterruptedException {
+    private List<Workspace> getListFromServer() {
         ListWorkspacesCommand command = new ListWorkspacesCommand(server);
         final List<Workspace> result = server.execute(command.getCallable());
         return result;
@@ -37,7 +37,7 @@ public class Workspaces implements ListWorkspacesCommand.WorkspaceFactory {
     /**
      * Populate the map field with workspaces from the server once.
      */
-    private void populateMapFromServer() throws IOException, InterruptedException {
+    private void populateMapFromServer() {
         if (!mapIsPopulatedFromServer) {
             for (Workspace workspace : getListFromServer()) {
                 workspaces.put(workspace.getName(), workspace);
@@ -51,7 +51,7 @@ public class Workspaces implements ListWorkspacesCommand.WorkspaceFactory {
      * @param workspaceName the name of the workspace name
      * @return the workspace with the specified name; null if it wasnt found
      */
-    public Workspace getWorkspace(String workspaceName) throws IOException, InterruptedException {
+    public Workspace getWorkspace(String workspaceName) {
         if (!workspaces.containsKey(workspaceName)) {
             populateMapFromServer();
         }
@@ -63,7 +63,7 @@ public class Workspaces implements ListWorkspacesCommand.WorkspaceFactory {
      * @param workspaceName the name of the workspace 
      * @return true if the workspace exists on server; false otherwise
      */
-    public boolean exists(String workspaceName) throws IOException, InterruptedException {
+    public boolean exists(String workspaceName) {
         if (!workspaces.containsKey(workspaceName)) {
             populateMapFromServer();
         }
@@ -75,7 +75,7 @@ public class Workspaces implements ListWorkspacesCommand.WorkspaceFactory {
      * @param workspace the workspace 
      * @return true if the workspace exists on server; false otherwise
      */
-    public boolean exists(Workspace workspace) throws IOException, InterruptedException {
+    public boolean exists(Workspace workspace) {
         return exists(workspace.getName());
     }
 
@@ -84,7 +84,7 @@ public class Workspaces implements ListWorkspacesCommand.WorkspaceFactory {
      * @param workspaceName the name of the new workspace
      * @return a workspace
      */
-    public Workspace newWorkspace(final String workspaceName, final String serverPath, final String localPath) throws IOException, InterruptedException {
+    public Workspace newWorkspace(final String workspaceName, final String serverPath, final String localPath) {
         NewWorkspaceCommand command = new NewWorkspaceCommand(server, workspaceName, serverPath, localPath);
         server.execute(command.getCallable());
         Workspace workspace = new Workspace(workspaceName);
@@ -96,7 +96,7 @@ public class Workspaces implements ListWorkspacesCommand.WorkspaceFactory {
      * Deletes the workspace from the server
      * @param workspace the workspace to delete
      */
-    public void deleteWorkspace(Workspace workspace) throws IOException, InterruptedException {
+    public void deleteWorkspace(Workspace workspace) {
         DeleteWorkspaceCommand command = new DeleteWorkspaceCommand(server, workspace.getName());
         workspaces.remove(workspace.getName());
         server.execute(command.getCallable());

--- a/src/main/java/hudson/plugins/tfs/model/Workspaces.java
+++ b/src/main/java/hudson/plugins/tfs/model/Workspaces.java
@@ -82,6 +82,8 @@ public class Workspaces implements ListWorkspacesCommand.WorkspaceFactory {
     /**
      * Create workspace on server, map it and return a workspace object with the specified name
      * @param workspaceName the name of the new workspace
+     * @param serverPath the path in TFVC to map
+     * @param localPath the path in the local filesystem to map
      * @return a workspace
      */
     public Workspace newWorkspace(final String workspaceName, final String serverPath, final String localPath) {

--- a/src/main/java/hudson/plugins/tfs/util/BuildVariableResolver.java
+++ b/src/main/java/hudson/plugins/tfs/util/BuildVariableResolver.java
@@ -75,6 +75,7 @@ public class BuildVariableResolver implements VariableResolver<String> {
      * This constructor should not be called in a method that may be called by
      * {@link AbstractBuild#getEnvVars()}.  
      * @param build used to get the project and the build env vars
+     * @param computer used to retrieve the name of the remote computer or of the account under which Jenkins runs
      *
      * @throws IOException If an I/O error occurs
      * @throws InterruptedException

--- a/src/main/java/hudson/plugins/tfs/util/BuildVariableResolver.java
+++ b/src/main/java/hudson/plugins/tfs/util/BuildVariableResolver.java
@@ -75,6 +75,10 @@ public class BuildVariableResolver implements VariableResolver<String> {
      * This constructor should not be called in a method that may be called by
      * {@link AbstractBuild#getEnvVars()}.  
      * @param build used to get the project and the build env vars
+     *
+     * @throws IOException If an I/O error occurs
+     * @throws InterruptedException
+     *      If the current thread is interrupted while waiting for the completion.
      */
     public BuildVariableResolver(final AbstractBuild<?, ?> build, final Computer computer)
             throws IOException, InterruptedException {

--- a/src/main/java/hudson/plugins/tfs/util/TextTableParser.java
+++ b/src/main/java/hudson/plugins/tfs/util/TextTableParser.java
@@ -84,7 +84,7 @@ public class TextTableParser {
      * Returns the number of columns
      * @return the number of columns
      */
-    public int getColumnCount() throws IOException {
+    public int getColumnCount() {
         return columns.size();
     }
 
@@ -93,7 +93,7 @@ public class TextTableParser {
      * @param index the column index
      * @return the value in the specified column; null if there is no value (the column is optional)
      */
-    public String getColumn(int index) throws IOException {
+    public String getColumn(int index) {
         if (currentLine == null) {
             throw new IllegalStateException("There is no active row.");
         }
@@ -113,7 +113,7 @@ public class TextTableParser {
     /**
      * Move to the next row
      * @return true, if there was a next row; false, if there is no next row.
-     * @throws IOException
+     * @throws IOException If an I/O error occurs
      */
     public boolean nextRow() throws IOException {
         do {


### PR DESCRIPTION
Previously Javadoc code documentation comments would only be verified during release; now it's done as part of the `verify` phase.

Fixed all warnings/errors reported by `mvn javadoc:jar`, which is a faster way to check what the Javadoc compiler has to say about the code. (it runs in less than 5 seconds)