### PR TITLE
Improve JavaDoc verification

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
             <id>verify-javadoc</id>
             <phase>verify</phase>
             <goals>
-              <goal>jar</goal>
+              <goal>javadoc</goal>
             </goals>
           </execution>
         </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
       </plugin>
       <plugin>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.8</version>
+        <version>${maven-javadoc-plugin.version}</version>
         <executions>
           <execution>
             <id>verify-javadoc</id>


### PR DESCRIPTION
The `jar` goal meant TWO copies of `tfs-javadoc.jar` would be uploaded to the `releases` repository upon release, whereas we don't even need the JAR built during `verify`, we just want to find any errors & warnings.

Manual testing
--------------
Temporarily re-introduced some JavaDoc errors in the code, then ran `mvn verify` to confirm the build would fail due to said errors.  Whether this fixes the release performance will be confirmed next release.

Mission accomplished!