### PR TITLE
Work around TFS SDK defect when re-creating an older workspace

### DIFF
--- a/src/main/java/hudson/plugins/tfs/model/MockableVersionControlClient.java
+++ b/src/main/java/hudson/plugins/tfs/model/MockableVersionControlClient.java
@@ -5,6 +5,7 @@ import com.microsoft.tfs.core.clients.versioncontrol.VersionControlClient;
 import com.microsoft.tfs.core.clients.versioncontrol.WorkspaceLocation;
 import com.microsoft.tfs.core.clients.versioncontrol.WorkspaceOptions;
 import com.microsoft.tfs.core.clients.versioncontrol.WorkspacePermissions;
+import com.microsoft.tfs.core.clients.versioncontrol.Workstation;
 import com.microsoft.tfs.core.clients.versioncontrol.events.VersionControlEventEngine;
 import com.microsoft.tfs.core.clients.versioncontrol.exceptions.ItemNotMappedException;
 import com.microsoft.tfs.core.clients.versioncontrol.exceptions.ServerPathFormatException;
@@ -12,6 +13,7 @@ import com.microsoft.tfs.core.clients.versioncontrol.soapextensions.*;
 import com.microsoft.tfs.core.clients.versioncontrol.soapextensions.Workspace;
 import com.microsoft.tfs.core.clients.versioncontrol.specs.LabelItemSpec;
 import com.microsoft.tfs.core.clients.versioncontrol.specs.version.VersionSpec;
+import com.microsoft.tfs.core.clients.versioncontrol.workspacecache.WorkspaceInfo;
 import com.microsoft.tfs.util.Closable;
 
 import javax.annotation.Nonnull;
@@ -159,5 +161,15 @@ public class MockableVersionControlClient implements Closable {
             @Nonnull final WorkspacePermissions permissionsFilter) {
         makeSureNotClosed();
         return vcc.queryWorkspaces(workspaceName, workspaceOwner, computer, permissionsFilter);
+    }
+
+    /**
+     * Removes a cached workspace that matches the given name and owner and this
+     * client's server's GUID from the {@link Workstation}'s cache. The caller
+     * is responsible for saving the {@link Workstation} cache.
+     */
+    public WorkspaceInfo removeCachedWorkspace(final String workspaceName, String workspaceOwner) {
+        makeSureNotClosed();
+        return vcc.removeCachedWorkspace(workspaceName, workspaceOwner);
     }
 }


### PR DESCRIPTION
It appears Visual Studio Team Services may have changed, in the last few months, the value of what the TFS SDK for Java maps to the `ownerName` attribute in the `Cache/VersionControl.config` file.  Previously, it appears the VSTS account e-mail address was stored (one of the `OwnerAlias` values) and now it's a GUID.  

Whatever the cause for this change, it means deleting a workspace that was created when `ownerName` wasn't a GUID will succeed in completing the operation on the server but the corresponding entry will not be removed from the cache (because it's looking for a workspace with an `ownerName` being a GUID), which will cause the subsequent workspace re-creation to succeed in completing the operation on the server, but fail when attempting to update the cache, saying there are two workspaces with the same name.

The defect was reproduced with a fairly complicated JUnit test, which is attached as [TeamFoundationServerScmIntegrationTest.java.txt](https://github.com/jenkinsci/tfs-plugin/files/317514/TeamFoundationServerScmIntegrationTest.java.txt)  Said test was submitted to the appropriate team for consideration.

This defect was causing failures of the Jenkins TFS plugin's functional tests on my Jenkins cluster.  Just pushing this branch to GitHub triggered a build, which saw all its functional tests now pass.

Mission accomplished!