### PR TITLE
JENKINS-32394 Fixed Changeset number display for Delivery Pipeline

### DIFF
--- a/src/main/java/hudson/plugins/tfs/model/ChangeSet.java
+++ b/src/main/java/hudson/plugins/tfs/model/ChangeSet.java
@@ -84,6 +84,11 @@ public class ChangeSet extends hudson.scm.ChangeLogSet.Entry {
     }
 
     @Exported
+    public String getCommitId() {
+        return version;
+    }
+
+    @Exported
     public String getDomain() {
         return domain;
     }


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/8586903/15293419/7a8830c4-1ba5-11e6-9e87-64bc43eb0441.png)

In the above screenshot, DPP shows Changes as null. This fixes this issue related Changeset number in DPP.