### PR TITLE
Introduce a simple VSTS REST client

### DIFF
--- a/src/main/java/hudson/plugins/tfs/model/HttpMethod.java
+++ b/src/main/java/hudson/plugins/tfs/model/HttpMethod.java
@@ -1,13 +1,61 @@
 package hudson.plugins.tfs.model;
 
+import org.apache.commons.io.IOUtils;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.ProtocolException;
+import java.nio.charset.Charset;
+
 public enum HttpMethod {
-    GET,
+    GET {
+        @Override
+        public void sendRequest(final HttpURLConnection connection, final String body) throws IOException{
+            // do nothing for GET
+        }
+    },
     POST,
-    HEAD,
+    HEAD {
+        @Override
+        public void sendRequest(final HttpURLConnection connection, final String body) throws IOException{
+            // do nothing for HEAD
+        }
+    },
     PATCH,
     OPTIONS,
     PUT,
     DELETE,
     TRACE,
     ;
+
+    private static final Charset UTF8 = Charset.forName("UTF-8");
+
+    public void sendRequest(final HttpURLConnection connection, final String body) throws IOException {
+        // https://www.visualstudio.com/en-us/docs/integrate/get-started/rest/basics#http-method-override
+        try {
+            connection.setRequestMethod("POST");
+        }
+        catch (final ProtocolException e) {
+            // shouldn't happen
+            throw new Error(e);
+        }
+        connection.setRequestProperty("X-HTTP-Method-Override", this.name());
+
+        if (body != null) {
+            final byte[] bytes = body.getBytes(UTF8);
+            connection.setRequestProperty("Content-Type", "application/json; charset=UTF8");
+            connection.setRequestProperty("Content-Length", Integer.toString(bytes.length, 10));
+            connection.setDoInput(true);
+            connection.setDoOutput(true);
+            OutputStream stream = null;
+            try {
+                stream = connection.getOutputStream();
+                stream.write(bytes);
+            }
+            finally {
+                IOUtils.closeQuietly(stream);
+            }
+        }
+    }
 }

--- a/src/main/java/hudson/plugins/tfs/model/HttpMethod.java
+++ b/src/main/java/hudson/plugins/tfs/model/HttpMethod.java
@@ -1,0 +1,13 @@
+package hudson.plugins.tfs.model;
+
+public enum HttpMethod {
+    GET,
+    POST,
+    HEAD,
+    PATCH,
+    OPTIONS,
+    PUT,
+    DELETE,
+    TRACE,
+    ;
+}

--- a/src/main/java/hudson/plugins/tfs/util/UriHelper.java
+++ b/src/main/java/hudson/plugins/tfs/util/UriHelper.java
@@ -23,6 +23,10 @@ public class UriHelper {
         }
     }
 
+    public static URI join(final URI collectionUri, final Object... components) {
+        return join(collectionUri.toString(), components);
+    }
+
     public static URI join(final String collectionUrl, final Object... components) {
         final StringBuilder sb = new StringBuilder(collectionUrl);
         final boolean baseEndedWithSlash = endsWithSlash(sb);

--- a/src/main/java/hudson/plugins/tfs/util/VstsRestClient.java
+++ b/src/main/java/hudson/plugins/tfs/util/VstsRestClient.java
@@ -1,14 +1,44 @@
 package hudson.plugins.tfs.util;
 
 import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
+import hudson.plugins.tfs.model.HttpMethod;
 import hudson.util.Secret;
+import net.sf.json.JSONObject;
+import net.sf.json.util.JSONTokener;
+import org.apache.commons.io.IOUtils;
 
 import javax.xml.bind.DatatypeConverter;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URL;
 import java.nio.charset.Charset;
 
 public class VstsRestClient {
 
+    private static final String AUTHORIZATION = "Authorization";
+    private static final String NEW_LINE = System.getProperty("line.separator");
     private static final Charset UTF8 = Charset.forName("UTF-8");
+
+    private final URI collectionUri;
+    private final boolean isHosted;
+    private final String authorization;
+
+    public VstsRestClient(final URI collectionUri, final StandardUsernamePasswordCredentials credentials) {
+        this.collectionUri = collectionUri;
+        final String hostName = collectionUri.getHost();
+        isHosted = StringHelper.endsWithIgnoreCase(hostName, ".visualstudio.com");
+        if (credentials != null) {
+            authorization = createAuthorization(credentials);
+        }
+        else {
+            authorization = null;
+        }
+    }
 
     static String createAuthorization(final StandardUsernamePasswordCredentials credentials) {
         final String username = credentials.getUsername();
@@ -19,6 +49,100 @@ public class VstsRestClient {
         final String base64enc = DatatypeConverter.printBase64Binary(credBytes);
         final String result = "Basic " + base64enc;
         return result;
+    }
+
+    protected <TRequest, TResponse> TResponse request(
+        final Class<TResponse> responseClass,
+        final HttpMethod httpMethod,
+        final URI requestUri,
+        final TRequest requestBody
+        ) throws IOException {
+
+        final URL requestUrl;
+        try {
+            requestUrl = requestUri.toURL();
+        }
+        catch (final MalformedURLException e) {
+            throw new Error(e);
+        }
+        // TODO: support Jenkins' proxy server configuration
+        final HttpURLConnection connection = (HttpURLConnection) requestUrl.openConnection();
+        try {
+            if (authorization != null) {
+                connection.setRequestProperty(AUTHORIZATION, authorization);
+            }
+            // TODO: add User-Agent
+
+            final String stringRequestBody;
+            if (requestBody != null) {
+                final JSONObject jsonObject = JSONObject.fromObject(requestBody);
+                stringRequestBody = jsonObject.toString();
+            }
+            else {
+                stringRequestBody = null;
+            }
+
+            final String stringResponseBody = innerRequest(httpMethod, connection, stringRequestBody);
+
+            if (responseClass == Void.class) {
+                return null;
+            }
+
+            if (responseClass == String.class) {
+                return (TResponse) stringResponseBody;
+            }
+
+            final JSONTokener tokener = new JSONTokener(stringResponseBody);
+            final JSONObject jsonObject = JSONObject.fromObject(tokener);
+            final TResponse result = (TResponse) jsonObject.toBean(responseClass);
+            return result;
+        }
+        finally {
+            connection.disconnect();
+        }
+    }
+
+    static String innerRequest(final HttpMethod httpMethod, final HttpURLConnection connection, final String body) throws IOException {
+        httpMethod.sendRequest(connection, body);
+
+        final int httpStatus = connection.getResponseCode();
+        final String stringResult;
+        InputStream responseStream = null;
+        try {
+            if (httpStatus >= HttpURLConnection.HTTP_BAD_REQUEST) {
+                responseStream = connection.getErrorStream();
+                if (responseStream == null) {
+                    responseStream = connection.getInputStream();
+                }
+                final String responseText = readResponseText(responseStream);
+                throw new Error(responseText);
+            }
+            responseStream = connection.getInputStream();
+            stringResult = readResponseText(responseStream);
+        }
+        finally {
+            IOUtils.closeQuietly(responseStream);
+        }
+        return stringResult;
+    }
+
+    static String readResponseText(final InputStream inputStream) throws IOException {
+        final InputStreamReader isr = new InputStreamReader(inputStream);
+        final BufferedReader reader = new BufferedReader(isr);
+        final StringBuilder sb = new StringBuilder();
+        try {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                sb.append(line);
+                sb.append(NEW_LINE);
+            }
+        }
+        finally {
+            IOUtils.closeQuietly(reader);
+            IOUtils.closeQuietly(isr);
+            IOUtils.closeQuietly(inputStream);
+        }
+        return sb.toString();
     }
 
 }

--- a/src/main/java/hudson/plugins/tfs/util/VstsRestClient.java
+++ b/src/main/java/hudson/plugins/tfs/util/VstsRestClient.java
@@ -1,5 +1,24 @@
 package hudson.plugins.tfs.util;
 
+import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
+import hudson.util.Secret;
+
+import javax.xml.bind.DatatypeConverter;
+import java.nio.charset.Charset;
+
 public class VstsRestClient {
+
+    private static final Charset UTF8 = Charset.forName("UTF-8");
+
+    static String createAuthorization(final StandardUsernamePasswordCredentials credentials) {
+        final String username = credentials.getUsername();
+        final Secret secretPassword = credentials.getPassword();
+        final String password = secretPassword.getPlainText();
+        final String credPair = username + ":" + password;
+        final byte[] credBytes = credPair.getBytes(UTF8);
+        final String base64enc = DatatypeConverter.printBase64Binary(credBytes);
+        final String result = "Basic " + base64enc;
+        return result;
+    }
 
 }

--- a/src/main/java/hudson/plugins/tfs/util/VstsRestClient.java
+++ b/src/main/java/hudson/plugins/tfs/util/VstsRestClient.java
@@ -1,0 +1,5 @@
+package hudson.plugins.tfs.util;
+
+public class VstsRestClient {
+
+}

--- a/src/main/java/hudson/plugins/tfs/util/VstsRestClient.java
+++ b/src/main/java/hudson/plugins/tfs/util/VstsRestClient.java
@@ -145,4 +145,16 @@ public class VstsRestClient {
         return sb.toString();
     }
 
+    public String ping() throws IOException {
+        final URI requestUri;
+        if (isHosted) {
+            requestUri = UriHelper.join(collectionUri, "_apis", "connectiondata");
+        }
+        else {
+            requestUri = UriHelper.join(collectionUri, "_home", "About");
+        }
+
+        return request(String.class, HttpMethod.GET, requestUri, null);
+    }
+
 }

--- a/src/test/java/hudson/plugins/tfs/util/UriHelperTest.java
+++ b/src/test/java/hudson/plugins/tfs/util/UriHelperTest.java
@@ -19,6 +19,14 @@ public class UriHelperTest {
     }
 
 
+    @Test public void join_uriNoSlash_pathComponents() throws Exception {
+        final URI collectionUri = URI.create("https://fabrikam-fiber-inc.visualstudio.com");
+
+        final URI actual = UriHelper.join(collectionUri, "_home", "About");
+
+        Assert.assertEquals(URI.create("https://fabrikam-fiber-inc.visualstudio.com/_home/About"), actual);
+    }
+
     @Test public void join_noSlash_pathComponents() throws Exception {
         final String collectionUrl = "https://fabrikam-fiber-inc.visualstudio.com";
 

--- a/src/test/java/hudson/plugins/tfs/util/VstsRestClientTest.java
+++ b/src/test/java/hudson/plugins/tfs/util/VstsRestClientTest.java
@@ -3,11 +3,17 @@ package hudson.plugins.tfs.util;
 import com.cloudbees.plugins.credentials.CredentialsScope;
 import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
 import com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl;
+import hudson.plugins.tfs.IntegrationTestHelper;
+import hudson.plugins.tfs.IntegrationTests;
 import hudson.util.SecretOverride;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.net.URI;
 
 /**
  * A class to test {@link VstsRestClient}.
@@ -38,5 +44,21 @@ public class VstsRestClientTest {
         final String actual = VstsRestClient.createAuthorization(creds);
 
         Assert.assertEquals("Basic UEFUOmFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWE=", actual);
+    }
+
+    @Ignore("Only works on visualstudio.com due to the use of the Authorization header")
+    @Category(IntegrationTests.class)
+    @Test public void ping() throws Exception {
+        final IntegrationTestHelper helper = new IntegrationTestHelper();
+        final URI collectionUri = new URI(helper.getServerUrl());
+        final StandardUsernamePasswordCredentials creds = new UsernamePasswordCredentialsImpl(
+                CredentialsScope.SYSTEM,
+                "vstsBuildAccount",
+                null,
+                helper.getUserName(),
+                helper.getUserPassword());
+        final VstsRestClient cut = new VstsRestClient(collectionUri, creds);
+
+        cut.ping();
     }
 }

--- a/src/test/java/hudson/plugins/tfs/util/VstsRestClientTest.java
+++ b/src/test/java/hudson/plugins/tfs/util/VstsRestClientTest.java
@@ -1,6 +1,12 @@
 package hudson.plugins.tfs.util;
 
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
+import com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl;
+import hudson.util.SecretOverride;
+import org.junit.After;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 
 /**
@@ -8,4 +14,29 @@ import org.junit.Test;
  */
 public class VstsRestClientTest {
 
+    private SecretOverride secretOverride = null;
+
+    @Before public void setUp() throws Exception {
+        secretOverride = new SecretOverride();
+    }
+
+    @After public void tearDown() throws Exception {
+        if (secretOverride != null) {
+            secretOverride.close();
+        }
+    }
+
+    @Test public void createAuthorization_typical() throws Exception {
+        final String personalAccessToken = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        final StandardUsernamePasswordCredentials creds = new UsernamePasswordCredentialsImpl(
+            CredentialsScope.SYSTEM,
+            "vstsBuildAccount",
+            null,
+            "PAT",
+            personalAccessToken);
+
+        final String actual = VstsRestClient.createAuthorization(creds);
+
+        Assert.assertEquals("Basic UEFUOmFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWE=", actual);
+    }
 }

--- a/src/test/java/hudson/plugins/tfs/util/VstsRestClientTest.java
+++ b/src/test/java/hudson/plugins/tfs/util/VstsRestClientTest.java
@@ -1,0 +1,11 @@
+package hudson.plugins.tfs.util;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * A class to test {@link VstsRestClient}.
+ */
+public class VstsRestClientTest {
+
+}


### PR DESCRIPTION
In preparation for a fair amount of interactions with VSTS, created the `VstsRestClient` class as a façade.  A sample of its use can be found in `VstsCollectionConfiguration`, for testing the collection URL paired with the credentials.

Manual testing
--------------

1. Temporarily re-enabled the `ping()` test and ran it with the necessary parameters to connect to a VSTS account.  The ping succeeded.
2. Launched a test Jenkins instance and navigated to the global configuration.  For a VSTS collection URL, clicked the [Test connection] button for:
    1. Valid credentials: **Success!**
    2. Invalid credentials: **Error: Server returned HTTP response code: 401 for URL: https://{collectionUrl}/_apis/connectiondata**
    3. No credentials: **Error: VSTS accounts need credentials, preferably a Personal Access Token**

Mission accomplished!