### PR TITLE
Cloaked paths should be case insensitive when polling for changes

### DIFF
--- a/src/main/java/hudson/plugins/tfs/model/Project.java
+++ b/src/main/java/hudson/plugins/tfs/model/Project.java
@@ -234,7 +234,7 @@ public class Project {
         for (final String tfsPath : changesetPaths) {
             boolean isPathCloaked = false;
             for (final String cloakedPath : cloakedPaths) {
-                if (tfsPath.toLowerCase().startsWith(cloakedPath.toLowerCase())) {
+                if (tfsPath.regionMatches(true, 0, cloakedPath, 0, cloakedPath.length())) {
                     isPathCloaked = true;
                     break;
                 }

--- a/src/main/java/hudson/plugins/tfs/model/Project.java
+++ b/src/main/java/hudson/plugins/tfs/model/Project.java
@@ -234,7 +234,7 @@ public class Project {
         for (final String tfsPath : changesetPaths) {
             boolean isPathCloaked = false;
             for (final String cloakedPath : cloakedPaths) {
-                if (tfsPath.startsWith(cloakedPath)) {
+                if (tfsPath.toLowerCase().startsWith(cloakedPath.toLowerCase())) {
                     isPathCloaked = true;
                     break;
                 }

--- a/src/test/java/hudson/plugins/tfs/model/ProjectTest.java
+++ b/src/test/java/hudson/plugins/tfs/model/ProjectTest.java
@@ -166,6 +166,7 @@ public class ProjectTest extends SwedishLocaleTestCase {
         Assert.assertEquals(false, actual);
     }
 
+
     @Test
     public void isChangesetFullyCloaked_independentCloakedPaths() {
         final List<String> changesetPaths = Arrays.asList("$/foo", "$/foo/bar.baz");
@@ -174,6 +175,16 @@ public class ProjectTest extends SwedishLocaleTestCase {
         final boolean actual = Project.isChangesetFullyCloaked(changesetPaths, cloakedPaths);
 
         Assert.assertEquals(false, actual);
+    }
+
+    @Test
+    public void isChangesetFullyCloaked_caseInsensitiveCloakedPaths() {
+        final List<String> changesetPaths = Arrays.asList("$/foo/bar/test.baz");
+        final List<String> cloakedPaths = Arrays.asList("$/fOo/bAr/");
+
+        final boolean actual = Project.isChangesetFullyCloaked(changesetPaths, cloakedPaths);
+
+        Assert.assertEquals(true, actual);
     }
 
     @Test


### PR DESCRIPTION
We noticed this issue last night. If you add a cloaked path like " $/Server/TeSt2" when the actual folder name on the server is "test2", a build will still be triggered if someone checks into that folder. The polling is case sensitive.

This is a quick fix for this case, polling is now insensitive.

No changes are needed to the get, it's already case insensitive. Polling now matches this behavior.