### PR TITLE
Add a VSTS push trigger

### DIFF
--- a/src/main/java/hudson/plugins/tfs/CommitParameterAction.java
+++ b/src/main/java/hudson/plugins/tfs/CommitParameterAction.java
@@ -1,0 +1,15 @@
+package hudson.plugins.tfs;
+
+import hudson.plugins.git.RevisionParameterAction;
+
+/**
+ * Used as a build parameter to record information about the associated project and
+ * Visual Studio Team Services account or TFS server to facilitate integration.
+ */
+public class CommitParameterAction extends RevisionParameterAction {
+
+    public CommitParameterAction(final String commit) {
+        super(commit);
+    }
+
+}

--- a/src/main/java/hudson/plugins/tfs/CommitParameterAction.java
+++ b/src/main/java/hudson/plugins/tfs/CommitParameterAction.java
@@ -1,6 +1,7 @@
 package hudson.plugins.tfs;
 
 import hudson.plugins.git.RevisionParameterAction;
+import hudson.plugins.tfs.model.GitCodePushedEventArgs;
 
 /**
  * Used as a build parameter to record information about the associated project and
@@ -8,8 +9,15 @@ import hudson.plugins.git.RevisionParameterAction;
  */
 public class CommitParameterAction extends RevisionParameterAction {
 
-    public CommitParameterAction(final String commit) {
-        super(commit);
+    private final GitCodePushedEventArgs gitCodePushedEventArgs;
+
+    public CommitParameterAction(final GitCodePushedEventArgs e) {
+        super(e.commit, e.getRepoURIish());
+
+        this.gitCodePushedEventArgs = e;
     }
 
+    public GitCodePushedEventArgs getGitCodePushedEventArgs() {
+        return gitCodePushedEventArgs;
+    }
 }

--- a/src/main/java/hudson/plugins/tfs/VstsHookEventName.java
+++ b/src/main/java/hudson/plugins/tfs/VstsHookEventName.java
@@ -1,5 +1,7 @@
 package hudson.plugins.tfs;
 
+import hudson.plugins.tfs.model.GitCodePushedEventArgs;
+
 /**
  * Represent the different types of notifications that VSTS can POST to Jenkins.
  */
@@ -19,7 +21,11 @@ public enum VstsHookEventName {
     /**
      * The GIT_CODE_PUSHED event is raised when a user pushes to a Git repository.
      */
-    GIT_CODE_PUSHED,
+    GIT_CODE_PUSHED {
+        @Override public Object parse(final String body) {
+            return GitCodePushedEventArgs.fromJsonString(body);
+        }
+    },
     /**
      * The TFVC_CODE_CHECKED_IN event is raised when a user checks in to a TFVC repository.
      */

--- a/src/main/java/hudson/plugins/tfs/VstsPushCause.java
+++ b/src/main/java/hudson/plugins/tfs/VstsPushCause.java
@@ -1,0 +1,36 @@
+package hudson.plugins.tfs;
+
+import hudson.triggers.SCMTrigger.SCMTriggerCause;
+import org.apache.commons.lang.StringUtils;
+
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * Indicates that a build was queued because of a VSTS push hook.
+ */
+public class VstsPushCause extends SCMTriggerCause {
+
+    private final String pushedBy;
+
+    public VstsPushCause(final String pushedBy) {
+        this("", pushedBy);
+    }
+
+    public VstsPushCause(final File logFile, final String pushedBy) throws IOException {
+        super(logFile);
+        this.pushedBy = pushedBy;
+    }
+
+    public VstsPushCause(final String pollingLog, final String pushedBy) {
+        super(pollingLog);
+        this.pushedBy = pushedBy;
+    }
+
+    @Override
+    public String getShortDescription() {
+        final String template = "Started by VSTS push by %s";
+        final String message = String.format(template, StringUtils.trimToEmpty(pushedBy));
+        return message;
+    }
+}

--- a/src/main/java/hudson/plugins/tfs/VstsPushTrigger.java
+++ b/src/main/java/hudson/plugins/tfs/VstsPushTrigger.java
@@ -1,17 +1,27 @@
 package hudson.plugins.tfs;
 
 import hudson.Extension;
+import hudson.Util;
 import hudson.model.Action;
+import hudson.model.CauseAction;
 import hudson.model.Item;
 import hudson.model.Job;
+import hudson.model.queue.QueueTaskFuture;
 import hudson.triggers.Trigger;
 import hudson.triggers.TriggerDescriptor;
+import hudson.util.StreamTaskListener;
 import jenkins.model.ParameterizedJobMixIn;
 import jenkins.triggers.SCMTriggerItem;
 import org.kohsuke.stapler.DataBoundConstructor;
 
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.text.DateFormat;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Date;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
@@ -25,9 +35,95 @@ public class VstsPushTrigger extends Trigger<Job<?, ?>> {
     public VstsPushTrigger() {
     }
 
-    public void execute() {
-        // TODO: run polling
-        // TODO: if polling says there are changes, create a VstsPushCause and scheduleBuild()
+    public void execute(final String pushedBy) {
+        // TODO: Consider executing the poll + queue asynchronously
+        final Runner runner = new Runner(pushedBy);
+        runner.run();
+    }
+
+    public File getLogFile() {
+        return new File(job.getRootDir(), "vsts-polling.log");
+    }
+
+    // TODO: This was inspired by SCMTrigger.Runner; it would be worth extracting something for re-use
+    public class Runner implements Runnable {
+
+        private final String pushedBy;
+
+        public Runner(final String pushedBy) {
+            this.pushedBy = pushedBy;
+        }
+
+        private SCMTriggerItem job() {
+            return SCMTriggerItem.SCMTriggerItems.asSCMTriggerItem(job);
+        }
+
+        private boolean runPolling() {
+            final String failedToRecord = "Failed to record SCM polling for " + job;
+            try {
+                final StreamTaskListener listener = new StreamTaskListener(getLogFile());
+
+                try {
+                    final PrintStream logger = listener.getLogger();
+                    final long startTimeMillis = System.currentTimeMillis();
+                    final Date date = new Date(startTimeMillis);
+                    logger.println("Started on "+ DateFormat.getDateTimeInstance().format(date));
+                    final boolean result = job().poll(listener).hasChanges();
+                    final long endTimeMillis = System.currentTimeMillis();
+                    logger.println("Done. Took "+ Util.getTimeSpanString(endTimeMillis - startTimeMillis));
+                    if (result) {
+                        logger.println("Changes found");
+                    }
+                    else {
+                        logger.println("No changes");
+                    }
+                    return result;
+                }
+                catch (final Error e) {
+                    e.printStackTrace(listener.error(failedToRecord));
+                    LOGGER.log(Level.SEVERE, failedToRecord,e);
+                    throw e;
+                }
+                catch (final RuntimeException e) {
+                    e.printStackTrace(listener.error(failedToRecord));
+                    LOGGER.log(Level.SEVERE, failedToRecord,e);
+                    throw e;
+                }
+                finally {
+                    listener.close();
+                }
+            }
+            catch (final IOException e) {
+                LOGGER.log(Level.SEVERE, failedToRecord, e);
+                return false;
+            }
+        }
+
+        @Override
+        public void run() {
+            if (runPolling()) {
+                final String changesDetected = "SCM changes detected in " + job.getFullDisplayName() + ".";
+                final SCMTriggerItem p = job();
+                final String name = " #" + p.getNextBuildNumber();
+                VstsPushCause cause;
+                try {
+                    cause = new VstsPushCause(getLogFile(), pushedBy);
+                }
+                catch (IOException e) {
+                    LOGGER.log(Level.WARNING, "Failed to parse the polling log", e);
+                    cause = new VstsPushCause(pushedBy);
+                }
+                final CauseAction causeAction = new CauseAction(cause);
+                final int quietPeriod = p.getQuietPeriod();
+                final QueueTaskFuture<?> queueTaskFuture = p.scheduleBuild2(quietPeriod, causeAction);
+                if (queueTaskFuture != null) {
+                    LOGGER.info(changesDetected + " Triggering " + name);
+                }
+                else {
+                    LOGGER.info(changesDetected + " Job is already in the queue");
+                }
+            }
+        }
     }
 
     @Override

--- a/src/main/java/hudson/plugins/tfs/VstsPushTrigger.java
+++ b/src/main/java/hudson/plugins/tfs/VstsPushTrigger.java
@@ -1,0 +1,82 @@
+package hudson.plugins.tfs;
+
+import hudson.Extension;
+import hudson.model.Action;
+import hudson.model.Item;
+import hudson.model.Job;
+import hudson.triggers.Trigger;
+import hudson.triggers.TriggerDescriptor;
+import jenkins.model.ParameterizedJobMixIn;
+import jenkins.triggers.SCMTriggerItem;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.logging.Logger;
+
+/**
+ * Triggers a build when we receive a VSTS post-push web hook.
+ */
+public class VstsPushTrigger extends Trigger<Job<?, ?>> {
+
+    private static final Logger LOGGER = Logger.getLogger(VstsPushTrigger.class.getName());
+
+    @DataBoundConstructor
+    public VstsPushTrigger() {
+    }
+
+    public void execute() {
+        // TODO: run polling
+        // TODO: if polling says there are changes, create a VstsPushCause and scheduleBuild()
+    }
+
+    @Override
+    public DescriptorImpl getDescriptor() {
+        return (DescriptorImpl) super.getDescriptor();
+    }
+
+    @Extension
+    public static class DescriptorImpl extends TriggerDescriptor {
+
+        @Override
+        public boolean isApplicable(final Item item) {
+            return item instanceof Job
+                    && SCMTriggerItem.SCMTriggerItems.asSCMTriggerItem(item) != null
+                    && item instanceof ParameterizedJobMixIn.ParameterizedJob;
+        }
+
+        @Override
+        public String getDisplayName() {
+            return "Build when a change is pushed to VSTS";
+        }
+    }
+
+    @Override
+    public Collection<? extends Action> getProjectActions() {
+        if (job == null) {
+            return Collections.emptyList();
+        }
+
+        return Collections.singleton(new VstsPollingAction());
+    }
+
+    public final class VstsPollingAction implements Action {
+
+        @Override
+        public String getIconFileName() {
+            return "clipboard.png";
+        }
+
+        @Override
+        public String getDisplayName() {
+            return "VSTS hook log";
+        }
+
+        @Override
+        public String getUrlName() {
+            return "VstsPollLog";
+        }
+
+        // TODO: what else do we need?
+    }
+}

--- a/src/main/java/hudson/plugins/tfs/VstsWebHook.java
+++ b/src/main/java/hudson/plugins/tfs/VstsWebHook.java
@@ -1,10 +1,29 @@
 package hudson.plugins.tfs;
 
 import hudson.Extension;
+import hudson.model.AbstractProject;
+import hudson.model.CauseAction;
+import hudson.model.Item;
+import hudson.model.Job;
 import hudson.model.UnprotectedRootAction;
+import hudson.plugins.git.GitSCM;
 import hudson.plugins.git.GitStatus;
 import hudson.plugins.tfs.util.MediaType;
+import hudson.plugins.git.RevisionParameterAction;
+import hudson.plugins.git.extensions.impl.IgnoreNotifyCommit;
+import hudson.plugins.tfs.model.GitCodePushedEventArgs;
 import hudson.plugins.tfs.util.StringBodyParameter;
+import hudson.scm.SCM;
+import hudson.security.ACL;
+import hudson.triggers.SCMTrigger;
+import hudson.triggers.Trigger;
+import jenkins.model.Jenkins;
+import jenkins.model.ParameterizedJobMixIn;
+import jenkins.triggers.SCMTriggerItem;
+import org.acegisecurity.context.SecurityContext;
+import org.acegisecurity.context.SecurityContextHolder;
+import org.eclipse.jgit.transport.RemoteConfig;
+import org.eclipse.jgit.transport.URIish;
 import org.kohsuke.stapler.HttpResponse;
 import org.kohsuke.stapler.HttpResponses;
 import org.kohsuke.stapler.QueryParameter;
@@ -12,18 +31,19 @@ import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
 import org.kohsuke.stapler.interceptor.RequirePOST;
 
-import static javax.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
-import static javax.servlet.http.HttpServletResponse.SC_OK;
-
 import javax.annotation.Nonnull;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
+import static javax.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
+import static javax.servlet.http.HttpServletResponse.SC_OK;
 
 /**
  * The endpoint that VSTS will POST to on push, pull request, etc.
@@ -67,6 +87,8 @@ public class VstsWebHook implements UnprotectedRootAction {
             case BUILD_COMPLETED:
                 break;
             case GIT_CODE_PUSHED:
+                final GitCodePushedEventArgs gitCodePushedEventArgs = (GitCodePushedEventArgs) parsedBody;
+                contributors = gitCodePushed(gitCodePushedEventArgs);
                 break;
             case TFVC_CODE_CHECKED_IN:
                 break;
@@ -96,6 +118,181 @@ public class VstsWebHook implements UnprotectedRootAction {
                 }
             };
 
+        }
+    }
+
+    public List<GitStatus.ResponseContributor> gitCodePushed(final GitCodePushedEventArgs gitCodePushedEventArgs) {
+        // TODO: add extension point for this event, then extract current implementation as extension(s)
+
+        List<GitStatus.ResponseContributor> result = new ArrayList<GitStatus.ResponseContributor>();
+        final String commit = gitCodePushedEventArgs.commit;
+        final URIish uri = gitCodePushedEventArgs.getRepoURIish();
+
+        // run in high privilege to see all the projects anonymous users don't see.
+        // this is safe because when we actually schedule a build, it's a build that can
+        // happen at some random time anyway.
+        SecurityContext old = ACL.impersonate(ACL.SYSTEM);
+        try {
+
+            boolean scmFound = false;
+            final Jenkins jenkins = Jenkins.getInstance();
+            if (jenkins == null) {
+                LOGGER.severe("Jenkins.getInstance() is null in VstsWebHook.gitCodePushed");
+                return result;
+            }
+            for (final Item project : Jenkins.getInstance().getAllItems()) {
+                final SCMTriggerItem scmTriggerItem = SCMTriggerItem.SCMTriggerItems.asSCMTriggerItem(project);
+                if (scmTriggerItem == null) {
+                    continue;
+                }
+                for (final SCM scm : scmTriggerItem.getSCMs()) {
+                    if (!(scm instanceof GitSCM)) {
+                        continue;
+                    }
+                    final GitSCM git = (GitSCM) scm;
+                    scmFound = true;
+
+                    for (final RemoteConfig repository : git.getRepositories()) {
+                        boolean repositoryMatches = false;
+                        for (URIish remoteURL : repository.getURIs()) {
+                            if (GitStatus.looselyMatches(uri, remoteURL)) {
+                                repositoryMatches = true;
+                                break;
+                            }
+                        }
+
+                        if (!repositoryMatches || git.getExtensions().get(IgnoreNotifyCommit.class)!=null) {
+                            continue;
+                        }
+
+                        if (!(project instanceof AbstractProject && ((AbstractProject) project).isDisabled())) {
+                            if (project instanceof Job) {
+                                // TODO: Add default parameters defined in the job
+                                final Job job = (Job) project;
+
+                                boolean triggered = false;
+                                if (!triggered) {
+                                    // TODO: check global override here
+                                }
+
+                                if (!triggered) {
+                                    final SCMTrigger scmTrigger = findTrigger(job, SCMTrigger.class);
+                                    if (scmTrigger != null && !scmTrigger.isIgnorePostCommitHooks()) {
+                                        // queue build without first polling
+                                        final int quietPeriod = scmTriggerItem.getQuietPeriod();
+                                        final GitStatus.CommitHookCause commitHookCause = new GitStatus.CommitHookCause(commit);
+                                        final CauseAction causeAction = new CauseAction(commitHookCause);
+                                        final CommitParameterAction commitParameterAction = new CommitParameterAction(gitCodePushedEventArgs);
+                                        scmTriggerItem.scheduleBuild2(quietPeriod, causeAction, commitParameterAction);
+                                        result.add(new ScheduledResponseContributor(project));
+                                        triggered = true;
+                                    }
+                                }
+                                if (!triggered) {
+                                    final VstsPushTrigger pushTrigger = findTrigger(job, VstsPushTrigger.class);
+                                    if (pushTrigger != null) {
+                                        pushTrigger.execute(gitCodePushedEventArgs);
+                                        result.add(new PollingScheduledResponseContributor(project));
+                                        triggered = true;
+                                    }
+                                }
+                                if (triggered) {
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            if (!scmFound) {
+                result.add(new GitStatus.MessageResponseContributor("No Git jobs found"));
+            }
+
+            return result;
+        }
+        finally {
+            SecurityContextHolder.setContext(old);
+        }
+    }
+
+    private static <T extends Trigger> T findTrigger(final Job<?, ?> job, final Class<T> tClass) {
+        if (job instanceof ParameterizedJobMixIn.ParameterizedJob) {
+            final ParameterizedJobMixIn.ParameterizedJob pJob = (ParameterizedJobMixIn.ParameterizedJob) job;
+            for (final Trigger trigger : pJob.getTriggers().values()) {
+                if (tClass.isInstance(trigger)) {
+                    return tClass.cast(trigger);
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * A response contributor for triggering polling of a project.
+     *
+     * @since 1.4.1
+     */
+    private static class PollingScheduledResponseContributor extends GitStatus.ResponseContributor {
+        /**
+         * The project
+         */
+        private final Item project;
+
+        /**
+         * Constructor.
+         *
+         * @param project the project.
+         */
+        public PollingScheduledResponseContributor(Item project) {
+            this.project = project;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public void addHeaders(StaplerRequest req, StaplerResponse rsp) {
+            rsp.addHeader("Triggered", project.getAbsoluteUrl());
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public void writeBody(PrintWriter w) {
+            w.println("Scheduled polling of " + project.getFullDisplayName());
+        }
+    }
+
+    private static class ScheduledResponseContributor extends GitStatus.ResponseContributor {
+        /**
+         * The project
+         */
+        private final Item project;
+
+        /**
+         * Constructor.
+         *
+         * @param project the project.
+         */
+        public ScheduledResponseContributor(Item project) {
+            this.project = project;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public void addHeaders(StaplerRequest req, StaplerResponse rsp) {
+            rsp.addHeader("Triggered", project.getAbsoluteUrl());
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public void writeBody(PrintWriter w) {
+            w.println("Scheduled " + project.getFullDisplayName());
         }
     }
 }

--- a/src/main/java/hudson/plugins/tfs/model/GitCodePushedEventArgs.java
+++ b/src/main/java/hudson/plugins/tfs/model/GitCodePushedEventArgs.java
@@ -3,14 +3,12 @@ package hudson.plugins.tfs.model;
 import net.sf.ezmorph.MorpherRegistry;
 import net.sf.json.JSONObject;
 import net.sf.json.JsonConfig;
-import net.sf.json.processors.PropertyNameProcessor;
 import net.sf.json.util.JSONUtils;
 import net.sf.json.util.JavaIdentifierTransformer;
 
 import java.net.URI;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 public class GitCodePushedEventArgs {
     public URI collectionUri;

--- a/src/main/java/hudson/plugins/tfs/model/GitCodePushedEventArgs.java
+++ b/src/main/java/hudson/plugins/tfs/model/GitCodePushedEventArgs.java
@@ -5,8 +5,10 @@ import net.sf.json.JSONObject;
 import net.sf.json.JsonConfig;
 import net.sf.json.util.JSONUtils;
 import net.sf.json.util.JavaIdentifierTransformer;
+import org.eclipse.jgit.transport.URIish;
 
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.HashMap;
 import java.util.List;
 
@@ -49,5 +51,15 @@ public class GitCodePushedEventArgs {
         }
 
         return result;
+    }
+
+    public URIish getRepoURIish() {
+        final String repoUriString = repoUri.toString();
+        try {
+            return new URIish(repoUriString);
+        } catch (final URISyntaxException e) {
+            // shouldn't happen
+            throw new Error(e);
+        }
     }
 }

--- a/src/main/resources/hudson/plugins/tfs/VstsPushTrigger/VstsPollingAction/index.jelly
+++ b/src/main/resources/hudson/plugins/tfs/VstsPushTrigger/VstsPollingAction/index.jelly
@@ -1,0 +1,45 @@
+<!--
+The MIT License
+
+Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+    <l:layout>
+        <st:include it="${it.owner}" page="sidepanel.jelly" optional="true"/>
+        <l:main-panel>
+            <h1>${(it.displayName)}</h1>
+            <j:set var="log" value="${it.log}" />
+            <j:choose>
+                <j:when test="${empty(log)}">
+                    ${%Polling has not run yet.}
+                </j:when>
+                <j:otherwise>
+                    <pre>
+                        <st:getOutput var="output" />
+                        <j:whitespace>${it.writeLogTo(output)}</j:whitespace>
+                    </pre>
+                </j:otherwise>
+            </j:choose>
+        </l:main-panel>
+    </l:layout>
+</j:jelly>

--- a/src/main/resources/hudson/plugins/tfs/VstsPushTrigger/help.html
+++ b/src/main/resources/hudson/plugins/tfs/VstsPushTrigger/help.html
@@ -1,0 +1,1 @@
+This job will be triggered if Jenkins receives a notification from VSTS for a Git repository defined in the Source Code Management section.

--- a/src/test/java/hudson/plugins/tfs/CommitParameterActionTest.java
+++ b/src/test/java/hudson/plugins/tfs/CommitParameterActionTest.java
@@ -1,0 +1,11 @@
+package hudson.plugins.tfs;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * A class to test {@link CommitParameterAction}.
+ */
+public class CommitParameterActionTest {
+
+}

--- a/src/test/java/hudson/plugins/tfs/VstsHookEventNameTest.java
+++ b/src/test/java/hudson/plugins/tfs/VstsHookEventNameTest.java
@@ -1,0 +1,21 @@
+package hudson.plugins.tfs;
+
+import hudson.plugins.tfs.model.GitCodePushedEventArgs;
+import hudson.plugins.tfs.model.GitCodePushedEventArgsTest;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * A class to test {@link VstsHookEventName}.
+ */
+public class VstsHookEventNameTest {
+
+    @Test public void gitCodePushed() throws Exception {
+        final String input = GitCodePushedEventArgsTest.FORMATTED_INPUT;
+
+        final Object actual = VstsHookEventName.GIT_CODE_PUSHED.parse(input);
+
+        Assert.assertTrue(actual instanceof GitCodePushedEventArgs);
+    }
+
+}


### PR DESCRIPTION
These changes add a **Build when a change is pushed to VSTS** *Build Trigger*, pictured below:

![image](https://cloud.githubusercontent.com/assets/297515/16960473/bd1ec828-4db7-11e6-98fc-013c858d500e.png)

...which has been activated through the `/vsts-hook/` using the `GIT_CODE_PUSHED` event.

Manual testing
--------------
Some steps below will use cURL to POST to the `/vsts-hook/` endpoint in `GIT_CODE_PUSHED` mode, sourcing the body of the request from the `git_code_pushed.json` text file: `curl --request POST http://localhost:9090/vsts-hook/?event=GIT_CODE_PUSHED --header 'Content-Type: application/json; charset=utf-8' --upload-file git_code_pushed.json`
The `git_code_pushed.json` file contains the following JSON:

```json
{
    "collectionUri":"https://mseng.visualstudio.com",
    "repoUri":"https://mseng.visualstudio.com/Personal/_git/olivida.gcm4ml",
    "projectId":"Personal",
    "repoId":"olivida.gcm4ml",
    "commit":"4cd71240a4253737fb281ff477c5fe2d75a2bc3d",
    "pushedBy":"olivida"
}
```

1. Run `mvn hpi:hpl` to prepare the `tfs.hpl` file, then fix it up to add the TFS SDK JAR to the `CLASSPATH`.  This will allow us to test our plugin in a local Jenkins instance without having to re-deploy.
2. Launch the local Jenkins instance on port 9090: `java -jar jenkins.war --httpPort=9090`
    1. You can see it is responding at `http://localhost:9090`
3. Create a project (let's call it **Git**), configure it to use the **Git** SCM against a Git repository in a VSTS account and check the shiny new **Build when a change is pushed to VSTS** checkbox, as well as the **Poll SCM** checkbox.
4. POST to `/vsts-hook/?event=GIT_CODE_PUSHED` once with **Ignore post-commit hooks** checked in the **Git** project.
    1. The console output contains `Scheduled polling of Git`.
    2. Since there were no changes in the Git repository since the last time the **Git** project ran a build, no runs were scheduled.
    3. The `~/.jenkins/jobs/Git/` folder contains `vsts-polling.log`, which contains the result of the poll.  This file is what's displayed when visiting the new `/job/Git/VstsPollLog/` page.
5. POST to `/vsts-hook/?event=GIT_CODE_PUSHED` a second time, this time with **Ignore post-commit hooks** un-checked in the **Git** project.
    1. The console output contains `Scheduled Git`.
    2. A run of the **Git** project was indeed queued and build number 10 was the result.
    3. A quick peek inside `~/.jenkins/jobs/Git/builds/10/build.xml` revealed the file contained the following fragment:

    ```xml
    <hudson.model.CauseAction>
      <causes>
        <hudson.plugins.git.GitStatus_-CommitHookCause plugin="git@2.5.2">
          <sha1>6a23fc7afec31f0a14bade6544bed4f16492e6d2</sha1>
        </hudson.plugins.git.GitStatus_-CommitHookCause>
      </causes>
    </hudson.model.CauseAction>
    <hudson.plugins.tfs.CommitParameterAction plugin="tfs@4.1.1-SNAPSHOT">
      <commit>6a23fc7afec31f0a14bade6544bed4f16492e6d2</commit>
      <combineCommits>false</combineCommits>
      <repoURL plugin="git-client@1.19.6">
        <scheme>https</scheme>
        <path>/Personal/_git/olivida.gcm4ml</path>
        <rawPath>/Personal/_git/olivida.gcm4ml</rawPath>
        <port>-1</port>
        <host>mseng.visualstudio.com</host>
      </repoURL>
      <gitCodePushedEventArgs>
        <collectionUri>https://mseng.visualstudio.com</collectionUri>
        <repoUri>https://mseng.visualstudio.com/Personal/_git/olivida.gcm4ml</repoUri>
        <projectId>Personal</projectId>
        <repoId>olivida.gcm4ml</repoId>
        <commit>6a23fc7afec31f0a14bade6544bed4f16492e6d2</commit>
        <pushedBy>olivida</pushedBy>
      </gitCodePushedEventArgs>
    </hudson.plugins.tfs.CommitParameterAction>
    ```
    ...notice the shiny new `hudson.plugins.tfs.CommitParameterAction`, which contains details that originated in the POST request's payload.

Mission accomplished!