### PR TITLE
Upgrade Jenkins dependencies to 1.580

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.448</version>
+    <version>1.580</version>
   </parent>
 
   <artifactId>tfs</artifactId>
@@ -12,6 +12,7 @@
   <version>4.1.1-SNAPSHOT</version>
   <url>http://wiki.jenkins-ci.org/display/JENKINS/Team+Foundation+Server+Plugin</url>
   <properties>
+    <jenkins.version>1.580</jenkins.version>
     <maven-surefire-plugin.version>2.18.1</maven-surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -193,27 +194,28 @@
     <dependency>
       <groupId>org.jenkins-ci.main</groupId>
       <artifactId>jenkins-war</artifactId>
-      <version>1.448</version>
+      <version>${jenkins.version}</version>
       <type>war</type>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.main</groupId>
       <artifactId>jenkins-core</artifactId>
-      <version>1.448</version>
+      <version>${jenkins.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.main</groupId>
       <artifactId>jenkins-test-harness</artifactId>
-      <version>1.448</version>
+      <version>${jenkins.version}</version>
       <scope>test</scope>
     </dependency>
+
     <dependency>
-      <groupId>org.jenkins-ci.main</groupId>
-      <artifactId>ui-samples-plugin</artifactId>
-      <version>1.448</version>
-      <scope>test</scope>
+      <!-- We need this plugin for the [current] TfsUserLookup implementation -->
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>mailer</artifactId>
+      <version>1.16</version>
     </dependency>
 
     <dependency>

--- a/src/main/java/hudson/plugins/tfs/TeamFoundationServerScm.java
+++ b/src/main/java/hudson/plugins/tfs/TeamFoundationServerScm.java
@@ -415,6 +415,11 @@ public class TeamFoundationServerScm extends SCM {
         return repositoryBrowser;
     }
 
+    // Convenience method for tests.
+    public void setRepositoryBrowser(final TeamFoundationServerRepositoryBrowser repositoryBrowser) {
+        this.repositoryBrowser = repositoryBrowser;
+    }
+
     @Override
     public void buildEnvVars(AbstractBuild<?,?> build, Map<String, String> env) {
         super.buildEnvVars(build, env);

--- a/src/test/java/hudson/plugins/tfs/FunctionalTest.java
+++ b/src/test/java/hudson/plugins/tfs/FunctionalTest.java
@@ -117,7 +117,7 @@ public class FunctionalTest {
         }
 
         @Override
-        protected void after() {
+        public void after() throws Exception {
             if (Functions.isWindows()) {
                 purgeSlaves();
             }

--- a/src/test/java/hudson/plugins/tfs/IntegrationTestHelper.java
+++ b/src/test/java/hudson/plugins/tfs/IntegrationTestHelper.java
@@ -2,7 +2,6 @@ package hudson.plugins.tfs;
 
 import hudson.*;
 import org.apache.commons.lang.StringUtils;
-import org.apache.maven.wagon.providers.http.httpclient.client.utils.URIUtils;
 import org.junit.Assert;
 import org.junit.runner.Description;
 
@@ -42,11 +41,11 @@ public class IntegrationTestHelper {
     public IntegrationTestHelper(final String tfsServerName, final String tfsUserName, final String tfsUserPassword) throws URISyntaxException {
         final URI serverUri;
         if (tfsServerName.endsWith(".visualstudio.com")) {
-            serverUri = URIUtils.createURI("https", tfsServerName, 443, "DefaultCollection", null, null);
+            serverUri = new URI("https", null, tfsServerName, 443, "/DefaultCollection", null, null);
             this.userName = tfsUserName;
             this.userPassword = tfsUserPassword;
         } else {
-            serverUri = URIUtils.createURI("http", tfsServerName, 8080, "tfs/" + "jenkins-tfs-plugin", null, null);
+            serverUri = new URI("http", null, tfsServerName, 8080, "/tfs/" + "jenkins-tfs-plugin", null, null);
             this.userName = (tfsUserName != null) ? tfsUserName : "jenkins-tfs-plugin";
             this.userPassword = (tfsUserPassword != null) ? tfsUserPassword : "for-test-only";
         }

--- a/src/test/java/hudson/plugins/tfs/TeamFoundationServerScmTest.java
+++ b/src/test/java/hudson/plugins/tfs/TeamFoundationServerScmTest.java
@@ -84,7 +84,7 @@ public class TeamFoundationServerScmTest {
                             "  <projectPath>$/example/path</projectPath>\n" +
                             "  <localPath>.</localPath>\n" +
                             "  <workspaceName>Hudson-${JOB_NAME}-${NODE_NAME}</workspaceName>\n" +
-                            "  <password>zs+99bxCGlcSxR3Umnj0q0OjYXVSiB+qLzS0ZjuHz2M=</password>\n" +
+                            "  <password>GZ3wK9L4iJXsMwXnJ4NieiVpOlxj0AVrthfe7MIr9w0=</password>\n" +
                             "  <userName>example\\tfsbuilder</userName>\n" +
                             "  <useUpdate>false</useUpdate>\n" +
                             "</hudson.plugins.tfs.TeamFoundationServerScm>";

--- a/src/test/java/hudson/plugins/tfs/browsers/TeamSystemWebAccessBrowserTest.java
+++ b/src/test/java/hudson/plugins/tfs/browsers/TeamSystemWebAccessBrowserTest.java
@@ -65,6 +65,9 @@ public class TeamSystemWebAccessBrowserTest {
         final String userName = null;
         final TeamFoundationServerScm result = new TeamFoundationServerScm(serverUrl, projectPath, null, null, false, null, userName, password);
 
+        final TeamFoundationServerRepositoryBrowser repositoryBrowser = mock(TeamFoundationServerRepositoryBrowser.class);
+        result.setRepositoryBrowser(repositoryBrowser);
+
         return result;
     }
 

--- a/src/test/java/hudson/plugins/tfs/browsers/TeamSystemWebAccessBrowserTest.java
+++ b/src/test/java/hudson/plugins/tfs/browsers/TeamSystemWebAccessBrowserTest.java
@@ -58,11 +58,22 @@ public class TeamSystemWebAccessBrowserTest {
 		assertEquals("The change set link was incorrect","http://tfs/_versionControl/changeset?id=99", actual.toString());
 	}
     
+    private static TeamFoundationServerScm createTestScm(String serverUrl) {
+        serverUrl = serverUrl != null ? serverUrl : "http://server:80/tfs/collection/";
+        final String projectPath = "$/project/folder/folder/branch";
+        final Secret password = null;
+        final String userName = null;
+        final TeamFoundationServerScm result = new TeamFoundationServerScm(serverUrl, projectPath, null, null, false, null, userName, password);
+
+        return result;
+    }
+
     @Test public void assertChangeSetLinkUsesScmConfiguration() throws Exception {
         AbstractBuild build = mock(AbstractBuild.class);
         AbstractProject<?,?> project = mock(AbstractProject.class);
         when(build.getProject()).thenReturn(project);
-        when(project.getScm()).thenReturn(new TeamFoundationServerScm("http://server:80/tfs/collection/", "$/project/folder/folder/branch", null, null, false, null, null, (Secret) null));
+        final TeamFoundationServerScm testScm = createTestScm(null);
+        when(project.getScm()).thenReturn(testScm);
         
         ChangeSet changeset = new ChangeSet("62643", null, "user", "comment");
         new ChangeLogSet(build, new ChangeSet[]{ changeset});        
@@ -77,7 +88,8 @@ public class TeamSystemWebAccessBrowserTest {
       AbstractProject<?,?> project = mock(AbstractProject.class);
       when(build.getProject()).thenReturn(project);
       // the server URL has not trailing slash...
-      when(project.getScm()).thenReturn(new TeamFoundationServerScm("http://server:80/tfs/collection", "$/project/folder/folder/branch", null, null, false, null, null, (Secret) null));
+      final TeamFoundationServerScm testScm = createTestScm("http://server:80/tfs/collection");
+      when(project.getScm()).thenReturn(testScm);
 
       ChangeSet changeset = new ChangeSet("62643", null, "user", "comment");
       new ChangeLogSet(build, new ChangeSet[]{ changeset});
@@ -91,7 +103,8 @@ public class TeamSystemWebAccessBrowserTest {
       AbstractBuild build = mock(AbstractBuild.class);
       AbstractProject<?,?> project = mock(AbstractProject.class);
       when(build.getProject()).thenReturn(project);
-      when(project.getScm()).thenReturn(new TeamFoundationServerScm("http://server:80/tfs/collection", "$/project/folder/folder/branch", null, null, false, null, null, (Secret) null));
+      final TeamFoundationServerScm testScm = createTestScm(null);
+      when(project.getScm()).thenReturn(testScm);
 
       ChangeSet changeset = new ChangeSet("62643", null, "user", "comment");
       ChangeSet.Item item = new Item("$/project/folder/folder/branch/some/path/to/some/file.txt", "action");
@@ -107,7 +120,8 @@ public class TeamSystemWebAccessBrowserTest {
       AbstractBuild build = mock(AbstractBuild.class);
       AbstractProject<?,?> project = mock(AbstractProject.class);
       when(build.getProject()).thenReturn(project);
-      when(project.getScm()).thenReturn(new TeamFoundationServerScm("http://server:80/tfs/collection", "$/project/folder/folder/branch", null, null, false, null, null, (Secret) null));
+      final TeamFoundationServerScm testScm = createTestScm(null);
+      when(project.getScm()).thenReturn(testScm);
 
       ChangeSet changeset = new ChangeSet("62643", null, "user", "comment");
       new ChangeLogSet(build, new ChangeSet[]{ changeset});

--- a/src/test/java/hudson/util/SecretOverride.java
+++ b/src/test/java/hudson/util/SecretOverride.java
@@ -1,5 +1,8 @@
 package hudson.util;
 
+import jenkins.security.ConfidentialStore;
+import jenkins.security.ConfidentialStoreOverride;
+
 import java.io.Closeable;
 import java.io.IOException;
 
@@ -10,8 +13,21 @@ import java.io.IOException;
  */
 public class SecretOverride implements Closeable {
 
+    private static ConfidentialStoreOverride confidentialStoreOverride = null;
+
     public static void set(final String secretKey) {
         Secret.SECRET = secretKey;
+        if (confidentialStoreOverride != null) {
+            try {
+                confidentialStoreOverride.close();
+            }
+            catch (final IOException ignored) {
+            }
+            confidentialStoreOverride = null;
+        }
+        if (secretKey != null) {
+            confidentialStoreOverride = new ConfidentialStoreOverride();
+        }
     }
 
     public SecretOverride() {

--- a/src/test/java/jenkins/security/ConfidentialStoreOverride.java
+++ b/src/test/java/jenkins/security/ConfidentialStoreOverride.java
@@ -1,11 +1,56 @@
 package jenkins.security;
 
+import hudson.Util;
+
 import java.io.Closeable;
+import java.io.File;
 import java.io.IOException;
+import java.util.Random;
 
 public class ConfidentialStoreOverride implements Closeable {
 
+    private static final File TEMP_FOLDER;
+    private static final ConfidentialStore TEST_CONFIDENTIAL_STORE;
+    private static final ThreadLocal<ConfidentialStore> TEST_THREAD_LOCAL;
+    private static final Random TEST_RANDOM_SOURCE = new Random(4 /* chosen by fair dice roll */);
+
+    static {
+        try {
+            TEMP_FOLDER = new File(Util.createTempDir(), "jenkins");
+            TEST_CONFIDENTIAL_STORE = new DefaultConfidentialStore(TEMP_FOLDER) {
+                public byte[] randomBytes(final int size) {
+                    byte[] random = new byte[size];
+                    TEST_RANDOM_SOURCE.nextBytes(random);
+                    return random;
+                }
+            };
+            TEST_THREAD_LOCAL = new ThreadLocal<ConfidentialStore>(){
+                protected ConfidentialStore initialValue() {
+                    return TEST_CONFIDENTIAL_STORE;
+                }
+            };
+        }
+        catch (final IOException e) {
+            throw new Error(e);
+        }
+        catch (final InterruptedException e) {
+            throw new Error(e);
+        }
+    }
+
+    public static void set(final ThreadLocal<ConfidentialStore> override) {
+        ConfidentialStore.TEST = override;
+    }
+
+    public ConfidentialStoreOverride() {
+        this(TEST_THREAD_LOCAL);
+    }
+
+    public ConfidentialStoreOverride(final ThreadLocal<ConfidentialStore> override) {
+        set(override);
+    }
+
     public void close() throws IOException {
-        // TODO: implement
+        set(null);
     }
 }

--- a/src/test/java/jenkins/security/ConfidentialStoreOverride.java
+++ b/src/test/java/jenkins/security/ConfidentialStoreOverride.java
@@ -1,0 +1,11 @@
+package jenkins.security;
+
+import java.io.Closeable;
+import java.io.IOException;
+
+public class ConfidentialStoreOverride implements Closeable {
+
+    public void close() throws IOException {
+        // TODO: implement
+    }
+}


### PR DESCRIPTION
Most of the resulting modifications were test-related.

Manual testing
--------------

1. `mvn verify clean`
2. Install `target/tfs.hpi` in a Jenkins instance.
3. Click around to configure a job that uses the TFS plugin, hit Save and go back to make sure the values are still there.
4. Queue a build that pull sources from TFVC.

Initial smoke tests pass!  The one thing that no longer appears to work is running through `mvn hpi:run` and that appears to be a problem with the classpath.