### PR TITLE
[JENKINS-16207] Repo browser links fixed

### DIFF
--- a/src/main/java/hudson/plugins/tfs/browsers/TeamSystemWebAccessBrowser.java
+++ b/src/main/java/hudson/plugins/tfs/browsers/TeamSystemWebAccessBrowser.java
@@ -90,10 +90,6 @@ public class TeamSystemWebAccessBrowser extends TeamFoundationServerRepositoryBr
         }
         return createChangeSetItemLink(item, "compare");
     }
-    
-    private String getPreviousChangeSetVersion(ChangeSet changeset) throws NumberFormatException {
-        return Integer.toString(Integer.parseInt(changeset.getVersion()) - 1);
-    }
 
     @Extension
     public static final class DescriptorImpl extends Descriptor<RepositoryBrowser<?>> {

--- a/src/main/java/hudson/plugins/tfs/browsers/TeamSystemWebAccessBrowser.java
+++ b/src/main/java/hudson/plugins/tfs/browsers/TeamSystemWebAccessBrowser.java
@@ -70,6 +70,7 @@ public class TeamSystemWebAccessBrowser extends TeamFoundationServerRepositoryBr
         final URL changeSetUrl = getChangeSetLink(changeSet);
         final QueryString qs = new QueryString();
         qs.put("path", item.getPath());
+        qs.put("version", changeSet.getVersion());
         qs.put("_a", action);
         return new URL(changeSetUrl, "#" + qs.toString());
     }

--- a/src/main/java/hudson/plugins/tfs/browsers/TeamSystemWebAccessBrowser.java
+++ b/src/main/java/hudson/plugins/tfs/browsers/TeamSystemWebAccessBrowser.java
@@ -46,7 +46,7 @@ public class TeamSystemWebAccessBrowser extends TeamFoundationServerRepositoryBr
     private String getBaseUrlString(ChangeSet changeSet) throws MalformedURLException {
         String baseUrl;
         if (url != null) {
-            baseUrl = url;
+            baseUrl = normalizeToEndWithSlash(new URL(url)).toString();
         } else {
             String scmUrl = getServerConfiguration(changeSet);
             baseUrl = normalizeToEndWithSlash(new URL(scmUrl)).toString();

--- a/src/main/java/hudson/plugins/tfs/browsers/TeamSystemWebAccessBrowser.java
+++ b/src/main/java/hudson/plugins/tfs/browsers/TeamSystemWebAccessBrowser.java
@@ -6,6 +6,7 @@ import hudson.model.AbstractProject;
 import hudson.model.Descriptor;
 import hudson.plugins.tfs.TeamFoundationServerScm;
 import hudson.plugins.tfs.model.ChangeSet;
+import hudson.plugins.tfs.util.QueryString;
 import hudson.scm.EditType;
 import hudson.scm.RepositoryBrowser;
 import hudson.scm.SCM;
@@ -45,46 +46,50 @@ public class TeamSystemWebAccessBrowser extends TeamFoundationServerRepositoryBr
     private String getBaseUrlString(ChangeSet changeSet) throws MalformedURLException {
         String baseUrl;
         if (url != null) {
-            baseUrl = DescriptorImpl.getBaseUrl(url);
+            baseUrl = url;
         } else {
-            baseUrl = String.format("%s/", getServerConfiguration(changeSet)); 
+            baseUrl = getServerConfiguration(changeSet);
         }
         return baseUrl;
     }
 
-    /*
-     * http://tswaserver:8090/cs.aspx?cs=99
+    /**
+     * Gets the link to a specific change set.
      */
     @Override
-    public URL getChangeSetLink(ChangeSet changeSet) throws IOException {
-        return new URL(String.format("%scs.aspx?cs=%s", getBaseUrlString(changeSet), changeSet.getVersion()));
+    public URL getChangeSetLink(final ChangeSet changeSet) throws IOException {
+        final String baseUrlString = getBaseUrlString(changeSet);
+        final URL baseUrl = new URL(baseUrlString);
+        final QueryString qs = new QueryString();
+        qs.put("id", changeSet.getVersion());
+        final URL changeSetUrl = new URL(baseUrl, "_versionControl/changeset?" + qs.toString());
+        return changeSetUrl;
     }
 
-    /*
-     * http://tswaserver:8090/view.aspx?path=$/Project/Folder/file.cs&cs=99
-     */
-    public URL getFileLink(ChangeSet.Item item) throws IOException {
-        return new URL(String.format("%sview.aspx?path=%s&cs=%s", getBaseUrlString(item.getParent()), item.getPath(), item.getParent().getVersion()));
+    URL createChangeSetItemLink(final ChangeSet.Item item, final String action) throws IOException {
+        final ChangeSet changeSet = item.getParent();
+        final URL changeSetUrl = getChangeSetLink(changeSet);
+        final QueryString qs = new QueryString();
+        qs.put("path", item.getPath());
+        qs.put("_a", action);
+        return new URL(changeSetUrl, "#" + qs.toString());
     }
 
-    /*
-     * http://tswaserver:8090/diff.aspx?opath=$/Project/Folder/file.cs&ocs=99&mpath=$/Project/Folder/file.cs&mcs=98
+    /**
+     * Gets the link for a specific file in a change set.
      */
-    public URL getDiffLink(ChangeSet.Item item) throws IOException {
-        ChangeSet parent = item.getParent();
+    public URL getFileLink(final ChangeSet.Item item) throws IOException {
+        return createChangeSetItemLink(item, "contents");
+    }
+
+    /**
+     * Gets the link to compare a specific file in a change set.
+     */
+    public URL getDiffLink(final ChangeSet.Item item) throws IOException {
         if (item.getEditType() != EditType.EDIT) {
             return null;
         }
-        try {
-            return new URL(String.format("%sdiff.aspx?opath=%s&ocs=%s&mpath=%s&mcs=%s", 
-                    getBaseUrlString(parent), 
-                    item.getPath(),
-                    getPreviousChangeSetVersion(parent), 
-                    item.getPath(),
-                    parent.getVersion()));
-        } catch (NumberFormatException nfe) {
-            return null;
-        }
+        return createChangeSetItemLink(item, "compare");
     }
     
     private String getPreviousChangeSetVersion(ChangeSet changeset) throws NumberFormatException {

--- a/src/main/java/hudson/plugins/tfs/browsers/TeamSystemWebAccessBrowser.java
+++ b/src/main/java/hudson/plugins/tfs/browsers/TeamSystemWebAccessBrowser.java
@@ -44,13 +44,11 @@ public class TeamSystemWebAccessBrowser extends TeamFoundationServerRepositoryBr
     }
 
     private String getBaseUrlString(ChangeSet changeSet) throws MalformedURLException {
-        String baseUrl;
-        if (url != null) {
-            baseUrl = normalizeToEndWithSlash(new URL(url)).toString();
-        } else {
-            String scmUrl = getServerConfiguration(changeSet);
-            baseUrl = normalizeToEndWithSlash(new URL(scmUrl)).toString();
+        String baseUrl = url;
+        if (baseUrl == null) {
+            baseUrl = getServerConfiguration(changeSet);
         }
+        baseUrl = normalizeToEndWithSlash(new URL(baseUrl)).toString();
         return baseUrl;
     }
 

--- a/src/main/java/hudson/plugins/tfs/browsers/TeamSystemWebAccessBrowser.java
+++ b/src/main/java/hudson/plugins/tfs/browsers/TeamSystemWebAccessBrowser.java
@@ -48,7 +48,8 @@ public class TeamSystemWebAccessBrowser extends TeamFoundationServerRepositoryBr
         if (url != null) {
             baseUrl = url;
         } else {
-            baseUrl = getServerConfiguration(changeSet);
+            String scmUrl = getServerConfiguration(changeSet);
+            baseUrl = normalizeToEndWithSlash(new URL(scmUrl)).toString();
         }
         return baseUrl;
     }

--- a/src/main/java/hudson/plugins/tfs/browsers/TeamSystemWebAccessBrowser.java
+++ b/src/main/java/hudson/plugins/tfs/browsers/TeamSystemWebAccessBrowser.java
@@ -106,10 +106,5 @@ public class TeamSystemWebAccessBrowser extends TeamFoundationServerRepositoryBr
         public String getDisplayName() {
             return "Team System Web Access";
         }
-        
-        public static String getBaseUrl(String urlExample) throws MalformedURLException {
-        	URL url = new URL(urlExample);
-        	return new URL(url.getProtocol(), url.getHost(), url.getPort(), String.format("/%s", FilenameUtils.getPath(url.getPath()))).toString();
-        }
     }
 }

--- a/src/main/java/hudson/plugins/tfs/util/License.txt
+++ b/src/main/java/hudson/plugins/tfs/util/License.txt
@@ -1,0 +1,25 @@
+Git Credential Manager for Mac and Linux
+
+Copyright (c) Microsoft Corporation
+
+All rights reserved.
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/src/main/java/hudson/plugins/tfs/util/QueryString.java
+++ b/src/main/java/hudson/plugins/tfs/util/QueryString.java
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See sibling License.txt file
+
+package hudson.plugins.tfs.util;
+
+import java.util.LinkedHashMap;
+
+public class QueryString extends LinkedHashMap<String, String> {
+    @Override
+    public String toString() {
+        return UriHelper.serializeParameters(this);
+    }
+}

--- a/src/main/java/hudson/plugins/tfs/util/UriHelper.java
+++ b/src/main/java/hudson/plugins/tfs/util/UriHelper.java
@@ -1,0 +1,65 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See sibling License.txt file
+
+package hudson.plugins.tfs.util;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URLEncoder;
+import java.util.Iterator;
+import java.util.Map;
+
+public class UriHelper {
+    public static final String UTF_8 = "UTF-8";
+
+    public static boolean isWellFormedUriString(final String uriString) {
+        try {
+            new URI(uriString);
+            return true;
+        }
+        catch (final URISyntaxException ignored) {
+            return false;
+        }
+    }
+
+    public static String serializeParameters(final Map<String, String> parameters) {
+        try {
+            final StringBuilder sb = new StringBuilder();
+            final Iterator<Map.Entry<String, String>> iterator = parameters.entrySet().iterator();
+            if (iterator.hasNext()) {
+                Map.Entry<String, String> entry;
+                String key;
+                String encodedKey;
+                String value;
+                String encodedValue;
+
+                entry = iterator.next();
+                key = entry.getKey();
+                encodedKey = URLEncoder.encode(key, UTF_8);
+                sb.append(encodedKey);
+                value = entry.getValue();
+                if (value != null) {
+                    encodedValue = URLEncoder.encode(value, UTF_8);
+                    sb.append('=').append(encodedValue);
+                }
+                while (iterator.hasNext()) {
+                    sb.append('&');
+                    entry = iterator.next();
+                    key = entry.getKey();
+                    encodedKey = URLEncoder.encode(key, UTF_8);
+                    sb.append(encodedKey);
+                    value = entry.getValue();
+                    if (value != null) {
+                        encodedValue = URLEncoder.encode(value, UTF_8);
+                        sb.append('=').append(encodedValue);
+                    }
+                }
+            }
+            return sb.toString();
+        }
+        catch (final UnsupportedEncodingException e) {
+            throw new Error(e);
+        }
+    }
+}

--- a/src/main/webapp/browsers/tswa.html
+++ b/src/main/webapp/browsers/tswa.html
@@ -1,12 +1,11 @@
 <div>
   <p>
-	Enter the URL to the TSWA server. Examples:<tt>http://tswasrv</tt> or <tt>http://TFSMachine:8080/</tt>.
-	The plugin will strip the last path (if any) of the URL when building URLs for change set pages and other pages. 
+	Enter the base URL to use for browsing changesets, files and diffs.  Examples: <tt>http://tfs:8080/tfs/DefaultCollection/teamproject/</tt> or <tt>https://vsts.example.com/DefaultCollection/teamproject/</tt>
   </p>	 
   <p>
-    If the field is empty then the plugin will try to build up a valid URL using the server URL.
-    For instance if the server URL is <tt>https://server:8090</tt> then the plugin will
-    creates links such as <tt>https://server:8090/cs.aspx?cs=99</tt>, which is identical if the user entered 
-    <tt>https://server:8090</tt> into this field.  
+    If the field is empty then the plugin will build URLs using the server URL.
+  </p>
+  <p>
+    One reason for providing a value here is if Jenkins connects to the TFS server on the LAN using the short host name and the Jenkins instance is also accessible through the internet and so links to TFS should use the Fully-Qualified Domain Name (FQDN) of the TFS server.
   </p>
 </div>

--- a/src/test/java/hudson/plugins/tfs/FunctionalTest.java
+++ b/src/test/java/hudson/plugins/tfs/FunctionalTest.java
@@ -719,6 +719,7 @@ C/C.txt
 
         final HttpProxyServer proxyServer = innerRunner.getServer();
         final LoggingFiltersSourceAdapter adapter = innerRunner.getAdapter();
+        final int previousChangeSet;
         try {
             Assert.assertFalse(adapter.proxyWasUsed());
 
@@ -730,8 +731,8 @@ C/C.txt
 
             adapter.reset();
             // make a change in source control
-            final int changeSet = checkInEmptyFile(tfsRunner);
-            Assert.assertTrue(changeSet >= 0);
+            previousChangeSet = checkInEmptyFile(tfsRunner);
+            Assert.assertTrue(previousChangeSet >= 0);
             Assert.assertFalse(adapter.proxyWasUsed());
 
             // second poll should queue a build
@@ -746,7 +747,7 @@ C/C.txt
         }
 
         // make a change in source control
-        final String fileContents = "1. Pick up vegetables.";
+        final String fileContents = "1. Pick up vegetables.\nPrevious changeset:" + previousChangeSet;
         final int changeSet = checkInFile(tfsRunner, "Now with content.", fileContents);
         Assert.assertTrue(changeSet >= 0);
         adapter.reset();

--- a/src/test/java/hudson/plugins/tfs/FunctionalTest.java
+++ b/src/test/java/hudson/plugins/tfs/FunctionalTest.java
@@ -746,7 +746,8 @@ C/C.txt
         }
 
         // make a change in source control
-        final int changeSet = checkInFile(tfsRunner, "Now with content.", "1. Pick up vegetables.");
+        final String fileContents = "1. Pick up vegetables.";
+        final int changeSet = checkInFile(tfsRunner, "Now with content.", fileContents);
         Assert.assertTrue(changeSet >= 0);
         adapter.reset();
 

--- a/src/test/java/hudson/plugins/tfs/browsers/TeamSystemWebAccessBrowserTest.java
+++ b/src/test/java/hudson/plugins/tfs/browsers/TeamSystemWebAccessBrowserTest.java
@@ -18,32 +18,29 @@ import org.jvnet.hudson.test.Bug;
 @SuppressWarnings("rawtypes")
 public class TeamSystemWebAccessBrowserTest {
 
-    /**
-     * http://tswaserver:8090/cs.aspx?cs=99
-     */
-    @Test public void assertChangeSetLink() throws Exception {
-        TeamSystemWebAccessBrowser browser = new TeamSystemWebAccessBrowser("http://tswaserver:8090/ViewChangeset.aspx?changeset=6200");
+    @Test public void assertChangeSetLinkWithServerUrlWithPort() throws Exception {
+        TeamSystemWebAccessBrowser browser = new TeamSystemWebAccessBrowser("http://tfs:8080/");
         ChangeSet changeSet = new ChangeSet("99", null, "user", "comment");
         URL actual = browser.getChangeSetLink(changeSet);
-        assertEquals("The change set link was incorrect", "http://tswaserver:8090/cs.aspx?cs=99", actual.toString());
+        assertEquals("The change set link was incorrect", "http://tfs:8080/_versionControl/changeset?id=99", actual.toString());
     }
 
 	@Bug(7394)
 	@Test
 	public void assertChangeSetLinkWithOnlyServerUrl() throws Exception {
-		TeamSystemWebAccessBrowser browser = new TeamSystemWebAccessBrowser("http://tswaserver");
+		TeamSystemWebAccessBrowser browser = new TeamSystemWebAccessBrowser("http://tfs");
 		ChangeSet changeSet = new ChangeSet("99", null, "user", "comment");
 		URL actual = browser.getChangeSetLink(changeSet);
-		assertEquals("The change set link was incorrect", "http://tswaserver/cs.aspx?cs=99", actual.toString());
+		assertEquals("The change set link was incorrect", "http://tfs/_versionControl/changeset?id=99", actual.toString());
 	}
 
 	@Bug(7394)
 	@Test
 	public void assertChangeSetLinkWithOnlyServerUrlWithTrailingSlash() throws Exception {
-		TeamSystemWebAccessBrowser browser = new TeamSystemWebAccessBrowser("http://tswaserver/");
+		TeamSystemWebAccessBrowser browser = new TeamSystemWebAccessBrowser("http://tfs/");
 		ChangeSet changeSet = new ChangeSet("99", null, "user", "comment");
 		URL actual = browser.getChangeSetLink(changeSet);
-		assertEquals("The change set link was incorrect","http://tswaserver/cs.aspx?cs=99", actual.toString());
+		assertEquals("The change set link was incorrect","http://tfs/_versionControl/changeset?id=99", actual.toString());
 	}
     
     @Test public void assertChangeSetLinkUsesScmConfiguration() throws Exception {
@@ -56,47 +53,33 @@ public class TeamSystemWebAccessBrowserTest {
         new ChangeLogSet(build, new ChangeSet[]{ changeset});        
         TeamSystemWebAccessBrowser browser = new TeamSystemWebAccessBrowser("");
         URL actual = browser.getChangeSetLink(changeset);
-        assertEquals("The change set link was incorrect", "http://server:80/cs.aspx?cs=62643", actual.toString());
+        assertEquals("The change set link was incorrect", "http://server:80/_versionControl/changeset?id=62643", actual.toString());
     }
 
-    /**
-     * http://tswaserver:8090/view.aspx?path=$/Project/Folder/file.cs&cs=99
-     */
     @Test public void assertFileLink() throws Exception {
-        TeamSystemWebAccessBrowser browser = new TeamSystemWebAccessBrowser("http://tswaserver:8090/ViewChangeset.aspx?changeset=6200");
+        TeamSystemWebAccessBrowser browser = new TeamSystemWebAccessBrowser("http://tfs:8080/");
         ChangeSet changeSet = new ChangeSet("99", null, "user", "comment");
         ChangeSet.Item item = new ChangeSet.Item("$/Project/Folder/file.cs", "add");
         changeSet.add(item);
         URL actual = browser.getFileLink(item);
-        assertEquals("The change set link was incorrect", "http://tswaserver:8090/view.aspx?path=$/Project/Folder/file.cs&cs=99", actual.toString());
+        assertEquals("The change set link was incorrect", "http://tfs:8080/_versionControl/changeset?id=99#path=%24%2FProject%2FFolder%2Ffile.cs&_a=contents", actual.toString());
     }
 
-    /**
-     * http://tswaserver:8090/diff.aspx?opath=$/Project/Folder/file.cs&ocs=99&mpath=$/Project/Folder/file.cs&mcs=98
-     */
     @Test public void assertDiffLink() throws Exception {
-        TeamSystemWebAccessBrowser browser = new TeamSystemWebAccessBrowser("http://tswaserver:8090/ViewChangeset.aspx?changeset=6200");
+        TeamSystemWebAccessBrowser browser = new TeamSystemWebAccessBrowser("http://tfs:8080/");
         ChangeSet changeSet = new ChangeSet("99", null, "user", "comment");
         ChangeSet.Item item = new ChangeSet.Item("$/Project/Folder/file.cs", "edit");
         changeSet.add(item);
         URL actual = browser.getDiffLink(item);
-        assertEquals("The change set link was incorrect", "http://tswaserver:8090/diff.aspx?opath=$/Project/Folder/file.cs&ocs=98&mpath=$/Project/Folder/file.cs&mcs=99", actual.toString());
+        assertEquals("The change set link was incorrect", "http://tfs:8080/_versionControl/changeset?id=99#path=%24%2FProject%2FFolder%2Ffile.cs&_a=compare", actual.toString());
     }
 
     @Test public void assertNullDiffLinkForAddedFile() throws Exception {
-        TeamSystemWebAccessBrowser browser = new TeamSystemWebAccessBrowser("http://tswaserver:8090/ViewChangeset.aspx?changeset=6200");
+        TeamSystemWebAccessBrowser browser = new TeamSystemWebAccessBrowser("http://tfs:8080/");
         ChangeSet changeSet = new ChangeSet("99", null, "user", "comment");
         ChangeSet.Item item = new ChangeSet.Item("$/Project/Folder/file.cs", "add");
         changeSet.add(item);
         assertNull("The diff link should be null for new files", browser.getDiffLink(item));
-    }
-
-    @Test public void assertNullDiffLinkForInvalidChangeSetVersion() throws Exception {
-        TeamSystemWebAccessBrowser browser = new TeamSystemWebAccessBrowser("http://tswaserver:8090/ViewChangeset.aspx?changeset=6200");
-        ChangeSet changeSet = new ChangeSet("aaaa", null, "user", "comment");
-        ChangeSet.Item item = new ChangeSet.Item("$/Project/Folder/file.cs", "edit");
-        changeSet.add(item);
-        assertNull("The diff link should be null for invalid change set version", browser.getDiffLink(item));
     }
     
     @Test public void assertDescriptorBaseUrlRemovesName() throws Exception {

--- a/src/test/java/hudson/plugins/tfs/browsers/TeamSystemWebAccessBrowserTest.java
+++ b/src/test/java/hudson/plugins/tfs/browsers/TeamSystemWebAccessBrowserTest.java
@@ -162,14 +162,4 @@ public class TeamSystemWebAccessBrowserTest {
         changeSet.add(item);
         assertNull("The diff link should be null for new files", browser.getDiffLink(item));
     }
-    
-    @Test public void assertDescriptorBaseUrlRemovesName() throws Exception {
-        String expected = TeamSystemWebAccessBrowser.DescriptorImpl.getBaseUrl("http://server:80/UI/Pages/Scc/ViewChangeset.aspx?changeset=62643");
-        assertEquals("The base url was incorrect", "http://server:80/UI/Pages/Scc/", expected);
-    }
-    
-    @Test public void assertDescriptorBaseUrlDoesNotRemoveLastPath() throws Exception {
-        String expected = TeamSystemWebAccessBrowser.DescriptorImpl.getBaseUrl("http://server:80/UI/Pages/Scc/");
-        assertEquals("The base url was incorrect", "http://server:80/UI/Pages/Scc/", expected);
-    }
 }

--- a/src/test/java/hudson/plugins/tfs/browsers/TeamSystemWebAccessBrowserTest.java
+++ b/src/test/java/hudson/plugins/tfs/browsers/TeamSystemWebAccessBrowserTest.java
@@ -26,6 +26,20 @@ public class TeamSystemWebAccessBrowserTest {
         assertEquals("The change set link was incorrect", "http://tfs:8080/_versionControl/changeset?id=99", actual.toString());
     }
 
+    @Test public void assertChangeSetLinkWithRealisticServerUrlWithPort() throws Exception {
+        TeamSystemWebAccessBrowser browser = new TeamSystemWebAccessBrowser("http://tfs:8080/tfs/coll");
+        ChangeSet changeSet = new ChangeSet("99", null, "user", "comment");
+        URL actual = browser.getChangeSetLink(changeSet);
+        assertEquals("The change set link was incorrect", "http://tfs:8080/tfs/coll/_versionControl/changeset?id=99", actual.toString());
+    }
+
+    @Test public void assertChangeSetLinkWithRealisticServerUrl() throws Exception {
+        TeamSystemWebAccessBrowser browser = new TeamSystemWebAccessBrowser("http://tfs/tfs/coll");
+        ChangeSet changeSet = new ChangeSet("99", null, "user", "comment");
+        URL actual = browser.getChangeSetLink(changeSet);
+        assertEquals("The change set link was incorrect", "http://tfs/tfs/coll/_versionControl/changeset?id=99", actual.toString());
+    }
+
 	@Bug(7394)
 	@Test
 	public void assertChangeSetLinkWithOnlyServerUrl() throws Exception {
@@ -70,7 +84,7 @@ public class TeamSystemWebAccessBrowserTest {
       TeamSystemWebAccessBrowser browser = new TeamSystemWebAccessBrowser(""); // configured but no URL specified
 
       URL actual = browser.getChangeSetLink(changeset);
-      assertEquals("The change set link was incorrect", "http://server:80/tfs/collection/_versionControl/changeset/62643", actual.toString());
+      assertEquals("The change set link was incorrect", "http://server:80/tfs/collection/_versionControl/changeset?id=62643", actual.toString());
     }
 
     @Test public void assertFileLinkUsesScmConfiguration() throws Exception {
@@ -86,7 +100,7 @@ public class TeamSystemWebAccessBrowserTest {
       TeamSystemWebAccessBrowser browser = new TeamSystemWebAccessBrowser(""); // configured but no URL specified
 
       URL actual = browser.getFileLink(item);
-      assertEquals("The file link was incorrect", "http://server:80/tfs/collection/_versionControl/changeset/62643#path=%24%2Fproject%2Ffolder%2Ffolder%2Fbranch%2Fsome%2Fpath%2Fto%2Fsome%2Ffile.txt&_a=contents", actual.toString());
+      assertEquals("The file link was incorrect", "http://server:80/tfs/collection/_versionControl/changeset?id=62643#path=%24%2Fproject%2Ffolder%2Ffolder%2Fbranch%2Fsome%2Fpath%2Fto%2Fsome%2Ffile.txt&_a=contents", actual.toString());
     }
 
     @Test public void assertDiffLinkUsesScmConfiguration() throws Exception {
@@ -102,7 +116,7 @@ public class TeamSystemWebAccessBrowserTest {
 
       TeamSystemWebAccessBrowser browser = new TeamSystemWebAccessBrowser(""); // configured but no URL specified
       URL actual = browser.getDiffLink(item);
-      assertEquals("The diff link was incorrect", "http://server:80/tfs/collection/_versionControl/changeset/62643#path=%24%2Fproject%2Ffolder%2Ffolder%2Fbranch%2Fsome%2Fpath%2Fto%2Fsome%2Ffile.txt&_a=compare", actual.toString());
+      assertEquals("The diff link was incorrect", "http://server:80/tfs/collection/_versionControl/changeset?id=62643#path=%24%2Fproject%2Ffolder%2Ffolder%2Fbranch%2Fsome%2Fpath%2Fto%2Fsome%2Ffile.txt&_a=compare", actual.toString());
     }
 
     @Test public void assertFileLink() throws Exception {
@@ -114,6 +128,15 @@ public class TeamSystemWebAccessBrowserTest {
         assertEquals("The file link was incorrect", "http://tfs:8080/_versionControl/changeset?id=99#path=%24%2FProject%2FFolder%2Ffile.cs&_a=contents", actual.toString());
     }
 
+    @Test public void assertFileLinkWithRealisticServerUrl() throws Exception {
+        TeamSystemWebAccessBrowser browser = new TeamSystemWebAccessBrowser("http://tfs:8080/tfs/coll");
+        ChangeSet changeSet = new ChangeSet("99", null, "user", "comment");
+        ChangeSet.Item item = new ChangeSet.Item("$/Project/Folder/file.cs", "add");
+        changeSet.add(item);
+        URL actual = browser.getFileLink(item);
+        assertEquals("The file link was incorrect", "http://tfs:8080/tfs/coll/_versionControl/changeset?id=99#path=%24%2FProject%2FFolder%2Ffile.cs&_a=contents", actual.toString());
+    }
+
     @Test public void assertDiffLink() throws Exception {
         TeamSystemWebAccessBrowser browser = new TeamSystemWebAccessBrowser("http://tfs:8080/");
         ChangeSet changeSet = new ChangeSet("99", null, "user", "comment");
@@ -121,6 +144,15 @@ public class TeamSystemWebAccessBrowserTest {
         changeSet.add(item);
         URL actual = browser.getDiffLink(item);
         assertEquals("The diff link was incorrect", "http://tfs:8080/_versionControl/changeset?id=99#path=%24%2FProject%2FFolder%2Ffile.cs&_a=compare", actual.toString());
+    }
+
+    @Test public void assertDiffLinkWithRealisticServerUrl() throws Exception {
+        TeamSystemWebAccessBrowser browser = new TeamSystemWebAccessBrowser("http://tfs:8080/tfs/coll");
+        ChangeSet changeSet = new ChangeSet("99", null, "user", "comment");
+        ChangeSet.Item item = new ChangeSet.Item("$/Project/Folder/file.cs", "edit");
+        changeSet.add(item);
+        URL actual = browser.getDiffLink(item);
+        assertEquals("The diff link was incorrect", "http://tfs:8080/tfs/coll/_versionControl/changeset?id=99#path=%24%2FProject%2FFolder%2Ffile.cs&_a=compare", actual.toString());
     }
 
     @Test public void assertNullDiffLinkForAddedFile() throws Exception {

--- a/src/test/java/hudson/plugins/tfs/browsers/TeamSystemWebAccessBrowserTest.java
+++ b/src/test/java/hudson/plugins/tfs/browsers/TeamSystemWebAccessBrowserTest.java
@@ -100,7 +100,7 @@ public class TeamSystemWebAccessBrowserTest {
       TeamSystemWebAccessBrowser browser = new TeamSystemWebAccessBrowser(""); // configured but no URL specified
 
       URL actual = browser.getFileLink(item);
-      assertEquals("The file link was incorrect", "http://server:80/tfs/collection/_versionControl/changeset?id=62643#path=%24%2Fproject%2Ffolder%2Ffolder%2Fbranch%2Fsome%2Fpath%2Fto%2Fsome%2Ffile.txt&_a=contents", actual.toString());
+      assertEquals("The file link was incorrect", "http://server:80/tfs/collection/_versionControl/changeset?id=62643#path=%24%2Fproject%2Ffolder%2Ffolder%2Fbranch%2Fsome%2Fpath%2Fto%2Fsome%2Ffile.txt&version=62643&_a=contents", actual.toString());
     }
 
     @Test public void assertDiffLinkUsesScmConfiguration() throws Exception {
@@ -116,7 +116,7 @@ public class TeamSystemWebAccessBrowserTest {
 
       TeamSystemWebAccessBrowser browser = new TeamSystemWebAccessBrowser(""); // configured but no URL specified
       URL actual = browser.getDiffLink(item);
-      assertEquals("The diff link was incorrect", "http://server:80/tfs/collection/_versionControl/changeset?id=62643#path=%24%2Fproject%2Ffolder%2Ffolder%2Fbranch%2Fsome%2Fpath%2Fto%2Fsome%2Ffile.txt&_a=compare", actual.toString());
+      assertEquals("The diff link was incorrect", "http://server:80/tfs/collection/_versionControl/changeset?id=62643#path=%24%2Fproject%2Ffolder%2Ffolder%2Fbranch%2Fsome%2Fpath%2Fto%2Fsome%2Ffile.txt&version=62643&_a=compare", actual.toString());
     }
 
     @Test public void assertFileLink() throws Exception {
@@ -125,7 +125,7 @@ public class TeamSystemWebAccessBrowserTest {
         ChangeSet.Item item = new ChangeSet.Item("$/Project/Folder/file.cs", "add");
         changeSet.add(item);
         URL actual = browser.getFileLink(item);
-        assertEquals("The file link was incorrect", "http://tfs:8080/_versionControl/changeset?id=99#path=%24%2FProject%2FFolder%2Ffile.cs&_a=contents", actual.toString());
+        assertEquals("The file link was incorrect", "http://tfs:8080/_versionControl/changeset?id=99#path=%24%2FProject%2FFolder%2Ffile.cs&version=99&_a=contents", actual.toString());
     }
 
     @Test public void assertFileLinkWithRealisticServerUrl() throws Exception {
@@ -134,7 +134,7 @@ public class TeamSystemWebAccessBrowserTest {
         ChangeSet.Item item = new ChangeSet.Item("$/Project/Folder/file.cs", "add");
         changeSet.add(item);
         URL actual = browser.getFileLink(item);
-        assertEquals("The file link was incorrect", "http://tfs:8080/tfs/coll/_versionControl/changeset?id=99#path=%24%2FProject%2FFolder%2Ffile.cs&_a=contents", actual.toString());
+        assertEquals("The file link was incorrect", "http://tfs:8080/tfs/coll/_versionControl/changeset?id=99#path=%24%2FProject%2FFolder%2Ffile.cs&version=99&_a=contents", actual.toString());
     }
 
     @Test public void assertDiffLink() throws Exception {
@@ -143,7 +143,7 @@ public class TeamSystemWebAccessBrowserTest {
         ChangeSet.Item item = new ChangeSet.Item("$/Project/Folder/file.cs", "edit");
         changeSet.add(item);
         URL actual = browser.getDiffLink(item);
-        assertEquals("The diff link was incorrect", "http://tfs:8080/_versionControl/changeset?id=99#path=%24%2FProject%2FFolder%2Ffile.cs&_a=compare", actual.toString());
+        assertEquals("The diff link was incorrect", "http://tfs:8080/_versionControl/changeset?id=99#path=%24%2FProject%2FFolder%2Ffile.cs&version=99&_a=compare", actual.toString());
     }
 
     @Test public void assertDiffLinkWithRealisticServerUrl() throws Exception {
@@ -152,7 +152,7 @@ public class TeamSystemWebAccessBrowserTest {
         ChangeSet.Item item = new ChangeSet.Item("$/Project/Folder/file.cs", "edit");
         changeSet.add(item);
         URL actual = browser.getDiffLink(item);
-        assertEquals("The diff link was incorrect", "http://tfs:8080/tfs/coll/_versionControl/changeset?id=99#path=%24%2FProject%2FFolder%2Ffile.cs&_a=compare", actual.toString());
+        assertEquals("The diff link was incorrect", "http://tfs:8080/tfs/coll/_versionControl/changeset?id=99#path=%24%2FProject%2FFolder%2Ffile.cs&version=99&_a=compare", actual.toString());
     }
 
     @Test public void assertNullDiffLinkForAddedFile() throws Exception {


### PR DESCRIPTION
# Description

Team Foundation Server (TFS) drastically changed the URLs to changesets, file contents and file diffs in TFS 2012, breaking links from Jenkins.  In TFS 2013 and 2015, the links generated by the web UI are slightly different but TFS 2012-style links are compatible.

Replaces pull request #26.

## Why not use the TFS SDK for Java's feature for building hyperlinks?

The `TSWAHyperlinkBuilder` class, despite not having a method for generating a link to a file diff, was used for a prototype.

Although it worked, with an overhead of _at least_ one remote procedure call (RPC) _per hyperlink_, the performance was deemed unacceptable.


# Documentation

Commit 3619ef3742f18f89aba6f12b34bd8013286c185d was added to the `documentation_4.1.0` branch. 

Here's a screenshot of the results of updating `src/main/webapp/browsers/tswa.html`, seen in context and with sample values:

![Screenshot of Team Foundation Server SCM with Repository browser configured to "Team System Web Access"](https://cloud.githubusercontent.com/assets/297515/13384624/61f26ca0-de65-11e5-82a7-ec9ad666436a.png)


# Manual testing

1. Upload private build of TFS plugin HPI to the Jenkins master via `/jenkins/pluginManager/advanced`, _Prepare for Shutdown_ via `/jenkins/quietDown` then restart Jenkins.
2. For each of TFS 2012, TFS 2013 and TFS 2015: 
    1. Create a Jenkins job to use the "Team Foundation Server" SCM with the following specifications (see the screenshot above for the values that were used for the TFS 2012 run):
        1. Set the _Server URL_ to use the TFS server's "short" host name (i.e. using WINS resolution).
        2. Set the _Repository browser_ to be **Team System Web Access** with its _URL_ set to the FQDN of the TFS server. 
    2. Launch the job so it can record a baseline changeset in the TFVC repository.
    3. Go make one or more changesets in the TFVC repository (such as by running this project's functional tests).
    4. Launch the job again and wait for it to finish.
    5. Visit the job's **Changes** page and click a sample of the **Team System Web Access** links to visit TFS's view of the changesets.
    6. Visit the last build's **Changes** page and click a sample of the _Version_ links, some changeset item links and some diff links to visit them in TFS.  Verify the results are expected, such as being consistent with changes made in a certain changeset.

Mission accomplished!