### PR TITLE
JENKINS-32394: Fix Changeset number display for Delivery Pipeline

### DIFF
--- a/src/main/java/hudson/plugins/tfs/model/ChangeSet.java
+++ b/src/main/java/hudson/plugins/tfs/model/ChangeSet.java
@@ -83,6 +83,17 @@ public class ChangeSet extends hudson.scm.ChangeLogSet.Entry {
         this.version = version;
     }
 
+    /**
+     * Returns a human readable display name of the changeset number.
+     *
+     * <p>
+     * This method is primarily intended for visualization of the data.
+     */
+    @Exported
+    public String getCommitId() {
+        return version;
+    }
+
     @Exported
     public String getDomain() {
         return domain;


### PR DESCRIPTION
Slight improvement of #76.

Manual testing
--------------

1. Install the [Delivery Pipeline Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Delivery+Pipeline+Plugin).
2. Create a new job called **JENKINS-32394**
    1. Check the **Delivery Pipeline configuration** box and configure as follows:
        1. *Stage Name*: **Development**
        2. *Task Name*: **Build**
        3. *Customize Task Description Template*: **Build #${BUILD_NUMBER} on ${NODE_NAME}**
    2. Select **Team Foundation Server** under *Source Code Management* and configure to get source code from a TFVC project.
    3. Add a build step just to see the build doing something.  I used **Execute Windows batch command** set to `dir /s`
    4. Click **[Save]**
3. Click **Build Now** on the new job.
4. Go to the Jenkins home and click the "+" on the top tab row to add a new view and configure as follows:
    1. *View name*: **Pipeline**
    2. Select **Delivery Pipeline View**
    3. Click **[OK]**
    4. Under *View settings*, check **Show commit messages**
    4. Under *Pipelines* > *Components*, click **[Add]** and configure as follows:
        1. *Name*: **Delivery**
        2. *Initial Job*: **JENKINS-32394**
    5. Click **[OK]**
5. Notice how there's the first build listed there.  Let's go create some changesets in source control and then come back to Jenkins.
6. Click **Build Now** on the new job a second time.
7. Before the changes from this branch/pull request were applied, the second build would show the "Changes" table with "null" as the changeset ID.  After these changes, the "Changes" table now shows the changeset IDs:

![image](https://cloud.githubusercontent.com/assets/297515/15549534/ec4a351e-227a-11e6-8dfb-6af03b7668fd.png)

Mission accomplished!
