### PR TITLE
Report pending and completion status to the associated VSTS commit

### DIFF
--- a/src/main/java/hudson/plugins/tfs/VstsCompletedStatusPostBuildAction.java
+++ b/src/main/java/hudson/plugins/tfs/VstsCompletedStatusPostBuildAction.java
@@ -1,17 +1,12 @@
 package hudson.plugins.tfs;
 
-import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
 import hudson.Extension;
 import hudson.FilePath;
 import hudson.Launcher;
 import hudson.model.AbstractProject;
-import hudson.model.Result;
 import hudson.model.Run;
 import hudson.model.TaskListener;
-import hudson.plugins.tfs.model.GitCodePushedEventArgs;
-import hudson.plugins.tfs.model.GitStatusState;
-import hudson.plugins.tfs.model.VstsGitStatus;
-import hudson.plugins.tfs.util.VstsRestClient;
+import hudson.plugins.tfs.util.VstsStatus;
 import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.BuildStepMonitor;
 import hudson.tasks.Notifier;
@@ -21,10 +16,6 @@ import org.kohsuke.stapler.DataBoundConstructor;
 
 import javax.annotation.Nonnull;
 import java.io.IOException;
-import java.net.URI;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * A _Post-Build Action_ that reports the completion status of an associated build to VSTS.
@@ -44,27 +35,7 @@ public class VstsCompletedStatusPostBuildAction extends Notifier implements Simp
             @Nonnull final TaskListener listener
     ) throws InterruptedException, IOException {
         try {
-            // TODO: also add support for a build triggered from a pull request
-            final CommitParameterAction commitParameter = run.getAction(CommitParameterAction.class);
-            final GitCodePushedEventArgs args;
-            if (commitParameter != null) {
-                args = commitParameter.getGitCodePushedEventArgs();
-            }
-            else {
-                // TODO: try to guess based on what we _do_ have (i.e. RevisionParameterAction)
-                return;
-            }
-
-            final URI collectionUri = args.collectionUri;
-            final StandardUsernamePasswordCredentials credentials =
-                    VstsCollectionConfiguration.findCredentialsForCollection(collectionUri);
-            final VstsRestClient client = new VstsRestClient(collectionUri, credentials);
-
-            final VstsGitStatus status = VstsGitStatus.fromRun(run);
-            // TODO: when code is pushed and polling happens, are we sure we built against the requested commit?
-            client.addCommitStatus(args, status);
-
-            // TODO: we could contribute an Action to the run, recording the ID of the status we created
+            VstsStatus.createFromRun(run);
         }
         catch (final Exception e) {
             e.printStackTrace(listener.error("Error while trying to update completion status in VSTS"));

--- a/src/main/java/hudson/plugins/tfs/VstsCompletedStatusPostBuildAction.java
+++ b/src/main/java/hudson/plugins/tfs/VstsCompletedStatusPostBuildAction.java
@@ -1,0 +1,58 @@
+package hudson.plugins.tfs;
+
+import hudson.Extension;
+import hudson.FilePath;
+import hudson.Launcher;
+import hudson.model.AbstractProject;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import hudson.tasks.BuildStepDescriptor;
+import hudson.tasks.BuildStepMonitor;
+import hudson.tasks.Notifier;
+import hudson.tasks.Publisher;
+import jenkins.tasks.SimpleBuildStep;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import javax.annotation.Nonnull;
+import java.io.IOException;
+
+/**
+ * A _Post-Build Action_ that reports the completion status of an associated build to VSTS.
+ */
+public class VstsCompletedStatusPostBuildAction extends Notifier implements SimpleBuildStep {
+
+    @DataBoundConstructor
+    public VstsCompletedStatusPostBuildAction() {
+
+    }
+
+    @Override
+    public void perform(
+            @Nonnull final Run<?, ?> run,
+            @Nonnull final FilePath workspace,
+            @Nonnull final Launcher launcher,
+            @Nonnull final TaskListener listener
+    ) throws InterruptedException, IOException {
+        // TODO: implement
+    }
+
+    @Override
+    public BuildStepMonitor getRequiredMonitorService() {
+        // TODO: implement
+        return null;
+    }
+
+    @Extension
+    public static class DescriptorImpl extends BuildStepDescriptor<Publisher> {
+
+        @Override
+        public boolean isApplicable(final Class<? extends AbstractProject> jobType) {
+            return true;
+        }
+
+        @Override
+        public String getDisplayName() {
+            return "Set completion status for VSTS commit or pull request";
+        }
+    }
+}

--- a/src/main/java/hudson/plugins/tfs/VstsCompletedStatusPostBuildAction.java
+++ b/src/main/java/hudson/plugins/tfs/VstsCompletedStatusPostBuildAction.java
@@ -1,11 +1,17 @@
 package hudson.plugins.tfs;
 
+import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
 import hudson.Extension;
 import hudson.FilePath;
 import hudson.Launcher;
 import hudson.model.AbstractProject;
+import hudson.model.Result;
 import hudson.model.Run;
 import hudson.model.TaskListener;
+import hudson.plugins.tfs.model.GitCodePushedEventArgs;
+import hudson.plugins.tfs.model.GitStatusState;
+import hudson.plugins.tfs.model.VstsGitStatus;
+import hudson.plugins.tfs.util.VstsRestClient;
 import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.BuildStepMonitor;
 import hudson.tasks.Notifier;
@@ -15,6 +21,10 @@ import org.kohsuke.stapler.DataBoundConstructor;
 
 import javax.annotation.Nonnull;
 import java.io.IOException;
+import java.net.URI;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * A _Post-Build Action_ that reports the completion status of an associated build to VSTS.
@@ -33,13 +43,38 @@ public class VstsCompletedStatusPostBuildAction extends Notifier implements Simp
             @Nonnull final Launcher launcher,
             @Nonnull final TaskListener listener
     ) throws InterruptedException, IOException {
-        // TODO: implement
+        try {
+            // TODO: also add support for a build triggered from a pull request
+            final CommitParameterAction commitParameter = run.getAction(CommitParameterAction.class);
+            final GitCodePushedEventArgs args;
+            if (commitParameter != null) {
+                args = commitParameter.getGitCodePushedEventArgs();
+            }
+            else {
+                // TODO: try to guess based on what we _do_ have (i.e. RevisionParameterAction)
+                return;
+            }
+
+            final URI collectionUri = args.collectionUri;
+            final StandardUsernamePasswordCredentials credentials =
+                    VstsCollectionConfiguration.findCredentialsForCollection(collectionUri);
+            final VstsRestClient client = new VstsRestClient(collectionUri, credentials);
+
+            final VstsGitStatus status = VstsGitStatus.fromRun(run);
+            // TODO: when code is pushed and polling happens, are we sure we built against the requested commit?
+            client.addCommitStatus(args, status);
+
+            // TODO: we could contribute an Action to the run, recording the ID of the status we created
+        }
+        catch (final Exception e) {
+            e.printStackTrace(listener.error("Error while trying to update completion status in VSTS"));
+        }
     }
 
     @Override
     public BuildStepMonitor getRequiredMonitorService() {
-        // TODO: implement
-        return null;
+        // we don't need the outcome of any previous builds for this step
+        return BuildStepMonitor.NONE;
     }
 
     @Extension

--- a/src/main/java/hudson/plugins/tfs/VstsPendingStatusBuildStep.java
+++ b/src/main/java/hudson/plugins/tfs/VstsPendingStatusBuildStep.java
@@ -6,6 +6,7 @@ import hudson.Launcher;
 import hudson.model.AbstractProject;
 import hudson.model.Run;
 import hudson.model.TaskListener;
+import hudson.plugins.tfs.util.VstsStatus;
 import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.Builder;
 import jenkins.tasks.SimpleBuildStep;
@@ -31,7 +32,12 @@ public class VstsPendingStatusBuildStep extends Builder implements SimpleBuildSt
             @Nonnull final Launcher launcher,
             @Nonnull final TaskListener listener
     ) throws InterruptedException, IOException {
-        // TODO: implement
+        try {
+            VstsStatus.createFromRun(run);
+        }
+        catch (final Exception e) {
+            e.printStackTrace(listener.error("Error while trying to update pending status in VSTS"));
+        }
     }
 
     @Extension

--- a/src/main/java/hudson/plugins/tfs/VstsPendingStatusBuildStep.java
+++ b/src/main/java/hudson/plugins/tfs/VstsPendingStatusBuildStep.java
@@ -1,0 +1,50 @@
+package hudson.plugins.tfs;
+
+import hudson.Extension;
+import hudson.FilePath;
+import hudson.Launcher;
+import hudson.model.AbstractProject;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import hudson.tasks.BuildStepDescriptor;
+import hudson.tasks.Builder;
+import jenkins.tasks.SimpleBuildStep;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import javax.annotation.Nonnull;
+import java.io.IOException;
+
+/**
+ * A _Build Step_ that reports the status of an associated build as "Pending" to VSTS.
+ */
+public class VstsPendingStatusBuildStep extends Builder implements SimpleBuildStep {
+
+    @DataBoundConstructor
+    public VstsPendingStatusBuildStep() {
+
+    }
+
+    @Override
+    public void perform(
+            @Nonnull final Run<?, ?> run,
+            @Nonnull final FilePath workspace,
+            @Nonnull final Launcher launcher,
+            @Nonnull final TaskListener listener
+    ) throws InterruptedException, IOException {
+        // TODO: implement
+    }
+
+    @Extension
+    public static class DescriptorImpl extends BuildStepDescriptor<Builder> {
+
+        @Override
+        public boolean isApplicable(Class<? extends AbstractProject> jobType) {
+            return true;
+        }
+
+        @Override
+        public String getDisplayName() {
+            return "Set pending status for VSTS commit or pull request";
+        }
+    }
+}

--- a/src/main/java/hudson/plugins/tfs/VstsPluginGlobalConfig.java
+++ b/src/main/java/hudson/plugins/tfs/VstsPluginGlobalConfig.java
@@ -1,8 +1,10 @@
 package hudson.plugins.tfs;
 
 import hudson.Extension;
+import hudson.ExtensionList;
 import jenkins.model.GlobalConfiguration;
 import net.sf.json.JSONObject;
+import org.apache.commons.lang3.ObjectUtils;
 import org.kohsuke.stapler.StaplerRequest;
 
 import java.util.ArrayList;
@@ -17,6 +19,7 @@ import java.util.logging.Logger;
 public class VstsPluginGlobalConfig extends GlobalConfiguration {
 
     private static final Logger LOGGER = Logger.getLogger(VstsPluginGlobalConfig.class.getName());
+    private static final VstsPluginGlobalConfig DEFAULT_CONFIG = new VstsPluginGlobalConfig();
 
     private List<VstsCollectionConfiguration> collectionConfigurations = new ArrayList<VstsCollectionConfiguration>();
 
@@ -29,6 +32,12 @@ public class VstsPluginGlobalConfig extends GlobalConfiguration {
         this.collectionConfigurations = collectionConfigurations;
     }
 
+    public static VstsPluginGlobalConfig get() {
+        final ExtensionList<GlobalConfiguration> configurationExtensions = all();
+        final VstsPluginGlobalConfig config = configurationExtensions.get(VstsPluginGlobalConfig.class);
+        final VstsPluginGlobalConfig result = ObjectUtils.defaultIfNull(config, DEFAULT_CONFIG);
+        return result;
+    }
 
     public List<VstsCollectionConfiguration> getCollectionConfigurations() {
         return collectionConfigurations;

--- a/src/main/java/hudson/plugins/tfs/model/GitStatusState.java
+++ b/src/main/java/hudson/plugins/tfs/model/GitStatusState.java
@@ -1,5 +1,9 @@
 package hudson.plugins.tfs.model;
 
+import java.util.Collections;
+import java.util.Map;
+import java.util.TreeMap;
+
 public enum GitStatusState {
 
     NotSet(0),
@@ -8,6 +12,26 @@ public enum GitStatusState {
     Failed(3),
     Error(4),
     ;
+
+    public static final Map<String, GitStatusState> CASE_INSENSITIVE_LOOKUP;
+
+    static {
+        final Map<String, GitStatusState> map = new TreeMap<String, GitStatusState>(String.CASE_INSENSITIVE_ORDER);
+        for (final GitStatusState value : GitStatusState.values()) {
+            map.put(value.name(), value);
+        }
+        CASE_INSENSITIVE_LOOKUP = Collections.unmodifiableMap(map);
+    }
+
+    public static GitStatusState caseInsensitiveValueOf(final String name) {
+        if (name == null) {
+            throw new NullPointerException("Name is null");
+        }
+        if (!CASE_INSENSITIVE_LOOKUP.containsKey(name)) {
+            throw new IllegalArgumentException("No enum constant " + name);
+        }
+        return CASE_INSENSITIVE_LOOKUP.get(name);
+    }
 
     private final int value;
 

--- a/src/main/java/hudson/plugins/tfs/model/GitStatusStateMorpher.java
+++ b/src/main/java/hudson/plugins/tfs/model/GitStatusStateMorpher.java
@@ -1,0 +1,37 @@
+package hudson.plugins.tfs.model;
+
+import net.sf.ezmorph.MorphException;
+import net.sf.ezmorph.ObjectMorpher;
+
+public class GitStatusStateMorpher implements ObjectMorpher {
+
+    public static final GitStatusStateMorpher INSTANCE = new GitStatusStateMorpher();
+
+    private GitStatusStateMorpher() {
+
+    }
+
+    @Override
+    public Object morph(final Object value) {
+        if (value == null) {
+            return null;
+        }
+
+        if (!supports(value.getClass())) {
+            throw new MorphException(value.getClass() + " is not supported");
+        }
+
+        final String s = value.toString();
+        return GitStatusState.caseInsensitiveValueOf(s);
+    }
+
+    @Override
+    public Class morphsTo() {
+        return GitStatusState.class;
+    }
+
+    @Override
+    public boolean supports(Class clazz) {
+        return String.class.isAssignableFrom(clazz);
+    }
+}

--- a/src/main/java/hudson/plugins/tfs/model/VstsGitStatus.java
+++ b/src/main/java/hudson/plugins/tfs/model/VstsGitStatus.java
@@ -32,8 +32,14 @@ public class VstsGitStatus {
     public static VstsGitStatus fromRun(@Nonnull final Run<?, ?> run) {
         final VstsGitStatus status = new VstsGitStatus();
         final Result result = run.getResult();
-        status.state = RESULT_TO_STATE.get(result);
-        status.description = result.toString();
+        if (result == null) {
+            status.state = GitStatusState.Pending;
+            status.description = status.state.toString();
+        }
+        else {
+            status.state = RESULT_TO_STATE.get(result);
+            status.description = result.toString();
+        }
         status.targetUrl = run.getAbsoluteUrl();
         final Job<?, ?> project = run.getParent();
         final String runDisplayName = run.getDisplayName();

--- a/src/main/java/hudson/plugins/tfs/model/VstsGitStatus.java
+++ b/src/main/java/hudson/plugins/tfs/model/VstsGitStatus.java
@@ -1,13 +1,46 @@
 package hudson.plugins.tfs.model;
 
+import hudson.model.Job;
+import hudson.model.Result;
+import hudson.model.Run;
 import net.sf.json.JSONObject;
 
+import javax.annotation.Nonnull;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
 public class VstsGitStatus {
+
+    private static final Map<Result, GitStatusState> RESULT_TO_STATE;
+
+    static {
+        final Map<Result, GitStatusState> resultToStatus = new HashMap<Result, GitStatusState>();
+        resultToStatus.put(Result.SUCCESS, GitStatusState.Succeeded);
+        resultToStatus.put(Result.UNSTABLE, GitStatusState.Failed);
+        resultToStatus.put(Result.FAILURE, GitStatusState.Failed);
+        resultToStatus.put(Result.NOT_BUILT, GitStatusState.Error);
+        resultToStatus.put(Result.ABORTED, GitStatusState.Error);
+        RESULT_TO_STATE = Collections.unmodifiableMap(resultToStatus);
+    }
 
     public GitStatusState state;
     public String description;
     public String targetUrl;
     public GitStatusContext context;
+
+    public static VstsGitStatus fromRun(@Nonnull final Run<?, ?> run) {
+        final VstsGitStatus status = new VstsGitStatus();
+        final Result result = run.getResult();
+        status.state = RESULT_TO_STATE.get(result);
+        status.description = result.toString();
+        status.targetUrl = run.getAbsoluteUrl();
+        final Job<?, ?> project = run.getParent();
+        final String runDisplayName = run.getDisplayName();
+        final String projectDisplayName = project.getDisplayName();
+        status.context = new GitStatusContext(runDisplayName, projectDisplayName);
+        return status;
+    }
 
     public String toJson() {
         final JSONObject jsonObject = JSONObject.fromObject(this);

--- a/src/main/java/hudson/plugins/tfs/util/StringHelper.java
+++ b/src/main/java/hudson/plugins/tfs/util/StringHelper.java
@@ -26,6 +26,28 @@ public class StringHelper {
         return haystack.regionMatches(true, toffset, needle, 0, nl);
     }
 
+    public static boolean equal(final String a, final String b) {
+        return innerEqual(a, b, false);
+    }
+
+    public static boolean equalIgnoringCase(final String a, final String b) {
+        return innerEqual(a, b, true);
+    }
+
+    static boolean innerEqual(final String a, final String b, final boolean ignoreCase) {
+        if (a == null) {
+            return b == null;
+        }
+        if (b == null) {
+            return false;
+        }
+        final int length = a.length();
+        if (length != b.length()) {
+            return false;
+        }
+        return a.regionMatches(ignoreCase, 0, b, 0, length);
+    }
+
     public static String determineContentTypeWithoutCharset(final String contentType) {
         if (contentType == null) {
             return null;

--- a/src/main/java/hudson/plugins/tfs/util/VstsStatus.java
+++ b/src/main/java/hudson/plugins/tfs/util/VstsStatus.java
@@ -1,0 +1,38 @@
+package hudson.plugins.tfs.util;
+
+import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
+import hudson.model.Run;
+import hudson.plugins.tfs.CommitParameterAction;
+import hudson.plugins.tfs.VstsCollectionConfiguration;
+import hudson.plugins.tfs.model.GitCodePushedEventArgs;
+import hudson.plugins.tfs.model.VstsGitStatus;
+
+import javax.annotation.Nonnull;
+import java.io.IOException;
+import java.net.URI;
+
+public class VstsStatus {
+    public static void createFromRun(@Nonnull Run<?, ?> run) throws IOException {
+        // TODO: also add support for a build triggered from a pull request
+        final CommitParameterAction commitParameter = run.getAction(CommitParameterAction.class);
+        final GitCodePushedEventArgs args;
+        if (commitParameter != null) {
+            args = commitParameter.getGitCodePushedEventArgs();
+        }
+        else {
+            // TODO: try to guess based on what we _do_ have (i.e. RevisionParameterAction)
+            return;
+        }
+
+        final URI collectionUri = args.collectionUri;
+        final StandardUsernamePasswordCredentials credentials =
+                VstsCollectionConfiguration.findCredentialsForCollection(collectionUri);
+        final VstsRestClient client = new VstsRestClient(collectionUri, credentials);
+
+        final VstsGitStatus status = VstsGitStatus.fromRun(run);
+        // TODO: when code is pushed and polling happens, are we sure we built against the requested commit?
+        client.addCommitStatus(args, status);
+
+        // TODO: we could contribute an Action to the run, recording the ID of the status we created
+    }
+}

--- a/src/test/java/hudson/plugins/tfs/model/VstsGitStatusTest.java
+++ b/src/test/java/hudson/plugins/tfs/model/VstsGitStatusTest.java
@@ -1,5 +1,9 @@
 package hudson.plugins.tfs.model;
 
+import net.sf.ezmorph.MorpherRegistry;
+import net.sf.json.JSONObject;
+import net.sf.json.util.JSONTokener;
+import net.sf.json.util.JSONUtils;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -29,5 +33,32 @@ public class VstsGitStatusTest {
                 "}" +
             "}";
         Assert.assertEquals(expected, actual);
+    }
+
+    @Test public void fromJsonString_vsts() throws Exception {
+        final String input =
+            "{" +
+                "\"state\":\"succeeded\"," +
+                "\"description\":\"SUCCESS\"," +
+                "\"targetUrl\":\"https://ci.fabrikam.com/my-project/build/124\"," +
+                "\"context\":" +
+                "{" +
+                    "\"name\":\"Build124\"," +
+                    "\"genre\":\"continuous-integration\"" +
+                "}" +
+            "}";
+
+        final JSONTokener tokener = new JSONTokener(input);
+        final JSONObject jsonObject = JSONObject.fromObject(tokener);
+        final MorpherRegistry registry = JSONUtils.getMorpherRegistry();
+        registry.registerMorpher(GitStatusStateMorpher.INSTANCE);
+        final VstsGitStatus actual;
+        try {
+            actual = (VstsGitStatus) jsonObject.toBean(VstsGitStatus.class);
+        }
+        finally {
+            registry.deregisterMorpher(GitStatusStateMorpher.INSTANCE);
+        }
+        Assert.assertEquals(GitStatusState.Succeeded, actual.state);
     }
 }

--- a/src/test/java/hudson/plugins/tfs/util/UriHelperTest.java
+++ b/src/test/java/hudson/plugins/tfs/util/UriHelperTest.java
@@ -18,6 +18,109 @@ public class UriHelperTest {
         lifeUniverseEverything.put("answer", "42");
     }
 
+    private static void assertSame(final String a, final String b) {
+        areSame(a, b, true);
+    }
+
+    private static void assertNotSame(final String a, final String b) {
+        areSame(a, b, false);
+    }
+
+    private static void areSame(final String a, final String b, final boolean expected) {
+        final URI uriA = a == null ? null : URI.create(a);
+        final URI uriB = b == null ? null : URI.create(b);
+        final String template = "Expected '%s' and '%s' to be considered%s the same.";
+        final String message = String.format(template, a, b, expected ? "" : " NOT");
+        Assert.assertEquals(message, expected, UriHelper.areSame(uriA, uriB));
+        Assert.assertEquals(message, expected, UriHelper.areSame(uriB, uriA));
+    }
+
+
+    @Test public void areSame_bothNull() throws Exception {
+        assertSame(null, null);
+    }
+
+    @Test public void areSame_sameInstance() throws Exception {
+        final URI uri = URI.create("http://one.example.com");
+        Assert.assertTrue(UriHelper.areSame(uri, uri));
+    }
+
+    @Test public void areSame_identity() throws Exception {
+        assertSame("http://one.example.com", "http://one.example.com");
+    }
+
+    @Test public void areSame_endsWithSlash() throws Exception {
+        assertSame("http://one.example.com/", "http://one.example.com");
+    }
+
+    @Test public void areSame_schemeCase() throws Exception {
+        assertSame("http://one.example.com", "HTTP://one.example.com");
+    }
+
+    @Test public void areSame_hostCase() throws Exception {
+        assertSame("http://ONE.example.com", "http://one.example.com");
+    }
+
+    @Test public void areSame_implicitPort() throws Exception {
+        assertSame("http://one.example.com", "http://one.example.com:80");
+    }
+
+    @Test public void areSame_withPathSlash() throws Exception {
+        assertSame("http://one.example.com/path/", "http://one.example.com/path/");
+    }
+
+    @Test public void areSame_withPathWithoutSlash() throws Exception {
+        assertSame("http://one.example.com/path/", "http://one.example.com/path");
+    }
+
+    @Test public void areSame_withPathQuery() throws Exception {
+        assertSame("http://one.example.com/search?q=example", "http://one.example.com/search?q=example");
+    }
+
+    @Test public void areSame_withPathQueryFragment() throws Exception {
+        assertSame("http://one.example.com/search?q=example#top", "http://one.example.com/search?q=example#top");
+    }
+
+
+    @Test public void areSame_oneNull() throws Exception {
+
+        assertNotSame("http://one.example.com/path/", null);
+    }
+
+    @Test public void areSame_differentScheme() throws Exception {
+
+        assertNotSame("http://one.example.com/path/", "https://one.example.com/path/");
+    }
+
+    @Test public void areSame_differentHost() throws Exception {
+
+        assertNotSame("http://one.example.com/path/", "http://two.example.com/path/");
+    }
+
+    @Test public void areSame_differentPort() throws Exception {
+
+        assertNotSame("http://one.example.com/path/", "http://one.example.com:8080/path/");
+    }
+
+    @Test public void areSame_differentPath() throws Exception {
+
+        assertNotSame("http://one.example.com/path/", "http://one.example.com/");
+    }
+
+    @Test public void areSame_differentQuery() throws Exception {
+
+        assertNotSame("http://one.example.com/path?q=example", "http://one.example.com/path?q=different");
+    }
+
+    @Test public void areSame_differentFragment() throws Exception {
+
+        assertNotSame("http://one.example.com/path#top", "http://one.example.com/path#bottom");
+    }
+
+    @Test public void areSame_differentFragmentAfterQuery() throws Exception {
+
+        assertNotSame("http://one.example.com/path?q=example#top", "http://one.example.com/path?q=example#bottom");
+    }
 
     @Test public void join_uriNoSlash_pathComponents() throws Exception {
         final URI collectionUri = URI.create("https://fabrikam-fiber-inc.visualstudio.com");


### PR DESCRIPTION
This pull request adds a **Set pending status for VSTS commit or pull request** _build step_ as well as a **Set completion status for VSTS commit or pull request** _post-build action_, as shown below in my test job:

![image](https://cloud.githubusercontent.com/assets/297515/17075149/c169d12c-5058-11e6-88dd-094f50fa6b65.png)

Manual testing
--------------

1. Triggered the `/vsts-hook/` with a specific commit, which queued my test job.
2. As soon as the Maven build started, I went to check on the commit in VSTS.  It had indeed received the "Pending" status.
3. As soon as the build completed successfully, I went to check on the commit in VSTS.  It had indeed received a "Success" status and was linking back to the Jenkins job.
4. I repeated the test, this time arranging for the build to fail.  VSTS indeed reported a "Failure" status, also linking back to the Jenkins job.

Mission accomplished!