### PR TITLE
Add base for VSTS web hook

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -234,6 +234,12 @@
       <artifactId>credentials</artifactId>
       <version>1.22</version>
     </dependency>
+    <dependency>
+      <!-- Used for augmenting Git-related activities, like commit status -->
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>git</artifactId>
+      <version>2.5.2</version>
+    </dependency>
 
     <dependency>
       <groupId>com.microsoft.tfs.sdk</groupId>

--- a/src/main/java/hudson/plugins/tfs/VstsCollectionConfiguration.java
+++ b/src/main/java/hudson/plugins/tfs/VstsCollectionConfiguration.java
@@ -31,8 +31,6 @@ import java.util.List;
 
 public class VstsCollectionConfiguration extends AbstractDescribableImpl<VstsCollectionConfiguration> {
 
-    private static final Charset ASCII = Charset.forName("ASCII");
-
     private final String collectionUrl;
     private final String credentialsId;
 

--- a/src/main/java/hudson/plugins/tfs/VstsHookEventName.java
+++ b/src/main/java/hudson/plugins/tfs/VstsHookEventName.java
@@ -1,0 +1,32 @@
+package hudson.plugins.tfs;
+
+/**
+ * Represent the different types of notifications that VSTS can POST to Jenkins.
+ */
+public enum VstsHookEventName {
+    /**
+     * The PING event is raised when testing the connection from VSTS to Jenkins.
+     */
+    PING,
+    /**
+     * The BUILD_COMPLETED event is raised when a VSTS build completes.
+     */
+    BUILD_COMPLETED,
+    /**
+     * The GIT_CODE_PUSHED event is raised when a user pushes to a Git repository.
+     */
+    GIT_CODE_PUSHED,
+    /**
+     * The TFVC_CODE_CHECKED_IN event is raised when a user checks in to a TFVC repository.
+     */
+    TFVC_CODE_CHECKED_IN,
+    /**
+     * The PULL_REQUEST_MERGE_COMMIT_CREATED event is raised when the merge commit
+     * for a pull request has been successfully created, usually as a result of a
+     * push of the corresponding branch.
+     */
+    PULL_REQUEST_MERGE_COMMIT_CREATED,
+    // TODO: clarify the following events
+    DEPLOYMENT_COMPLETED,
+    RELEASE_CREATED,
+}

--- a/src/main/java/hudson/plugins/tfs/VstsHookEventName.java
+++ b/src/main/java/hudson/plugins/tfs/VstsHookEventName.java
@@ -34,7 +34,6 @@ public enum VstsHookEventName {
      * The DEPLOYMENT_COMPLETED event is raised when one of the release's deployments have completed.
      */
     DEPLOYMENT_COMPLETED,
-    RELEASE_CREATED,
     ;
 
     public Object parse(final String body) {

--- a/src/main/java/hudson/plugins/tfs/VstsHookEventName.java
+++ b/src/main/java/hudson/plugins/tfs/VstsHookEventName.java
@@ -7,7 +7,11 @@ public enum VstsHookEventName {
     /**
      * The PING event is raised when testing the connection from VSTS to Jenkins.
      */
-    PING,
+    PING {
+        @Override public Object parse(final String body) {
+            return body;
+        }
+    },
     /**
      * The BUILD_COMPLETED event is raised when a VSTS build completes.
      */
@@ -29,4 +33,9 @@ public enum VstsHookEventName {
     // TODO: clarify the following events
     DEPLOYMENT_COMPLETED,
     RELEASE_CREATED,
+    ;
+
+    public Object parse(final String body) {
+        return new IllegalStateException("Not implemented");
+    }
 }

--- a/src/main/java/hudson/plugins/tfs/VstsHookEventName.java
+++ b/src/main/java/hudson/plugins/tfs/VstsHookEventName.java
@@ -30,7 +30,9 @@ public enum VstsHookEventName {
      * push of the corresponding branch.
      */
     PULL_REQUEST_MERGE_COMMIT_CREATED,
-    // TODO: clarify the following events
+    /**
+     * The DEPLOYMENT_COMPLETED event is raised when one of the release's deployments have completed.
+     */
     DEPLOYMENT_COMPLETED,
     RELEASE_CREATED,
     ;

--- a/src/main/java/hudson/plugins/tfs/VstsWebHook.java
+++ b/src/main/java/hudson/plugins/tfs/VstsWebHook.java
@@ -3,6 +3,7 @@ package hudson.plugins.tfs;
 import hudson.Extension;
 import hudson.model.UnprotectedRootAction;
 import hudson.plugins.git.GitStatus;
+import hudson.plugins.tfs.util.MediaType;
 import hudson.plugins.tfs.util.StringBodyParameter;
 import org.kohsuke.stapler.HttpResponse;
 import org.kohsuke.stapler.HttpResponses;
@@ -83,7 +84,7 @@ public class VstsWebHook implements UnprotectedRootAction {
                 public void generateResponse(StaplerRequest req, StaplerResponse rsp, Object node)
                         throws IOException, ServletException {
                     rsp.setStatus(SC_OK);
-                    rsp.setContentType("text/plain");
+                    rsp.setContentType(MediaType.TEXT_PLAIN);
                     for (GitStatus.ResponseContributor c : finalContributors) {
                         c.addHeaders(req, rsp);
                     }

--- a/src/main/java/hudson/plugins/tfs/VstsWebHook.java
+++ b/src/main/java/hudson/plugins/tfs/VstsWebHook.java
@@ -2,15 +2,26 @@ package hudson.plugins.tfs;
 
 import hudson.Extension;
 import hudson.model.UnprotectedRootAction;
+import hudson.plugins.git.GitStatus;
 import hudson.plugins.tfs.util.StringBodyParameter;
 import org.kohsuke.stapler.HttpResponse;
 import org.kohsuke.stapler.HttpResponses;
 import org.kohsuke.stapler.QueryParameter;
+import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerResponse;
 import org.kohsuke.stapler.interceptor.RequirePOST;
 
 import static javax.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
+import static javax.servlet.http.HttpServletResponse.SC_OK;
+
 import javax.annotation.Nonnull;
+import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.Collections;
+import java.util.List;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
@@ -43,9 +54,15 @@ public class VstsWebHook implements UnprotectedRootAction {
             final HttpServletRequest request,
             @QueryParameter(required = true) @Nonnull final VstsHookEventName event,
             @StringBodyParameter @Nonnull final String body) {
+        LOGGER.log(Level.FINER, "{}/?event={}\n{}", new String[]{URL_NAME, event.name(), body});
+        final Object parsedBody = event.parse(body);
+        List<? extends GitStatus.ResponseContributor> contributors = null;
         switch (event) {
             case PING:
-                return HttpResponses.plainText("Pong from the Jenkins TFS plugin! Here's your body:\n" + body);
+                final String message = "Pong from the Jenkins TFS plugin! Here's your body:\n" + parsedBody;
+                final GitStatus.MessageResponseContributor contributor;
+                contributor = new GitStatus.MessageResponseContributor(message);
+                contributors = Collections.singletonList(contributor);
             case BUILD_COMPLETED:
                 break;
             case GIT_CODE_PUSHED:
@@ -59,6 +76,26 @@ public class VstsWebHook implements UnprotectedRootAction {
             case RELEASE_CREATED:
                 break;
         }
-        return HttpResponses.error(SC_BAD_REQUEST, "Not implemented");
+        if (contributors == null) {
+            return HttpResponses.error(SC_BAD_REQUEST, "Not implemented");
+        }
+        else {
+            final List<? extends GitStatus.ResponseContributor> finalContributors = contributors;
+            return new HttpResponse() {
+                public void generateResponse(StaplerRequest req, StaplerResponse rsp, Object node)
+                        throws IOException, ServletException {
+                    rsp.setStatus(SC_OK);
+                    rsp.setContentType("text/plain");
+                    for (GitStatus.ResponseContributor c : finalContributors) {
+                        c.addHeaders(req, rsp);
+                    }
+                    PrintWriter w = rsp.getWriter();
+                    for (GitStatus.ResponseContributor c : finalContributors) {
+                        c.writeBody(req, rsp, w);
+                    }
+                }
+            };
+
+        }
     }
 }

--- a/src/main/java/hudson/plugins/tfs/VstsWebHook.java
+++ b/src/main/java/hudson/plugins/tfs/VstsWebHook.java
@@ -73,8 +73,6 @@ public class VstsWebHook implements UnprotectedRootAction {
                 break;
             case DEPLOYMENT_COMPLETED:
                 break;
-            case RELEASE_CREATED:
-                break;
         }
         if (contributors == null) {
             return HttpResponses.error(SC_BAD_REQUEST, "Not implemented");

--- a/src/main/java/hudson/plugins/tfs/VstsWebHook.java
+++ b/src/main/java/hudson/plugins/tfs/VstsWebHook.java
@@ -88,6 +88,7 @@ public class VstsWebHook implements UnprotectedRootAction {
                     for (GitStatus.ResponseContributor c : finalContributors) {
                         c.addHeaders(req, rsp);
                     }
+                    rsp.setCharacterEncoding(MediaType.UTF_8.name());
                     PrintWriter w = rsp.getWriter();
                     for (GitStatus.ResponseContributor c : finalContributors) {
                         c.writeBody(req, rsp, w);

--- a/src/main/java/hudson/plugins/tfs/VstsWebHook.java
+++ b/src/main/java/hudson/plugins/tfs/VstsWebHook.java
@@ -1,0 +1,64 @@
+package hudson.plugins.tfs;
+
+import hudson.Extension;
+import hudson.model.UnprotectedRootAction;
+import hudson.plugins.tfs.util.StringBodyParameter;
+import org.kohsuke.stapler.HttpResponse;
+import org.kohsuke.stapler.HttpResponses;
+import org.kohsuke.stapler.QueryParameter;
+import org.kohsuke.stapler.interceptor.RequirePOST;
+
+import static javax.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
+import javax.annotation.Nonnull;
+import javax.servlet.http.HttpServletRequest;
+import java.util.logging.Logger;
+
+/**
+ * The endpoint that VSTS will POST to on push, pull request, etc.
+ */
+@Extension
+public class VstsWebHook implements UnprotectedRootAction {
+
+    private static final Logger LOGGER = Logger.getLogger(VstsWebHook.class.getName());
+
+    public static final String URL_NAME = "vsts-hook";
+
+    @Override
+    public String getIconFileName() {
+        return null;
+    }
+
+    @Override
+    public String getDisplayName() {
+        return null;
+    }
+
+    @Override
+    public String getUrlName() {
+        return URL_NAME;
+    }
+
+    @RequirePOST
+    public HttpResponse doIndex(
+            final HttpServletRequest request,
+            @QueryParameter(required = true) @Nonnull final VstsHookEventName event,
+            @StringBodyParameter @Nonnull final String body) {
+        switch (event) {
+            case PING:
+                return HttpResponses.plainText("Pong from the Jenkins TFS plugin! Here's your body:\n" + body);
+            case BUILD_COMPLETED:
+                break;
+            case GIT_CODE_PUSHED:
+                break;
+            case TFVC_CODE_CHECKED_IN:
+                break;
+            case PULL_REQUEST_MERGE_COMMIT_CREATED:
+                break;
+            case DEPLOYMENT_COMPLETED:
+                break;
+            case RELEASE_CREATED:
+                break;
+        }
+        return HttpResponses.error(SC_BAD_REQUEST, "Not implemented");
+    }
+}

--- a/src/main/java/hudson/plugins/tfs/model/HttpMethod.java
+++ b/src/main/java/hudson/plugins/tfs/model/HttpMethod.java
@@ -30,8 +30,6 @@ public enum HttpMethod {
     TRACE,
     ;
 
-    private static final Charset UTF8 = Charset.forName("UTF-8");
-
     public void sendRequest(final HttpURLConnection connection, final String body) throws IOException {
         // https://www.visualstudio.com/en-us/docs/integrate/get-started/rest/basics#http-method-override
         try {
@@ -44,7 +42,7 @@ public enum HttpMethod {
         connection.setRequestProperty("X-HTTP-Method-Override", this.name());
 
         if (body != null) {
-            final byte[] bytes = body.getBytes(UTF8);
+            final byte[] bytes = body.getBytes(MediaType.UTF_8);
             connection.setRequestProperty("Content-Type", MediaType.APPLICATION_JSON_UTF_8);
             connection.setRequestProperty("Content-Length", Integer.toString(bytes.length, 10));
             connection.setDoInput(true);

--- a/src/main/java/hudson/plugins/tfs/model/HttpMethod.java
+++ b/src/main/java/hudson/plugins/tfs/model/HttpMethod.java
@@ -1,5 +1,6 @@
 package hudson.plugins.tfs.model;
 
+import hudson.plugins.tfs.util.MediaType;
 import org.apache.commons.io.IOUtils;
 
 import java.io.IOException;
@@ -44,7 +45,7 @@ public enum HttpMethod {
 
         if (body != null) {
             final byte[] bytes = body.getBytes(UTF8);
-            connection.setRequestProperty("Content-Type", "application/json; charset=UTF8");
+            connection.setRequestProperty("Content-Type", MediaType.APPLICATION_JSON_UTF_8);
             connection.setRequestProperty("Content-Length", Integer.toString(bytes.length, 10));
             connection.setDoInput(true);
             connection.setDoOutput(true);

--- a/src/main/java/hudson/plugins/tfs/util/MediaType.java
+++ b/src/main/java/hudson/plugins/tfs/util/MediaType.java
@@ -1,0 +1,8 @@
+package hudson.plugins.tfs.util;
+
+public class MediaType {
+    public static final String APPLICATION_FORM_URLENCODED = "application/x-www-form-urlencoded";
+    public static final String APPLICATION_JSON = "application/json";
+    public static final String APPLICATION_JSON_UTF_8 = "application/json; charset=utf-8";
+    public static final String TEXT_PLAIN = "text/plain";
+}

--- a/src/main/java/hudson/plugins/tfs/util/MediaType.java
+++ b/src/main/java/hudson/plugins/tfs/util/MediaType.java
@@ -1,6 +1,9 @@
 package hudson.plugins.tfs.util;
 
+import java.nio.charset.Charset;
+
 public class MediaType {
+    public static final Charset UTF_8 = Charset.forName("UTF-8");
     public static final String APPLICATION_FORM_URLENCODED = "application/x-www-form-urlencoded";
     public static final String APPLICATION_JSON = "application/json";
     public static final String APPLICATION_JSON_UTF_8 = "application/json; charset=utf-8";

--- a/src/main/java/hudson/plugins/tfs/util/StringBodyParameter.java
+++ b/src/main/java/hudson/plugins/tfs/util/StringBodyParameter.java
@@ -34,11 +34,13 @@ public @interface StringBodyParameter {
         @Override
         public Object parse(final StaplerRequest request, final StringBodyParameter a, final Class type, final String parameterName) throws ServletException {
 
-            final String contentType = request.getContentType();
+            final String rawContentType = request.getContentType();
+            final String contentType = StringHelper.determineContentTypeWithoutCharset(rawContentType);
 
             if (MediaType.APPLICATION_JSON.equals(contentType)) {
+                final String characterEncoding = request.getCharacterEncoding();
                 try {
-                    return IOUtils.toString(request.getInputStream(), Charsets.UTF_8);
+                    return IOUtils.toString(request.getInputStream(), characterEncoding);
                 }
                 catch (final IOException e) {
                     LOGGER.log(Level.SEVERE, "Unable to obtain request body: {}", e.getMessage());

--- a/src/main/java/hudson/plugins/tfs/util/StringBodyParameter.java
+++ b/src/main/java/hudson/plugins/tfs/util/StringBodyParameter.java
@@ -1,0 +1,54 @@
+package hudson.plugins.tfs.util;
+
+import com.google.common.base.Charsets;
+import org.apache.commons.io.IOUtils;
+import org.kohsuke.stapler.AnnotationHandler;
+import org.kohsuke.stapler.InjectedParameter;
+import org.kohsuke.stapler.StaplerRequest;
+
+import javax.servlet.ServletException;
+import java.io.IOException;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * {@link InjectedParameter} annotation to use on
+ * {@link org.kohsuke.stapler.WebMethod} parameters to extract the body of the request
+ * as a single string.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.PARAMETER)
+@Documented
+@InjectedParameter(StringBodyParameter.StringBodyHandler.class)
+public @interface StringBodyParameter {
+    class StringBodyHandler extends AnnotationHandler<StringBodyParameter> {
+
+        private static final Logger LOGGER = Logger.getLogger(StringBodyHandler.class.getName());
+
+
+        @Override
+        public Object parse(final StaplerRequest request, final StringBodyParameter a, final Class type, final String parameterName) throws ServletException {
+
+            final String contentType = request.getContentType();
+
+            if ("application/json".equals(contentType)) {
+                try {
+                    return IOUtils.toString(request.getInputStream(), Charsets.UTF_8);
+                }
+                catch (final IOException e) {
+                    LOGGER.log(Level.SEVERE, "Unable to obtain request body: {}", e.getMessage());
+                }
+            }
+            else if ("application/x-www-form-urlencoded".equals(contentType)) {
+                return request.getParameter(parameterName);
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/main/java/hudson/plugins/tfs/util/StringBodyParameter.java
+++ b/src/main/java/hudson/plugins/tfs/util/StringBodyParameter.java
@@ -36,7 +36,7 @@ public @interface StringBodyParameter {
 
             final String contentType = request.getContentType();
 
-            if ("application/json".equals(contentType)) {
+            if (MediaType.APPLICATION_JSON.equals(contentType)) {
                 try {
                     return IOUtils.toString(request.getInputStream(), Charsets.UTF_8);
                 }
@@ -44,11 +44,12 @@ public @interface StringBodyParameter {
                     LOGGER.log(Level.SEVERE, "Unable to obtain request body: {}", e.getMessage());
                 }
             }
-            else if ("application/x-www-form-urlencoded".equals(contentType)) {
+            else if (MediaType.APPLICATION_FORM_URLENCODED.equals(contentType)) {
                 return request.getParameter(parameterName);
             }
 
             return null;
         }
+
     }
 }

--- a/src/main/java/hudson/plugins/tfs/util/StringHelper.java
+++ b/src/main/java/hudson/plugins/tfs/util/StringHelper.java
@@ -26,4 +26,15 @@ public class StringHelper {
         return haystack.regionMatches(true, toffset, needle, 0, nl);
     }
 
+    public static String determineContentTypeWithoutCharset(final String contentType) {
+        if (contentType == null) {
+            return null;
+        }
+        final int indexOfSemicolon = contentType.indexOf(';');
+        if (indexOfSemicolon != -1) {
+            final String beforeCharset = contentType.substring(0, indexOfSemicolon);
+            return beforeCharset.trim();
+        }
+        return contentType;
+    }
 }

--- a/src/main/java/hudson/plugins/tfs/util/VstsRestClient.java
+++ b/src/main/java/hudson/plugins/tfs/util/VstsRestClient.java
@@ -22,7 +22,6 @@ public class VstsRestClient {
 
     private static final String AUTHORIZATION = "Authorization";
     private static final String NEW_LINE = System.getProperty("line.separator");
-    private static final Charset UTF8 = Charset.forName("UTF-8");
 
     private final URI collectionUri;
     private final boolean isHosted;
@@ -45,7 +44,7 @@ public class VstsRestClient {
         final Secret secretPassword = credentials.getPassword();
         final String password = secretPassword.getPlainText();
         final String credPair = username + ":" + password;
-        final byte[] credBytes = credPair.getBytes(UTF8);
+        final byte[] credBytes = credPair.getBytes(MediaType.UTF_8);
         final String base64enc = DatatypeConverter.printBase64Binary(credBytes);
         final String result = "Basic " + base64enc;
         return result;

--- a/src/test/java/hudson/plugins/tfs/util/StringHelperTest.java
+++ b/src/test/java/hudson/plugins/tfs/util/StringHelperTest.java
@@ -1,0 +1,33 @@
+package hudson.plugins.tfs.util;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * A class to test {@link StringHelper}.
+ */
+public class StringHelperTest {
+
+    @Test public void determineContentTypeWithoutCharset_null() throws Exception {
+        final String actual = StringHelper.determineContentTypeWithoutCharset(null);
+
+        Assert.assertEquals(null, actual);
+    }
+
+    @Test public void determineContentTypeWithoutCharset_withoutCharset() throws Exception {
+        final String input = "application/json";
+
+        final String actual = StringHelper.determineContentTypeWithoutCharset(input);
+
+        Assert.assertEquals("application/json", actual);
+    }
+
+    @Test public void determineContentTypeWithoutCharset_withCharset() throws Exception {
+        final String input = "application/json; charset=utf-8";
+
+        final String actual = StringHelper.determineContentTypeWithoutCharset(input);
+
+        Assert.assertEquals("application/json", actual);
+    }
+
+}


### PR DESCRIPTION
These changes add a framework for a VSTS endpoint, with the events we expect to be able to receive from Visual Studio Team Services and Team Foundation Server.

The `VstsWebHook` exposes the `/vsts-hook/` URL where payloads may be POSTed with an event name.

Manual testing
--------------

1. Run `mvn hpi:hpl` to prepare the `tfs.hpl` file, then fix it up to add the TFS SDK JAR to the `CLASSPATH`.  This will allow us to test our plugin in a local Jenkins instance without having to re-deploy.
2. Launch the local Jenkins instance on port 9090: `java -jar jenkins.war --httpPort=9090`
    1. You can see it is responding at `http://localhost:9090`
3. Use cURL to POST to the new `/vsts-hook/` endpoint in `PING` mode, sourcing the body of the request from the `git_code_pushed.json` text file: `curl --request POST http://localhost:9090/vsts-hook/?event=PING --header 'Content-Type: application/json' --upload-file git_code_pushed.json`
    1. In the console, we see the following output:

    ```
    Pong from the Jenkins TFS plugin! Here's your body:
    {
        "repoUrl":"https://mseng.visualstudio.com/Personal/_git/olivida.gcm4ml",
        "serverBaseUrl":"https://mseng.visualstudio.com",
        "projectId":"Personal",
        "repoId":"olivida.gcm4ml",
        "commit":"6a23fc7afec31f0a14bade6544bed4f16492e6d2",
        "pushedBy":"olivida"
    }
    ```
    ...which just so happens to be the contents of the `git_code_pushed.json` file.

Mission accomplished!