### PR TITLE
changed language level check to use 1.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -127,6 +127,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>animal-sniffer-maven-plugin</artifactId>
+        <!-- version inherited from parent pom -->
         <configuration>
           <signature>
             <groupId>org.codehaus.mojo.signature</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -125,27 +125,25 @@
         </configuration>
       </plugin>
       <plugin>
-	<groupId>org.codehaus.mojo</groupId>
-	<artifactId>animal-sniffer-maven-plugin</artifactId>
-	<version>1.7</version>
-	<configuration>
-	  <signature>
-	    <groupId>org.codehaus.mojo.signature</groupId>
-	    <artifactId>java15</artifactId>
-	    <version>1.0</version>
-	  </signature>
-	</configuration>
-	<executions>
-	  <execution>
-	    <id>java.1.5.check</id>
-	    <phase>verify</phase>
-	    <goals>
-	      <goal>check</goal>
-	    </goals>
-	  </execution>
-	</executions>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>animal-sniffer-maven-plugin</artifactId>
+        <configuration>
+          <signature>
+            <groupId>org.codehaus.mojo.signature</groupId>
+            <artifactId>java16</artifactId>
+            <version>1.1</version>
+          </signature>
+        </configuration>
+        <executions>
+          <execution>
+            <id>java.1.6.check</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
-
     </plugins>
   </build>
 


### PR DESCRIPTION
A side effect of https://github.com/jenkinsci/tfs-plugin/pull/81 is that the language level for Jenkins plugin compilation (and Jenkins) changes to Java 6. 

This PR fixes the build check to validate java 6 instead of java 5. This essentially allows Java 6 usage without breaking the build (not that there were any language changes but anyway...) .

Ran full build and tested deployment and usage of plugin manually. No IT runs necessary since build output is not affected by this change.

This PR and the above merged PR replace https://github.com/jenkinsci/tfs-plugin/pull/62, which I will close.

Unless there are any objections I will merge this tomorrow. fyi @olivierdagenais 