### PR TITLE
Automatically configure used webbrowser access

### DIFF
--- a/src/main/java/hudson/plugins/tfs/TeamFoundationServerScm.java
+++ b/src/main/java/hudson/plugins/tfs/TeamFoundationServerScm.java
@@ -421,9 +421,8 @@ public class TeamFoundationServerScm extends SCM {
     
     @Override
     public @CheckForNull RepositoryBrowser<?> guessBrowser() {
-      return new TeamSystemWebAccessBrowser( serverUrl + projectPath );
+      return new TeamSystemWebAccessBrowser(serverUrl);
     }
-    
 
     // Convenience method for tests.
     public void setRepositoryBrowser(final TeamFoundationServerRepositoryBrowser repositoryBrowser) {

--- a/src/main/java/hudson/plugins/tfs/TeamFoundationServerScm.java
+++ b/src/main/java/hudson/plugins/tfs/TeamFoundationServerScm.java
@@ -419,9 +419,14 @@ public class TeamFoundationServerScm extends SCM {
         return repositoryBrowser;
     }
     
+    /**
+     *
+     * @return a new TeamSystemWebAccessBrowser even if no repository browser (value in UI is Auto) is 
+     * configured since its the only implementation that exists anyway
+     */
     @Override
     public @CheckForNull RepositoryBrowser<?> guessBrowser() {
-      return new TeamSystemWebAccessBrowser(serverUrl);
+        return new TeamSystemWebAccessBrowser(serverUrl);
     }
 
     // Convenience method for tests.

--- a/src/main/java/hudson/plugins/tfs/TeamFoundationServerScm.java
+++ b/src/main/java/hudson/plugins/tfs/TeamFoundationServerScm.java
@@ -14,6 +14,8 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
 
+import javax.annotation.CheckForNull;
+
 import com.microsoft.tfs.core.clients.versioncontrol.specs.version.ChangesetVersionSpec;
 import com.microsoft.tfs.core.clients.versioncontrol.specs.version.DateVersionSpec;
 import com.microsoft.tfs.core.clients.versioncontrol.specs.version.VersionSpec;
@@ -40,6 +42,7 @@ import hudson.model.TaskListener;
 import hudson.plugins.tfs.actions.CheckoutAction;
 import hudson.plugins.tfs.actions.RemoveWorkspaceAction;
 import hudson.plugins.tfs.browsers.TeamFoundationServerRepositoryBrowser;
+import hudson.plugins.tfs.browsers.TeamSystemWebAccessBrowser;
 import hudson.plugins.tfs.model.Project;
 import hudson.plugins.tfs.model.WorkspaceConfiguration;
 import hudson.plugins.tfs.model.Server;
@@ -50,6 +53,7 @@ import hudson.plugins.tfs.util.BuildWorkspaceConfigurationRetriever.BuildWorkspa
 import hudson.scm.ChangeLogParser;
 import hudson.scm.PollingResult;
 import hudson.scm.PollingResult.Change;
+import hudson.scm.RepositoryBrowser;
 import hudson.scm.RepositoryBrowsers;
 import hudson.scm.SCMRevisionState;
 import hudson.scm.SCM;
@@ -414,6 +418,12 @@ public class TeamFoundationServerScm extends SCM {
     public TeamFoundationServerRepositoryBrowser getBrowser() {
         return repositoryBrowser;
     }
+    
+    @Override
+    public @CheckForNull RepositoryBrowser<?> guessBrowser() {
+      return new TeamSystemWebAccessBrowser( serverUrl + projectPath );
+    }
+    
 
     // Convenience method for tests.
     public void setRepositoryBrowser(final TeamFoundationServerRepositoryBrowser repositoryBrowser) {


### PR DESCRIPTION
The updated core dependency to 1.580 allows us to override the new guessBrowser method. It sets a default web access browser if none is configured on a job.

Since there is only one TFVC web browser implementation we can assume it to be used and therefore activated when "(Auto)" e.g. nothing , is configured in the SCM sections "Repository browser"	drop down.

Full build is passing. 

Tested with a Jenkins 2.7.1 instance and a TFS server as well as a VS Online account. Works as expected.

