### PR TITLE
Fix VSTS workspace management

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -219,9 +219,9 @@
     <dependency>
       <groupId>com.microsoft.tfs.sdk</groupId>
       <artifactId>com.microsoft.tfs.sdk</artifactId>
-      <version>14.0.1</version>
+      <version>14.0.2_jenkins-tfs-plugin</version>
       <scope>system</scope>
-      <systemPath>${project.basedir}/src/main/webapp/WEB-INF/lib/com.microsoft.tfs.sdk-14.0.1.jar</systemPath>
+      <systemPath>${project.basedir}/src/main/webapp/WEB-INF/lib/com.microsoft.tfs.sdk-14.0.2_jenkins-tfs-plugin.jar</systemPath>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/src/main/webapp/WEB-INF/lib/redist.txt
+++ b/src/main/webapp/WEB-INF/lib/redist.txt
@@ -8,7 +8,7 @@ Software License Terms.
 
 ThirdPartyNotices.html
 
-lib/com.microsoft.tfs.sdk-14.0.1.jar
+lib/com.microsoft.tfs.sdk-14.0.2.jar
 
 native/macosx/libnative_misc.jnilib
 native/macosx/libnative_keychain.jnilib

--- a/src/test/java/hudson/plugins/tfs/EndToEndTfs.java
+++ b/src/test/java/hudson/plugins/tfs/EndToEndTfs.java
@@ -5,6 +5,7 @@ import com.microsoft.tfs.core.clients.versioncontrol.PendChangesOptions;
 import com.microsoft.tfs.core.clients.versioncontrol.VersionControlConstants;
 import com.microsoft.tfs.core.clients.versioncontrol.WorkspaceLocation;
 import com.microsoft.tfs.core.clients.versioncontrol.WorkspaceOptions;
+import com.microsoft.tfs.core.clients.versioncontrol.WorkspacePermissions;
 import com.microsoft.tfs.core.clients.versioncontrol.soapextensions.LockLevel;
 import com.microsoft.tfs.core.clients.versioncontrol.soapextensions.PendingChange;
 import com.microsoft.tfs.core.clients.versioncontrol.soapextensions.PendingSet;
@@ -267,8 +268,8 @@ public @interface EndToEndTfs {
         }
 
         static void deleteWorkspace(final MockableVersionControlClient vcc, final String workspaceName) {
-            final Workspace workspace = vcc.getLocalWorkspace(workspaceName, VersionControlConstants.AUTHENTICATED_USER);
-            if (workspace != null) {
+            final Workspace[] workspaces = vcc.queryWorkspaces(workspaceName, null, /* TODO: computer */null, WorkspacePermissions.NONE_OR_NOT_SUPPORTED);
+            for (final Workspace workspace : workspaces) {
                 for (WorkingFolder workingFolder : workspace.getFolders()) {
                     final String localItem = workingFolder.getLocalItem();
                     if (localItem != null) {


### PR DESCRIPTION
CI builds started failing integration tests with:

```
java.lang.IllegalArgumentException: Owners must be the same: jenkins-tfs-plugin@outlook.com vs. Windows Live ID\jenkins-tfs-plugin@outlook.com
	at com.microsoft.tfs.util.Check.throwForFalse(Check.java:173)
	at com.microsoft.tfs.util.Check.isTrue(Check.java:115)
	at com.microsoft.tfs.core.clients.versioncontrol.workspacecache.WorkspaceInfo.update(WorkspaceInfo.java:672)
	at com.microsoft.tfs.core.clients.versioncontrol.workspacecache.internal.InternalCache.merge(InternalCache.java:865)
	at com.microsoft.tfs.core.clients.versioncontrol.workspacecache.internal.InternalCache.save(InternalCache.java:646)
	at com.microsoft.tfs.core.clients.versioncontrol.workspacecache.internal.InternalCacheLoader.saveConfigIfDirty(InternalCacheLoader.java:210)
	at com.microsoft.tfs.core.clients.versioncontrol.Workstation.saveConfigIfDirty(Workstation.java:1371)
	at com.microsoft.tfs.core.clients.versioncontrol.VersionControlClient.createWorkspace(VersionControlClient.java:1184)
```

...and trying to diagnose this, I noticed that the integration test wasn't able to delete its workspace when connecting to Visual Studio Team Services (VSTS), apparently due to a mismatch in owner name/alias.  VSTS appears to be sending a value for owner name that's different from what it used to send previously.

The change to `EndToEndTfs.java` (3c70147) improves the ability to find and delete workspaces, bringing it on par with the production implementation.

As for the `IllegalArgumentException` noted above, that was traced to a defect in the TFS SDK for Java, whereby owner aliases should be consulted when checking whether two Workspace instances are the same.  Because version 14.0.2 of TEE had recently been released (and another release wasn't planned soon), a special branch was created off of 14.0.2 and the `WorkspaceInfo#update()` method fix was applied.  This is what is included in 0dc7fbd.