### PR TITLE
Add global configuration of Team Project Collections and associated credentials

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -228,6 +228,12 @@
       <artifactId>mailer</artifactId>
       <version>1.16</version>
     </dependency>
+    <dependency>
+      <!-- Used for configuring collections globally -->
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>credentials</artifactId>
+      <version>1.22</version>
+    </dependency>
 
     <dependency>
       <groupId>com.microsoft.tfs.sdk</groupId>

--- a/src/main/java/hudson/plugins/tfs/VstsCollectionConfiguration.java
+++ b/src/main/java/hudson/plugins/tfs/VstsCollectionConfiguration.java
@@ -3,9 +3,13 @@ package hudson.plugins.tfs;
 import hudson.Extension;
 import hudson.model.AbstractDescribableImpl;
 import hudson.model.Descriptor;
+import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
+
+import java.net.MalformedURLException;
+import java.net.URL;
 
 public class VstsCollectionConfiguration extends AbstractDescribableImpl<VstsCollectionConfiguration> {
 
@@ -37,6 +41,22 @@ public class VstsCollectionConfiguration extends AbstractDescribableImpl<VstsCol
         @Override
         public String getDisplayName() {
             return "Team Project Collection";
+        }
+
+        @SuppressWarnings("unused")
+        public FormValidation doCheckCollectionUrl(
+                @QueryParameter final String value) {
+
+            try {
+                new URL(value);
+            }
+            catch (MalformedURLException e) {
+                return FormValidation.error("Malformed VSTS/TFS collection URL (%s)", e.getMessage());
+            }
+
+            // TODO: check that it's not a deep URL to a repository, work item, API endpoint, etc.
+
+            return FormValidation.ok();
         }
 
         @SuppressWarnings("unused")

--- a/src/main/java/hudson/plugins/tfs/VstsCollectionConfiguration.java
+++ b/src/main/java/hudson/plugins/tfs/VstsCollectionConfiguration.java
@@ -1,0 +1,50 @@
+package hudson.plugins.tfs;
+
+import hudson.Extension;
+import hudson.model.AbstractDescribableImpl;
+import hudson.model.Descriptor;
+import hudson.util.ListBoxModel;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.QueryParameter;
+
+public class VstsCollectionConfiguration extends AbstractDescribableImpl<VstsCollectionConfiguration> {
+
+    private final String collectionUrl;
+    private final String credentialsId;
+
+    @DataBoundConstructor
+    public VstsCollectionConfiguration(final String collectionUrl, final String credentialsId) {
+        this.collectionUrl = collectionUrl;
+        this.credentialsId = credentialsId;
+    }
+
+    public String getCollectionUrl() {
+        return collectionUrl;
+    }
+
+    public String getCredentialsId() {
+        return credentialsId;
+    }
+
+    @Override
+    public DescriptorImpl getDescriptor() {
+        return (DescriptorImpl) super.getDescriptor();
+    }
+
+    @Extension
+    public static class DescriptorImpl extends Descriptor<VstsCollectionConfiguration> {
+
+        @Override
+        public String getDisplayName() {
+            return "Team Project Collection";
+        }
+
+        @SuppressWarnings("unused")
+        public ListBoxModel doFillCredentialsIdItems(
+            @QueryParameter final String collectionUrl) {
+
+            // TODO: populate listbox with credentials
+            return new ListBoxModel();
+        }
+    }
+}

--- a/src/main/java/hudson/plugins/tfs/VstsCollectionConfiguration.java
+++ b/src/main/java/hudson/plugins/tfs/VstsCollectionConfiguration.java
@@ -1,15 +1,22 @@
 package hudson.plugins.tfs;
 
+import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.common.StandardListBoxModel;
+import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
+import com.cloudbees.plugins.credentials.domains.HostnameRequirement;
 import hudson.Extension;
 import hudson.model.AbstractDescribableImpl;
 import hudson.model.Descriptor;
+import hudson.security.ACL;
 import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
+import jenkins.model.Jenkins;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.List;
 
 public class VstsCollectionConfiguration extends AbstractDescribableImpl<VstsCollectionConfiguration> {
 
@@ -63,8 +70,31 @@ public class VstsCollectionConfiguration extends AbstractDescribableImpl<VstsCol
         public ListBoxModel doFillCredentialsIdItems(
             @QueryParameter final String collectionUrl) {
 
-            // TODO: populate listbox with credentials
-            return new ListBoxModel();
+            final Jenkins jenkins = Jenkins.getInstance();
+
+            String hostName = null;
+            try {
+                final URL url = new URL(collectionUrl);
+                hostName = url.getHost();
+            }
+            catch (final MalformedURLException ignored) {
+            }
+
+            if (hostName == null || !jenkins.hasPermission(Jenkins.ADMINISTER)) {
+                return new ListBoxModel();
+            }
+
+            final HostnameRequirement requirement = new HostnameRequirement(hostName);
+            final List<StandardUsernamePasswordCredentials> matches =
+                CredentialsProvider.lookupCredentials(
+                    StandardUsernamePasswordCredentials.class,
+                    jenkins,
+                    ACL.SYSTEM,
+                    requirement
+                );
+            return new StandardListBoxModel()
+                    .withEmptySelection()
+                    .withAll(matches);
         }
     }
 }

--- a/src/main/java/hudson/plugins/tfs/VstsCollectionConfiguration.java
+++ b/src/main/java/hudson/plugins/tfs/VstsCollectionConfiguration.java
@@ -1,5 +1,7 @@
 package hudson.plugins.tfs;
 
+import com.cloudbees.plugins.credentials.CredentialsMatcher;
+import com.cloudbees.plugins.credentials.CredentialsMatchers;
 import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.common.StandardListBoxModel;
 import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
@@ -7,18 +9,28 @@ import com.cloudbees.plugins.credentials.domains.HostnameRequirement;
 import hudson.Extension;
 import hudson.model.AbstractDescribableImpl;
 import hudson.model.Descriptor;
+import hudson.plugins.tfs.util.StringHelper;
+import hudson.plugins.tfs.util.UriHelper;
 import hudson.security.ACL;
 import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
+import hudson.util.Secret;
 import jenkins.model.Jenkins;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 
+import javax.xml.bind.DatatypeConverter;
+import java.io.IOException;
+import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
+import java.nio.charset.Charset;
 import java.util.List;
 
 public class VstsCollectionConfiguration extends AbstractDescribableImpl<VstsCollectionConfiguration> {
+
+    private static final Charset ASCII = Charset.forName("ASCII");
 
     private final String collectionUrl;
     private final String credentialsId;
@@ -67,6 +79,42 @@ public class VstsCollectionConfiguration extends AbstractDescribableImpl<VstsCol
         }
 
         @SuppressWarnings("unused")
+        public FormValidation doTestCredentials(
+                @QueryParameter final String collectionUrl,
+                @QueryParameter final String credentialsId) {
+
+            final String errorTemplate = "Error: %s";
+
+            String hostName = null;
+            try {
+                final URL url = new URL(collectionUrl);
+                hostName = url.getHost();
+            }
+            catch (final MalformedURLException e) {
+                return FormValidation.error(errorTemplate, e.getMessage());
+            }
+
+            try {
+                final StandardUsernamePasswordCredentials credential = findCredential(hostName, credentialsId);
+                if (StringHelper.endsWithIgnoreCase(hostName, ".visualstudio.com")) {
+                    if (credential == null) {
+                        return FormValidation.error(errorTemplate, "VSTS accounts need credentials, preferably a Personal Access Token");
+                    }
+                }
+                final int code = testConnection(collectionUrl, hostName, credential);
+
+                if (code >= HttpURLConnection.HTTP_BAD_REQUEST) {
+                    return FormValidation.error(errorTemplate, "HTTP code " + code);
+                }
+            }
+            catch (final IOException e) {
+                return FormValidation.error(e, errorTemplate, e.getMessage());
+            }
+
+            return FormValidation.ok("Success!");
+        }
+
+        @SuppressWarnings("unused")
         public ListBoxModel doFillCredentialsIdItems(
             @QueryParameter final String collectionUrl) {
 
@@ -89,6 +137,44 @@ public class VstsCollectionConfiguration extends AbstractDescribableImpl<VstsCol
                     .withEmptySelection()
                     .withAll(matches);
         }
+    }
+
+    static int testConnection(final String collectionUrl, final String hostName, final StandardUsernamePasswordCredentials credentials) throws IOException {
+
+        final URI testUri;
+        if (StringHelper.endsWithIgnoreCase(hostName, ".visualstudio.com")) {
+            testUri = UriHelper.join(collectionUrl, "_apis", "connectiondata");
+        }
+        else {
+            // for on-prem, we can hit this page since TFS 2012
+            testUri = UriHelper.join(collectionUrl, "_home", "About");
+        }
+        final URL testUrl = testUri.toURL();
+        // TODO: configure this connection so it also works through a proxy server
+        final HttpURLConnection connection = (HttpURLConnection) testUrl.openConnection();
+        // TODO: set user-agent
+        if (credentials != null) {
+            final String username = credentials.getUsername();
+            final Secret secretPassword = credentials.getPassword();
+            final String password = secretPassword.getPlainText();
+            final String credPair = username + ":" + password;
+            final byte[] credBytes = credPair.getBytes(ASCII);
+            final String base64enc = DatatypeConverter.printBase64Binary(credBytes);
+
+            connection.setRequestProperty("Authorization", "Basic" + " " + base64enc);
+        }
+
+        // TODO: extract the version from _home/About's <p class="version">Version 11.0.50727.1</p>
+        final int responseCode = connection.getResponseCode();
+
+        return responseCode;
+    }
+
+    static StandardUsernamePasswordCredentials findCredential(final String hostName, final String credentialsId) {
+        final List<StandardUsernamePasswordCredentials> matches = findCredentials(hostName);
+        final CredentialsMatcher matcher = CredentialsMatchers.withId(credentialsId);
+        final StandardUsernamePasswordCredentials result = CredentialsMatchers.firstOrNull(matches, matcher);
+        return result;
     }
 
     static List<StandardUsernamePasswordCredentials> findCredentials(final String hostName) {

--- a/src/main/java/hudson/plugins/tfs/VstsCollectionConfiguration.java
+++ b/src/main/java/hudson/plugins/tfs/VstsCollectionConfiguration.java
@@ -84,17 +84,23 @@ public class VstsCollectionConfiguration extends AbstractDescribableImpl<VstsCol
                 return new ListBoxModel();
             }
 
-            final HostnameRequirement requirement = new HostnameRequirement(hostName);
-            final List<StandardUsernamePasswordCredentials> matches =
-                CredentialsProvider.lookupCredentials(
-                    StandardUsernamePasswordCredentials.class,
-                    jenkins,
-                    ACL.SYSTEM,
-                    requirement
-                );
+            final List<StandardUsernamePasswordCredentials> matches = findCredentials(hostName);
             return new StandardListBoxModel()
                     .withEmptySelection()
                     .withAll(matches);
         }
+    }
+
+    static List<StandardUsernamePasswordCredentials> findCredentials(final String hostName) {
+        final Jenkins jenkins = Jenkins.getInstance();
+        final HostnameRequirement requirement = new HostnameRequirement(hostName);
+        final List<StandardUsernamePasswordCredentials> matches =
+                CredentialsProvider.lookupCredentials(
+                        StandardUsernamePasswordCredentials.class,
+                        jenkins,
+                        ACL.SYSTEM,
+                        requirement
+                );
+        return matches;
     }
 }

--- a/src/main/java/hudson/plugins/tfs/VstsPluginGlobalConfig.java
+++ b/src/main/java/hudson/plugins/tfs/VstsPluginGlobalConfig.java
@@ -1,0 +1,16 @@
+package hudson.plugins.tfs;
+
+import hudson.Extension;
+import jenkins.model.GlobalConfiguration;
+
+/**
+ * All the settings that apply globally.
+ */
+@Extension
+public class VstsPluginGlobalConfig extends GlobalConfiguration {
+
+    @Override
+    public String getDisplayName() {
+        return "Visual Studio Team Services and Team Foundation Server";
+    }
+}

--- a/src/main/java/hudson/plugins/tfs/VstsPluginGlobalConfig.java
+++ b/src/main/java/hudson/plugins/tfs/VstsPluginGlobalConfig.java
@@ -2,12 +2,56 @@ package hudson.plugins.tfs;
 
 import hudson.Extension;
 import jenkins.model.GlobalConfiguration;
+import net.sf.json.JSONObject;
+import org.kohsuke.stapler.StaplerRequest;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * All the settings that apply globally.
  */
 @Extension
 public class VstsPluginGlobalConfig extends GlobalConfiguration {
+
+    private static final Logger LOGGER = Logger.getLogger(VstsPluginGlobalConfig.class.getName());
+
+    private List<VstsCollectionConfiguration> collectionConfigurations = new ArrayList<VstsCollectionConfiguration>();
+
+
+    public VstsPluginGlobalConfig() {
+        load();
+    }
+
+    public VstsPluginGlobalConfig(final List<VstsCollectionConfiguration> collectionConfigurations) {
+        this.collectionConfigurations = collectionConfigurations;
+    }
+
+
+    public List<VstsCollectionConfiguration> getCollectionConfigurations() {
+        return collectionConfigurations;
+    }
+
+    public void setCollectionConfigurations(final List<VstsCollectionConfiguration> collectionConfigurations) {
+        this.collectionConfigurations = collectionConfigurations;
+    }
+
+    @Override
+    public boolean configure(StaplerRequest req, JSONObject json) throws FormException {
+        try {
+            req.bindJSON(this, json);
+        }
+        catch (final Exception e) {
+            final String message = "Configuration error: " + e.getMessage();
+            LOGGER.log(Level.WARNING, message, e);
+            LOGGER.log(Level.FINE, "Form data: {}", json.toString());
+            throw new FormException(message, e, "vsts-configuration");
+        }
+        save();
+        return true;
+    }
 
     @Override
     public String getDisplayName() {

--- a/src/main/java/hudson/plugins/tfs/util/QueryString.java
+++ b/src/main/java/hudson/plugins/tfs/util/QueryString.java
@@ -6,6 +6,21 @@ package hudson.plugins.tfs.util;
 import java.util.LinkedHashMap;
 
 public class QueryString extends LinkedHashMap<String, String> {
+
+    public QueryString() {
+    }
+
+    public QueryString(final String... nameValuePairs) {
+        final int length = nameValuePairs.length;
+        if (length % 2 != 0) {
+            final String message = "This QueryString constructor needs an even number of parameters";
+            throw new IllegalArgumentException(message);
+        }
+        for (int i = 0; i < length; i+=2) {
+            put(nameValuePairs[i], nameValuePairs[i + 1]);
+        }
+    }
+
     @Override
     public String toString() {
         return UriHelper.serializeParameters(this);

--- a/src/main/java/hudson/plugins/tfs/util/StringHelper.java
+++ b/src/main/java/hudson/plugins/tfs/util/StringHelper.java
@@ -1,0 +1,29 @@
+package hudson.plugins.tfs.util;
+
+public class StringHelper {
+
+    public static boolean endsWithIgnoreCase(final String haystack, final String needle)
+    {
+        if (haystack == null)
+            throw new IllegalArgumentException("Parameter 'haystack' is null.");
+        if (needle == null)
+            throw new IllegalArgumentException("Parameter 'needle' is null.");
+
+        final int nl = needle.length();
+        final int hl = haystack.length();
+        if (nl == hl)
+        {
+            return haystack.equalsIgnoreCase(needle);
+        }
+
+        if (nl > hl)
+        {
+            return false;
+        }
+
+        // Inspired by https://stackoverflow.com/a/19154150/
+        final int toffset = hl - nl;
+        return haystack.regionMatches(true, toffset, needle, 0, nl);
+    }
+
+}

--- a/src/main/java/hudson/plugins/tfs/util/UriHelper.java
+++ b/src/main/java/hudson/plugins/tfs/util/UriHelper.java
@@ -23,6 +23,35 @@ public class UriHelper {
         }
     }
 
+    public static URI join(final String collectionUrl, final Object... components) {
+        final StringBuilder sb = new StringBuilder(collectionUrl);
+        final boolean baseEndedWithSlash = endsWithSlash(sb);
+
+        boolean first = true;
+        for (final Object component : components) {
+            boolean hasSlash = false;
+            if (first) {
+                first = false;
+                hasSlash = baseEndedWithSlash;
+            }
+            if (component instanceof String) {
+                final String pathComponent = (String) component;
+                if (!hasSlash) {
+                    sb.append('/');
+                }
+                sb.append(pathComponent);
+            }
+        }
+
+        final String uriString = sb.toString();
+        return URI.create(uriString);
+    }
+
+    static boolean endsWithSlash(final StringBuilder stringBuilder) {
+        final int length = stringBuilder.length();
+        return length > 0 && stringBuilder.charAt(length - 1) == '/';
+    }
+
     public static String serializeParameters(final Map<String, String> parameters) {
         try {
             final StringBuilder sb = new StringBuilder();

--- a/src/main/java/hudson/plugins/tfs/util/UriHelper.java
+++ b/src/main/java/hudson/plugins/tfs/util/UriHelper.java
@@ -30,16 +30,29 @@ public class UriHelper {
         boolean first = true;
         for (final Object component : components) {
             boolean hasSlash = false;
-            if (first) {
-                first = false;
-                hasSlash = baseEndedWithSlash;
+            if (component instanceof QueryString) {
+                final QueryString queryString = (QueryString) component;
+                if (first) {
+                    if (!baseEndedWithSlash) {
+                        sb.append('/');
+                    }
+                }
+                sb.append("?");
+                sb.append(queryString.toString());
+                // a QueryString must be the last of the components
+                break;
             }
-            if (component instanceof String) {
-                final String pathComponent = (String) component;
-                if (!hasSlash) {
+            else {
+                if (first) {
+                    first = false;
+                    if (!baseEndedWithSlash) {
+                        sb.append('/');
+                    }
+                }
+                else {
                     sb.append('/');
                 }
-                sb.append(pathComponent);
+                sb.append(component);
             }
         }
 

--- a/src/main/resources/hudson/plugins/tfs/TeamFoundationServerScm/global.jelly
+++ b/src/main/resources/hudson/plugins/tfs/TeamFoundationServerScm/global.jelly
@@ -1,4 +1,0 @@
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-
-</j:jelly>
-

--- a/src/main/resources/hudson/plugins/tfs/VstsCollectionConfiguration/config.groovy
+++ b/src/main/resources/hudson/plugins/tfs/VstsCollectionConfiguration/config.groovy
@@ -1,0 +1,18 @@
+package hudson.plugins.tfs.VstsCollectionConfiguration;
+
+def f = namespace(lib.FormTagLib);
+def c = namespace(lib.CredentialsTagLib);
+
+f.entry(title: _("Collection URL"), field: "collectionUrl") {
+    f.textbox()
+}
+
+f.entry(title: _("Credentials"), field: "credentialsId") {
+    c.select()
+}
+
+f.entry {
+    div(align: "right") {
+        f.repeatableDeleteButton()
+    }
+}

--- a/src/main/resources/hudson/plugins/tfs/VstsCollectionConfiguration/config.groovy
+++ b/src/main/resources/hudson/plugins/tfs/VstsCollectionConfiguration/config.groovy
@@ -11,6 +11,15 @@ f.entry(title: _("Credentials"), field: "credentialsId") {
     c.select()
 }
 
+f.block() {
+    f.validateButton(
+            title: _("Test connection"),
+            progress: _("Testing..."),
+            method: "testCredentials",
+            with: "collectionUrl,credentialsId"
+    )
+}
+
 f.entry {
     div(align: "right") {
         f.repeatableDeleteButton()

--- a/src/main/resources/hudson/plugins/tfs/VstsCollectionConfiguration/help-collectionUrl.html
+++ b/src/main/resources/hudson/plugins/tfs/VstsCollectionConfiguration/help-collectionUrl.html
@@ -1,0 +1,9 @@
+<div>
+    The URL to the VS Team Services or TFS <em>team project collection</em>.<br />
+    Examples:<br />
+    <ul>
+        <li><code>http://tfs.example.com:8080/tfs/DefaultCollection</code></li>
+        <li><code>https://tfs.example.com:8080/tfs/CustomCollection</code></li>
+        <li><code>https://fabrikam-fiber-inc.visualstudio.com/DefaultCollection</code></li>
+    </ul>
+</div>

--- a/src/main/resources/hudson/plugins/tfs/VstsPluginGlobalConfig/config.groovy
+++ b/src/main/resources/hudson/plugins/tfs/VstsPluginGlobalConfig/config.groovy
@@ -1,0 +1,6 @@
+package hudson.plugins.tfs.VstsPluginGlobalConfig;
+
+def f = namespace(lib.FormTagLib);
+
+f.section(title: descriptor.displayName) {
+}

--- a/src/main/resources/hudson/plugins/tfs/VstsPluginGlobalConfig/config.groovy
+++ b/src/main/resources/hudson/plugins/tfs/VstsPluginGlobalConfig/config.groovy
@@ -3,4 +3,10 @@ package hudson.plugins.tfs.VstsPluginGlobalConfig;
 def f = namespace(lib.FormTagLib);
 
 f.section(title: descriptor.displayName) {
+    f.entry(title: _("Team Project Collections"),
+            field: "collectionConfigurations",
+            help: descriptor.getHelpFile()) {
+
+        f.repeatableProperty(field: "collectionConfigurations")
+    }
 }

--- a/src/main/resources/hudson/plugins/tfs/VstsPluginGlobalConfig/help.jelly
+++ b/src/main/resources/hudson/plugins/tfs/VstsPluginGlobalConfig/help.jelly
@@ -1,0 +1,8 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout">
+    <l:ajax>
+        <div>
+            TODO: add documentation
+        </div>
+    </l:ajax>
+</j:jelly>

--- a/src/test/java/hudson/plugins/tfs/VstsCollectionConfigurationTest.java
+++ b/src/test/java/hudson/plugins/tfs/VstsCollectionConfigurationTest.java
@@ -1,0 +1,11 @@
+package hudson.plugins.tfs;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * A class to test {@link VstsCollectionConfiguration}.
+ */
+public class VstsCollectionConfigurationTest {
+
+}

--- a/src/test/java/hudson/plugins/tfs/util/QueryStringTest.java
+++ b/src/test/java/hudson/plugins/tfs/util/QueryStringTest.java
@@ -17,4 +17,27 @@ public class QueryStringTest {
         Assert.assertEquals("answer=42", actual);
     }
 
+    @Test public void constructor_typical() throws Exception {
+        //noinspection MismatchedQueryAndUpdateOfCollection
+        final QueryString cut = new QueryString("answer", "42");
+
+        final String actual = cut.toString();
+
+        Assert.assertEquals("answer=42", actual);
+    }
+
+    @Test public void constructor_twoPairs() throws Exception {
+        //noinspection MismatchedQueryAndUpdateOfCollection
+        final QueryString cut = new QueryString("answer", "42", "question", "whatdoyoug");
+
+        final String actual = cut.toString();
+
+        Assert.assertEquals("answer=42&question=whatdoyoug", actual);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void constructor_oddParameters() throws Exception {
+        new QueryString("answer");
+    }
+
 }

--- a/src/test/java/hudson/plugins/tfs/util/QueryStringTest.java
+++ b/src/test/java/hudson/plugins/tfs/util/QueryStringTest.java
@@ -1,0 +1,20 @@
+package hudson.plugins.tfs.util;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * A class to test {@link QueryString}.
+ */
+public class QueryStringTest {
+
+    @Test public void toString_typical() throws Exception {
+        final QueryString cut = new QueryString();
+        cut.put("answer", "42");
+
+        final String actual = cut.toString();
+
+        Assert.assertEquals("answer=42", actual);
+    }
+
+}

--- a/src/test/java/hudson/plugins/tfs/util/UriHelperTest.java
+++ b/src/test/java/hudson/plugins/tfs/util/UriHelperTest.java
@@ -1,0 +1,21 @@
+package hudson.plugins.tfs.util;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.net.URI;
+
+/**
+ * A class to test {@link UriHelper}.
+ */
+public class UriHelperTest {
+
+    @Test public void join_noSlash_pathComponents() throws Exception {
+        final String collectionUrl = "https://fabrikam-fiber-inc.visualstudio.com";
+
+        final URI actual = UriHelper.join(collectionUrl, "_home", "About");
+
+        Assert.assertEquals(URI.create("https://fabrikam-fiber-inc.visualstudio.com/_home/About"), actual);
+    }
+
+}

--- a/src/test/java/hudson/plugins/tfs/util/UriHelperTest.java
+++ b/src/test/java/hudson/plugins/tfs/util/UriHelperTest.java
@@ -67,4 +67,13 @@ public class UriHelperTest {
         Assert.assertEquals(URI.create("https://fabrikam-fiber-inc.visualstudio.com/_home/About?answer=42"), actual);
     }
 
+    @Test public void join_sampleApiCall() throws Exception {
+        final String collectionUrl = "https://fabrikam-fiber-inc.visualstudio.com/";
+        final QueryString qs = new QueryString("api-version", "2.0");
+
+        final URI actual = UriHelper.join(collectionUrl, "DefaultCollection", "_apis", "projects", qs);
+
+        Assert.assertEquals(URI.create("https://fabrikam-fiber-inc.visualstudio.com/DefaultCollection/_apis/projects?api-version=2.0"), actual);
+    }
+
 }

--- a/src/test/java/hudson/plugins/tfs/util/UriHelperTest.java
+++ b/src/test/java/hudson/plugins/tfs/util/UriHelperTest.java
@@ -18,4 +18,12 @@ public class UriHelperTest {
         Assert.assertEquals(URI.create("https://fabrikam-fiber-inc.visualstudio.com/_home/About"), actual);
     }
 
+    @Test public void join_withSlash_pathComponents() throws Exception {
+        final String collectionUrl = "https://fabrikam-fiber-inc.visualstudio.com/";
+
+        final URI actual = UriHelper.join(collectionUrl, "_home", "About");
+
+        Assert.assertEquals(URI.create("https://fabrikam-fiber-inc.visualstudio.com/_home/About"), actual);
+    }
+
 }

--- a/src/test/java/hudson/plugins/tfs/util/UriHelperTest.java
+++ b/src/test/java/hudson/plugins/tfs/util/UriHelperTest.java
@@ -1,6 +1,7 @@
 package hudson.plugins.tfs.util;
 
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.net.URI;
@@ -9,6 +10,14 @@ import java.net.URI;
  * A class to test {@link UriHelper}.
  */
 public class UriHelperTest {
+
+    private QueryString lifeUniverseEverything;
+
+    @Before public void setUp() {
+        lifeUniverseEverything = new QueryString();
+        lifeUniverseEverything.put("answer", "42");
+    }
+
 
     @Test public void join_noSlash_pathComponents() throws Exception {
         final String collectionUrl = "https://fabrikam-fiber-inc.visualstudio.com";
@@ -24,6 +33,22 @@ public class UriHelperTest {
         final URI actual = UriHelper.join(collectionUrl, "_home", "About");
 
         Assert.assertEquals(URI.create("https://fabrikam-fiber-inc.visualstudio.com/_home/About"), actual);
+    }
+
+    @Test public void join_noSlash_queryString() throws Exception {
+        final String collectionUrl = "https://fabrikam-fiber-inc.visualstudio.com/";
+
+        final URI actual = UriHelper.join(collectionUrl, lifeUniverseEverything);
+
+        Assert.assertEquals(URI.create("https://fabrikam-fiber-inc.visualstudio.com/?answer=42"), actual);
+    }
+
+    @Test public void join_withSlash_queryString() throws Exception {
+        final String collectionUrl = "https://fabrikam-fiber-inc.visualstudio.com/";
+
+        final URI actual = UriHelper.join(collectionUrl, lifeUniverseEverything);
+
+        Assert.assertEquals(URI.create("https://fabrikam-fiber-inc.visualstudio.com/?answer=42"), actual);
     }
 
 }

--- a/src/test/java/hudson/plugins/tfs/util/UriHelperTest.java
+++ b/src/test/java/hudson/plugins/tfs/util/UriHelperTest.java
@@ -51,4 +51,20 @@ public class UriHelperTest {
         Assert.assertEquals(URI.create("https://fabrikam-fiber-inc.visualstudio.com/?answer=42"), actual);
     }
 
+    @Test public void join_noSlash_pathAndQueryString() throws Exception {
+        final String collectionUrl = "https://fabrikam-fiber-inc.visualstudio.com/";
+
+        final URI actual = UriHelper.join(collectionUrl, "_home", "About", lifeUniverseEverything);
+
+        Assert.assertEquals(URI.create("https://fabrikam-fiber-inc.visualstudio.com/_home/About?answer=42"), actual);
+    }
+
+    @Test public void join_withSlash_pathAndQueryString() throws Exception {
+        final String collectionUrl = "https://fabrikam-fiber-inc.visualstudio.com/";
+
+        final URI actual = UriHelper.join(collectionUrl, "_home", "About", lifeUniverseEverything);
+
+        Assert.assertEquals(URI.create("https://fabrikam-fiber-inc.visualstudio.com/_home/About?answer=42"), actual);
+    }
+
 }


### PR DESCRIPTION
These changes add a new section to the global configuration, where one or more pairs of *Team Project Collection* URL and Credentials can be added (and tested!):

![image](https://cloud.githubusercontent.com/assets/297515/16883507/4dd2b39e-4a92-11e6-877b-3e05ce377c5a.png)

This also lays the groundwork for [JENKINS-13663: Allow use of credentials from Credentials Plugin](https://issues.jenkins-ci.org/browse/JENKINS-13663).

Manual testing
--------------
As can be seen in the screenshot, I added some credentials to Jenkins and then was able to select them when adding/editing team project collections.

The [Test connection] button mostly works for finding errors in the URL and appears to use NTLM when communicating with TFS (even when credentials are provided), so more testing would be required on that front, especially when the Jenkins master is not in a domain, running as a domain user or on Windows.