### PR TITLE
Change minimum run time requirement to Java6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.448</version>
+    <version>1.520</version>
   </parent>
 
   <artifactId>tfs</artifactId>
@@ -118,25 +118,25 @@
         </configuration>
       </plugin>
       <plugin>
-	<groupId>org.codehaus.mojo</groupId>
-	<artifactId>animal-sniffer-maven-plugin</artifactId>
-	<version>1.7</version>
-	<configuration>
-	  <signature>
-	    <groupId>org.codehaus.mojo.signature</groupId>
-	    <artifactId>java15</artifactId>
-	    <version>1.0</version>
-	  </signature>
-	</configuration>
-	<executions>
-	  <execution>
-	    <id>java.1.5.check</id>
-	    <phase>verify</phase>
-	    <goals>
-	      <goal>check</goal>
-	    </goals>
-	  </execution>
-	</executions>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>animal-sniffer-maven-plugin</artifactId>
+        <version>1.7</version>
+        <configuration>
+        <signature>
+            <groupId>org.codehaus.mojo.signature</groupId>
+            <artifactId>java16</artifactId>
+            <version>1.0</version>
+          </signature>
+        </configuration>
+        <executions>
+          <execution>
+            <id>java.1.6.check</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
 
     </plugins>
@@ -193,26 +193,26 @@
     <dependency>
       <groupId>org.jenkins-ci.main</groupId>
       <artifactId>jenkins-war</artifactId>
-      <version>1.448</version>
+      <version>1.520</version>
       <type>war</type>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.main</groupId>
       <artifactId>jenkins-core</artifactId>
-      <version>1.448</version>
+      <version>1.520</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.main</groupId>
       <artifactId>jenkins-test-harness</artifactId>
-      <version>1.448</version>
+      <version>1.520</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.main</groupId>
       <artifactId>ui-samples-plugin</artifactId>
-      <version>1.448</version>
+      <version>1.520</version>
       <scope>test</scope>
     </dependency>
 
@@ -240,6 +240,12 @@
         <artifactId>mockito-core</artifactId>
         <version>1.7</version> 
         <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>mailer</artifactId>
+      <version>1.5</version>
+      <type>jar</type>
     </dependency>
   </dependencies>
 

--- a/src/test/java/hudson/plugins/tfs/FunctionalTest.java
+++ b/src/test/java/hudson/plugins/tfs/FunctionalTest.java
@@ -109,7 +109,7 @@ public class FunctionalTest {
         }
 
         @Override
-        protected void after() {
+        protected void after() throws Exception {
             if (Functions.isWindows()) {
                 purgeSlaves();
             }

--- a/src/test/java/hudson/plugins/tfs/TeamFoundationServerScmTest.java
+++ b/src/test/java/hudson/plugins/tfs/TeamFoundationServerScmTest.java
@@ -29,14 +29,19 @@ import hudson.plugins.tfs.model.Project;
 import hudson.util.Secret;
 import hudson.util.SecretOverride;
 import hudson.util.XStream2;
+import jenkins.model.Jenkins;
 import org.junit.After;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
 
 
 @SuppressWarnings("unchecked")
 public class TeamFoundationServerScmTest {
 
+    @Rule public JenkinsRule j = new JenkinsRule();
+        
     private FilePath workspace;
 
     @After public void tearDown() throws Exception {
@@ -52,46 +57,41 @@ public class TeamFoundationServerScmTest {
      This test makes sure a job can be upgraded without loss of the password.
      */
     @Test public void upgradeFromScrambledPassword() {
+        final String xmlString =
+                "<scm class='hudson.plugins.tfs.TeamFoundationServerScm' plugin='tfs@3.1.1'>\n" +
+                "    <serverUrl>http://example.tfs.server.invalid:8080/tfs</serverUrl>\n" +
+                "    <projectPath>$/example/path</projectPath>\n" +
+                "    <localPath>.</localPath>\n" +
+                "    <workspaceName>Hudson-${JOB_NAME}-${NODE_NAME}</workspaceName>\n" +
+                "    <userPassword>ZXhhbXBsZVBhc3N3b3Jk</userPassword>\n" +
+                "    <userName>example\\tfsbuilder</userName>\n" +
+                "    <useUpdate>false</useUpdate>\n" +
+                "</scm>";
+        final XStream serializer = new XStream2();
+
+        final TeamFoundationServerScm tfsScmObject = (TeamFoundationServerScm) serializer.fromXML(xmlString);
+
+        final String actual = tfsScmObject.getUserPassword();
+        assertEquals("examplePassword", actual);
+        assertEquals("examplePassword", Secret.toString(tfsScmObject.getPassword()));
+
+        final String upgradedXml = serializer.toXML(tfsScmObject);
+
+        final TeamFoundationServerScm tfsScmObject2 = (TeamFoundationServerScm) serializer.fromXML(upgradedXml);
+        final String actual2 = tfsScmObject2.getUserPassword();
+        assertEquals("examplePassword", actual2);
+        assertEquals("examplePassword", Secret.toString(tfsScmObject.getPassword()));
+    }
+    
+    // jenkins changed implementation of hudson.util.Secret in a9aff088f327278a8873aef47fa8f80d3c5932fd
+    @Test public void decryptPasswordFromPre1498() {
         SecretOverride secretOverride = null;
         try {
             secretOverride = new SecretOverride();
-            final String xmlString =
-                    "<scm class='hudson.plugins.tfs.TeamFoundationServerScm' plugin='tfs@3.1.1'>\n" +
-                    "    <serverUrl>http://example.tfs.server.invalid:8080/tfs</serverUrl>\n" +
-                    "    <projectPath>$/example/path</projectPath>\n" +
-                    "    <localPath>.</localPath>\n" +
-                    "    <workspaceName>Hudson-${JOB_NAME}-${NODE_NAME}</workspaceName>\n" +
-                    "    <userPassword>ZXhhbXBsZVBhc3N3b3Jk</userPassword>\n" +
-                    "    <userName>example\\tfsbuilder</userName>\n" +
-                    "    <useUpdate>false</useUpdate>\n" +
-                    "</scm>";
-            final XStream serializer = new XStream2();
-
-            final TeamFoundationServerScm tfsScmObject = (TeamFoundationServerScm) serializer.fromXML(xmlString);
-
-            final String actual = tfsScmObject.getUserPassword();
+            
+            Secret secret = Secret.decrypt( "zs+99bxCGlcSxR3Umnj0q0OjYXVSiB+qLzS0ZjuHz2M=" );
+            String actual = secret.getPlainText();
             assertEquals("examplePassword", actual);
-            assertEquals("examplePassword", Secret.toString(tfsScmObject.getPassword()));
-
-            final String expectedUpgradedXml =
-                    "<hudson.plugins.tfs.TeamFoundationServerScm>\n" +
-                            "  <serverUrl>http://example.tfs.server.invalid:8080/tfs</serverUrl>\n" +
-                            "  <projectPath>$/example/path</projectPath>\n" +
-                            "  <localPath>.</localPath>\n" +
-                            "  <workspaceName>Hudson-${JOB_NAME}-${NODE_NAME}</workspaceName>\n" +
-                            "  <password>zs+99bxCGlcSxR3Umnj0q0OjYXVSiB+qLzS0ZjuHz2M=</password>\n" +
-                            "  <userName>example\\tfsbuilder</userName>\n" +
-                            "  <useUpdate>false</useUpdate>\n" +
-                            "</hudson.plugins.tfs.TeamFoundationServerScm>";
-
-            final String actualUpgradedXml = serializer.toXML(tfsScmObject);
-
-            assertEquals(expectedUpgradedXml, actualUpgradedXml);
-
-            final TeamFoundationServerScm tfsScmObject2 = (TeamFoundationServerScm) serializer.fromXML(actualUpgradedXml);
-            final String actual2 = tfsScmObject2.getUserPassword();
-            assertEquals("examplePassword", actual2);
-            assertEquals("examplePassword", Secret.toString(tfsScmObject.getPassword()));
         }
         finally {
             if (secretOverride != null) {


### PR DESCRIPTION
Title speaks for itself i guess. jenkins-core started using java6 mid 2013 and java7 mid 2015.
http://jenkins-ci.org/content/good-bye-java6