### PR TITLE
Report pending and completion status to the associated VSTS pull request

### DIFF
--- a/src/main/java/hudson/plugins/tfs/PullRequestParameterAction.java
+++ b/src/main/java/hudson/plugins/tfs/PullRequestParameterAction.java
@@ -1,0 +1,17 @@
+package hudson.plugins.tfs;
+
+import hudson.plugins.tfs.model.PullRequestMergeCommitCreatedEventArgs;
+
+public class PullRequestParameterAction extends CommitParameterAction {
+
+    private final PullRequestMergeCommitCreatedEventArgs args;
+
+    public PullRequestParameterAction(final PullRequestMergeCommitCreatedEventArgs args) {
+        super(args);
+        this.args = args;
+    }
+
+    public PullRequestMergeCommitCreatedEventArgs getPullRequestMergeCommitCreatedEventArgs() {
+        return args;
+    }
+}

--- a/src/main/java/hudson/plugins/tfs/VstsHookCause.java
+++ b/src/main/java/hudson/plugins/tfs/VstsHookCause.java
@@ -1,0 +1,15 @@
+package hudson.plugins.tfs;
+
+import hudson.plugins.git.GitStatus;
+
+public class VstsHookCause extends GitStatus.CommitHookCause {
+
+    public VstsHookCause(final String sha1) {
+        super(sha1);
+    }
+
+    @Override
+    public String getShortDescription() {
+        return "Started by VSTS web hook for commit " + sha1;
+    }
+}

--- a/src/main/java/hudson/plugins/tfs/VstsHookEventName.java
+++ b/src/main/java/hudson/plugins/tfs/VstsHookEventName.java
@@ -1,6 +1,7 @@
 package hudson.plugins.tfs;
 
 import hudson.plugins.tfs.model.GitCodePushedEventArgs;
+import hudson.plugins.tfs.model.PullRequestMergeCommitCreatedEventArgs;
 
 /**
  * Represent the different types of notifications that VSTS can POST to Jenkins.
@@ -35,7 +36,11 @@ public enum VstsHookEventName {
      * for a pull request has been successfully created, usually as a result of a
      * push of the corresponding branch.
      */
-    PULL_REQUEST_MERGE_COMMIT_CREATED,
+    PULL_REQUEST_MERGE_COMMIT_CREATED {
+        @Override public Object parse(final String body) {
+            return PullRequestMergeCommitCreatedEventArgs.fromJsonString(body);
+        }
+    },
     /**
      * The DEPLOYMENT_COMPLETED event is raised when one of the release's deployments have completed.
      */

--- a/src/main/java/hudson/plugins/tfs/VstsWebHook.java
+++ b/src/main/java/hudson/plugins/tfs/VstsWebHook.java
@@ -2,6 +2,7 @@ package hudson.plugins.tfs;
 
 import hudson.Extension;
 import hudson.model.AbstractProject;
+import hudson.model.Cause;
 import hudson.model.CauseAction;
 import hudson.model.Item;
 import hudson.model.Job;
@@ -187,8 +188,8 @@ public class VstsWebHook implements UnprotectedRootAction {
                                     if (scmTrigger != null && !scmTrigger.isIgnorePostCommitHooks()) {
                                         // queue build without first polling
                                         final int quietPeriod = scmTriggerItem.getQuietPeriod();
-                                        final GitStatus.CommitHookCause commitHookCause = new GitStatus.CommitHookCause(commit);
-                                        final CauseAction causeAction = new CauseAction(commitHookCause);
+                                        final Cause cause = new VstsHookCause(commit);
+                                        final CauseAction causeAction = new CauseAction(cause);
                                         final CommitParameterAction commitParameterAction = new CommitParameterAction(gitCodePushedEventArgs);
                                         scmTriggerItem.scheduleBuild2(quietPeriod, causeAction, commitParameterAction);
                                         result.add(new ScheduledResponseContributor(project));

--- a/src/main/java/hudson/plugins/tfs/VstsWebHook.java
+++ b/src/main/java/hudson/plugins/tfs/VstsWebHook.java
@@ -8,8 +8,8 @@ import hudson.model.Job;
 import hudson.model.UnprotectedRootAction;
 import hudson.plugins.git.GitSCM;
 import hudson.plugins.git.GitStatus;
+import hudson.plugins.tfs.model.PullRequestMergeCommitCreatedEventArgs;
 import hudson.plugins.tfs.util.MediaType;
-import hudson.plugins.git.RevisionParameterAction;
 import hudson.plugins.git.extensions.impl.IgnoreNotifyCommit;
 import hudson.plugins.tfs.model.GitCodePushedEventArgs;
 import hudson.plugins.tfs.util.StringBodyParameter;
@@ -93,6 +93,8 @@ public class VstsWebHook implements UnprotectedRootAction {
             case TFVC_CODE_CHECKED_IN:
                 break;
             case PULL_REQUEST_MERGE_COMMIT_CREATED:
+                final PullRequestMergeCommitCreatedEventArgs pullRequestMergeCommitCreatedEventArgs = (PullRequestMergeCommitCreatedEventArgs) parsedBody;
+                contributors = pullRequestMergeCommitCreated(pullRequestMergeCommitCreatedEventArgs);
                 break;
             case DEPLOYMENT_COMPLETED:
                 break;
@@ -119,6 +121,11 @@ public class VstsWebHook implements UnprotectedRootAction {
             };
 
         }
+    }
+
+    public List<GitStatus.ResponseContributor> pullRequestMergeCommitCreated(final PullRequestMergeCommitCreatedEventArgs args) {
+        // TODO: implement
+        return null;
     }
 
     public List<GitStatus.ResponseContributor> gitCodePushed(final GitCodePushedEventArgs gitCodePushedEventArgs) {

--- a/src/main/java/hudson/plugins/tfs/VstsWebHook.java
+++ b/src/main/java/hudson/plugins/tfs/VstsWebHook.java
@@ -125,8 +125,10 @@ public class VstsWebHook implements UnprotectedRootAction {
     }
 
     public List<GitStatus.ResponseContributor> pullRequestMergeCommitCreated(final PullRequestMergeCommitCreatedEventArgs args) {
-        // TODO: implement
-        return null;
+        final PullRequestParameterAction action = new PullRequestParameterAction(args);
+        // TODO: add extension point for this event, then extract current implementation as extension(s)
+
+        return pollOrQueueFromEvent(args, action);
     }
 
     public List<GitStatus.ResponseContributor> gitCodePushed(final GitCodePushedEventArgs gitCodePushedEventArgs) {

--- a/src/main/java/hudson/plugins/tfs/VstsWebHook.java
+++ b/src/main/java/hudson/plugins/tfs/VstsWebHook.java
@@ -133,6 +133,10 @@ public class VstsWebHook implements UnprotectedRootAction {
         final CommitParameterAction commitParameterAction = new CommitParameterAction(gitCodePushedEventArgs);
         // TODO: add extension point for this event, then extract current implementation as extension(s)
 
+        return pollOrQueueFromEvent(gitCodePushedEventArgs, commitParameterAction);
+    }
+
+    List<GitStatus.ResponseContributor> pollOrQueueFromEvent(final GitCodePushedEventArgs gitCodePushedEventArgs, final CommitParameterAction commitParameterAction) {
         List<GitStatus.ResponseContributor> result = new ArrayList<GitStatus.ResponseContributor>();
         final String commit = gitCodePushedEventArgs.commit;
         final URIish uri = gitCodePushedEventArgs.getRepoURIish();

--- a/src/main/java/hudson/plugins/tfs/VstsWebHook.java
+++ b/src/main/java/hudson/plugins/tfs/VstsWebHook.java
@@ -130,6 +130,7 @@ public class VstsWebHook implements UnprotectedRootAction {
     }
 
     public List<GitStatus.ResponseContributor> gitCodePushed(final GitCodePushedEventArgs gitCodePushedEventArgs) {
+        final CommitParameterAction commitParameterAction = new CommitParameterAction(gitCodePushedEventArgs);
         // TODO: add extension point for this event, then extract current implementation as extension(s)
 
         List<GitStatus.ResponseContributor> result = new ArrayList<GitStatus.ResponseContributor>();
@@ -190,7 +191,6 @@ public class VstsWebHook implements UnprotectedRootAction {
                                         final int quietPeriod = scmTriggerItem.getQuietPeriod();
                                         final Cause cause = new VstsHookCause(commit);
                                         final CauseAction causeAction = new CauseAction(cause);
-                                        final CommitParameterAction commitParameterAction = new CommitParameterAction(gitCodePushedEventArgs);
                                         scmTriggerItem.scheduleBuild2(quietPeriod, causeAction, commitParameterAction);
                                         result.add(new ScheduledResponseContributor(project));
                                         triggered = true;

--- a/src/main/java/hudson/plugins/tfs/VstsWebHook.java
+++ b/src/main/java/hudson/plugins/tfs/VstsWebHook.java
@@ -203,7 +203,7 @@ public class VstsWebHook implements UnprotectedRootAction {
                                 if (!triggered) {
                                     final VstsPushTrigger pushTrigger = findTrigger(job, VstsPushTrigger.class);
                                     if (pushTrigger != null) {
-                                        pushTrigger.execute(gitCodePushedEventArgs);
+                                        pushTrigger.execute(gitCodePushedEventArgs, commitParameterAction);
                                         result.add(new PollingScheduledResponseContributor(project));
                                         triggered = true;
                                     }

--- a/src/main/java/hudson/plugins/tfs/util/VstsRestClient.java
+++ b/src/main/java/hudson/plugins/tfs/util/VstsRestClient.java
@@ -4,6 +4,7 @@ import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredenti
 import hudson.plugins.tfs.model.GitCodePushedEventArgs;
 import hudson.plugins.tfs.model.GitStatusStateMorpher;
 import hudson.plugins.tfs.model.HttpMethod;
+import hudson.plugins.tfs.model.PullRequestMergeCommitCreatedEventArgs;
 import hudson.plugins.tfs.model.VstsGitStatus;
 import hudson.util.Secret;
 import net.sf.ezmorph.MorpherRegistry;
@@ -169,6 +170,28 @@ public class VstsRestClient {
             "_apis", "git",
             "repositories", args.repoId,
             "commits", args.commit,
+            "statuses",
+            qs);
+
+        final MorpherRegistry registry = JSONUtils.getMorpherRegistry();
+        registry.registerMorpher(GitStatusStateMorpher.INSTANCE);
+        try {
+            return request(VstsGitStatus.class, HttpMethod.POST, requestUri, status);
+        }
+        finally {
+            registry.deregisterMorpher(GitStatusStateMorpher.INSTANCE);
+        }
+    }
+
+    public VstsGitStatus addPullRequestIterationStatus(final PullRequestMergeCommitCreatedEventArgs args, final VstsGitStatus status) throws IOException {
+
+        final QueryString qs = new QueryString(API_VERSION, "3.0-preview.1");
+        final URI requestUri = UriHelper.join(
+            collectionUri, args.projectId,
+            "_apis", "git",
+            "repositories", args.repoId,
+            "pullRequests", args.pullRequestId,
+            "iterations", args.iterationId,
             "statuses",
             qs);
 

--- a/src/main/java/hudson/plugins/tfs/util/VstsStatus.java
+++ b/src/main/java/hudson/plugins/tfs/util/VstsStatus.java
@@ -3,8 +3,10 @@ package hudson.plugins.tfs.util;
 import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
 import hudson.model.Run;
 import hudson.plugins.tfs.CommitParameterAction;
+import hudson.plugins.tfs.PullRequestParameterAction;
 import hudson.plugins.tfs.VstsCollectionConfiguration;
 import hudson.plugins.tfs.model.GitCodePushedEventArgs;
+import hudson.plugins.tfs.model.PullRequestMergeCommitCreatedEventArgs;
 import hudson.plugins.tfs.model.VstsGitStatus;
 
 import javax.annotation.Nonnull;
@@ -12,12 +14,20 @@ import java.io.IOException;
 import java.net.URI;
 
 public class VstsStatus {
-    public static void createFromRun(@Nonnull Run<?, ?> run) throws IOException {
+    public static void createFromRun(@Nonnull final Run<?, ?> run) throws IOException {
         // TODO: also add support for a build triggered from a pull request
         final CommitParameterAction commitParameter = run.getAction(CommitParameterAction.class);
         final GitCodePushedEventArgs gitCodePushedEventArgs;
+        final PullRequestMergeCommitCreatedEventArgs pullRequestMergeCommitCreatedEventArgs;
         if (commitParameter != null) {
             gitCodePushedEventArgs = commitParameter.getGitCodePushedEventArgs();
+            if (commitParameter instanceof PullRequestParameterAction) {
+                final PullRequestParameterAction prpa = (PullRequestParameterAction) commitParameter;
+                pullRequestMergeCommitCreatedEventArgs = prpa.getPullRequestMergeCommitCreatedEventArgs();
+            }
+            else {
+                pullRequestMergeCommitCreatedEventArgs = null;
+            }
         }
         else {
             // TODO: try to guess based on what we _do_ have (i.e. RevisionParameterAction)
@@ -31,7 +41,12 @@ public class VstsStatus {
 
         final VstsGitStatus status = VstsGitStatus.fromRun(run);
         // TODO: when code is pushed and polling happens, are we sure we built against the requested commit?
-        client.addCommitStatus(gitCodePushedEventArgs, status);
+        if (pullRequestMergeCommitCreatedEventArgs != null) {
+            client.addPullRequestIterationStatus(pullRequestMergeCommitCreatedEventArgs, status);
+        }
+        if (gitCodePushedEventArgs != null) {
+            client.addCommitStatus(gitCodePushedEventArgs, status);
+        }
 
         // TODO: we could contribute an Action to the run, recording the ID of the status we created
     }

--- a/src/main/java/hudson/plugins/tfs/util/VstsStatus.java
+++ b/src/main/java/hudson/plugins/tfs/util/VstsStatus.java
@@ -15,23 +15,23 @@ public class VstsStatus {
     public static void createFromRun(@Nonnull Run<?, ?> run) throws IOException {
         // TODO: also add support for a build triggered from a pull request
         final CommitParameterAction commitParameter = run.getAction(CommitParameterAction.class);
-        final GitCodePushedEventArgs args;
+        final GitCodePushedEventArgs gitCodePushedEventArgs;
         if (commitParameter != null) {
-            args = commitParameter.getGitCodePushedEventArgs();
+            gitCodePushedEventArgs = commitParameter.getGitCodePushedEventArgs();
         }
         else {
             // TODO: try to guess based on what we _do_ have (i.e. RevisionParameterAction)
             return;
         }
 
-        final URI collectionUri = args.collectionUri;
+        final URI collectionUri = gitCodePushedEventArgs.collectionUri;
         final StandardUsernamePasswordCredentials credentials =
                 VstsCollectionConfiguration.findCredentialsForCollection(collectionUri);
         final VstsRestClient client = new VstsRestClient(collectionUri, credentials);
 
         final VstsGitStatus status = VstsGitStatus.fromRun(run);
         // TODO: when code is pushed and polling happens, are we sure we built against the requested commit?
-        client.addCommitStatus(args, status);
+        client.addCommitStatus(gitCodePushedEventArgs, status);
 
         // TODO: we could contribute an Action to the run, recording the ID of the status we created
     }

--- a/src/test/java/hudson/plugins/tfs/VstsHookEventNameTest.java
+++ b/src/test/java/hudson/plugins/tfs/VstsHookEventNameTest.java
@@ -2,6 +2,8 @@ package hudson.plugins.tfs;
 
 import hudson.plugins.tfs.model.GitCodePushedEventArgs;
 import hudson.plugins.tfs.model.GitCodePushedEventArgsTest;
+import hudson.plugins.tfs.model.PullRequestMergeCommitCreatedEventArgs;
+import hudson.plugins.tfs.model.PullRequestMergeCommitCreatedEventArgsTest;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -18,4 +20,11 @@ public class VstsHookEventNameTest {
         Assert.assertTrue(actual instanceof GitCodePushedEventArgs);
     }
 
+    @Test public void pullRequestMergeCommitCreated() throws Exception {
+        final String input = PullRequestMergeCommitCreatedEventArgsTest.FORMATTED_INPUT;
+
+        final Object actual = VstsHookEventName.PULL_REQUEST_MERGE_COMMIT_CREATED.parse(input);
+
+        Assert.assertTrue(actual instanceof PullRequestMergeCommitCreatedEventArgs);
+    }
 }


### PR DESCRIPTION
This pull request augments the recently-added build step and post-build action to also handle pull request status, assuming the right payload was delivered to the web hook.

Manual testing
--------------

1. Configured a freestyle job to use the TFS plugin's recently-added **Set pending status** build step as well as the **Set completion status** post-build action: ![image](https://cloud.githubusercontent.com/assets/297515/17075149/c169d12c-5058-11e6-88dd-094f50fa6b65.png)
2. Triggered the `/vsts-hook/` as the PULL_REQUEST_MERGE_COMMIT_CREATED event with a specific commit, pull request ID and iteration ID, which queued my test job.
3. Because there's no UI for the pull request status, I visited the pull request iteration's `/statuses` URL in my web browser to confirm that the "Pending" and "SUCCESS" statuses were created and linked back to the Jenkins job.
4. I also visited the associated commit ID's `/statuses` URL in my web browser to confirm that the same Jenkins build statuses ("Pending" and "SUCCESS") were reported.

Mission accomplished!