### PR TITLE
JENKINS-30330: Only request workspaces for the current computer

### DIFF
--- a/src/main/java/hudson/plugins/tfs/commands/ListWorkspacesCommand.java
+++ b/src/main/java/hudson/plugins/tfs/commands/ListWorkspacesCommand.java
@@ -22,18 +22,21 @@ public class ListWorkspacesCommand extends AbstractCallableCommand implements Ca
     private static final String ListingWorkspacesTemplate = "Listing workspaces from %s...";
 
     private final String computer;
+    private final boolean shouldLogWorkspaces;
 
     public interface WorkspaceFactory {
         Workspace createWorkspace(String name, String computer, String owner, String comment);
     }
     
     public ListWorkspacesCommand(final ServerConfigurationProvider server) {
-        this(server, null);
+        // TODO: shouldLogWorkspaces could be controlled by a property
+        this(server, null, false);
     }
 
-    ListWorkspacesCommand(final ServerConfigurationProvider server, final String computer) {
+    ListWorkspacesCommand(final ServerConfigurationProvider server, final String computer, final boolean shouldLogWorkspaces) {
         super(server);
         this.computer = computer;
+        this.shouldLogWorkspaces = shouldLogWorkspaces;
     }
 
     @Override
@@ -74,7 +77,9 @@ public class ListWorkspacesCommand extends AbstractCallableCommand implements Ca
             result.add(workspace);
         }
 
-        log(result, logger);
+        if (shouldLogWorkspaces) {
+            log(result, logger);
+        }
 
         return result;
     }

--- a/src/main/java/hudson/plugins/tfs/commands/ListWorkspacesCommand.java
+++ b/src/main/java/hudson/plugins/tfs/commands/ListWorkspacesCommand.java
@@ -1,6 +1,7 @@
 package hudson.plugins.tfs.commands;
 
 import com.microsoft.tfs.core.clients.versioncontrol.WorkspacePermissions;
+import com.microsoft.tfs.jni.helpers.LocalHost;
 import hudson.Util;
 import hudson.model.TaskListener;
 import hudson.plugins.tfs.model.MockableVersionControlClient;
@@ -30,7 +31,7 @@ public class ListWorkspacesCommand extends AbstractCallableCommand implements Ca
         this(server, null);
     }
 
-    public ListWorkspacesCommand(final ServerConfigurationProvider server, final String computer) {
+    ListWorkspacesCommand(final ServerConfigurationProvider server, final String computer) {
         super(server);
         this.computer = computer;
     }
@@ -45,6 +46,7 @@ public class ListWorkspacesCommand extends AbstractCallableCommand implements Ca
         final MockableVersionControlClient vcc = server.getVersionControlClient();
         final TaskListener listener = server.getListener();
         final PrintStream logger = listener.getLogger();
+        final String computerName = (computer != null) ? computer : LocalHost.getShortName();
 
         final String listWorkspacesMessage = String.format(ListingWorkspacesTemplate, server.getUrl());
         logger.println(listWorkspacesMessage);
@@ -53,7 +55,7 @@ public class ListWorkspacesCommand extends AbstractCallableCommand implements Ca
                 = vcc.queryWorkspaces(
                 null,
                 null,
-                Util.fixEmpty(computer),
+                computerName,
                 WorkspacePermissions.NONE_OR_NOT_SUPPORTED
         );
 

--- a/src/main/java/hudson/plugins/tfs/model/Workspaces.java
+++ b/src/main/java/hudson/plugins/tfs/model/Workspaces.java
@@ -1,14 +1,13 @@
 package hudson.plugins.tfs.model;
 
-import java.io.IOException;
+import hudson.plugins.tfs.commands.DeleteWorkspaceCommand;
+import hudson.plugins.tfs.commands.ListWorkspacesCommand;
+import hudson.plugins.tfs.commands.NewWorkspaceCommand;
+
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import hudson.plugins.tfs.commands.DeleteWorkspaceCommand;
-import hudson.plugins.tfs.commands.ListWorkspacesCommand;
-import hudson.plugins.tfs.commands.NewWorkspaceCommand;
 
 /**
  * Class that creates, deletes and gets workspaces from a TeamFoundationServer.
@@ -20,7 +19,7 @@ public class Workspaces implements ListWorkspacesCommand.WorkspaceFactory {
     private Map<String,Workspace> workspaces = new HashMap<String,Workspace>();
     private Server server;
     private boolean mapIsPopulatedFromServer;
-    
+
     public Workspaces(Server server) {
         this.server = server;
     }
@@ -30,6 +29,7 @@ public class Workspaces implements ListWorkspacesCommand.WorkspaceFactory {
      * @return the list of workspaces at the server
      */
     private List<Workspace> getListFromServer() {
+        // the 2nd arg must NOT be provided, to force computerName resolution on the agent & not the master
         ListWorkspacesCommand command = new ListWorkspacesCommand(server);
         final List<Workspace> result = server.execute(command.getCallable());
         return result;

--- a/src/test/java/hudson/plugins/tfs/commands/ListWorkspacesCommandTest.java
+++ b/src/test/java/hudson/plugins/tfs/commands/ListWorkspacesCommandTest.java
@@ -1,14 +1,5 @@
 package hudson.plugins.tfs.commands;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
-
-import java.io.IOException;
-import java.io.StringReader;
-import java.net.URI;
-import java.util.ArrayList;
-import java.util.List;
-
 import com.microsoft.tfs.core.TFSTeamProjectCollection;
 import com.microsoft.tfs.core.clients.versioncontrol.VersionControlClient;
 import com.microsoft.tfs.core.clients.versioncontrol.WorkspaceLocation;
@@ -19,11 +10,23 @@ import hudson.plugins.tfs.IntegrationTests;
 import hudson.plugins.tfs.model.NativeLibraryManager;
 import hudson.plugins.tfs.model.Server;
 import hudson.plugins.tfs.model.Workspace;
-
 import hudson.remoting.Callable;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.jvnet.hudson.test.Bug;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Matchers.isA;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class ListWorkspacesCommandTest extends AbstractCallableCommandTest {
 
@@ -98,7 +101,7 @@ public class ListWorkspacesCommandTest extends AbstractCallableCommandTest {
                     WorkspaceLocation.SERVER
             );
             when(server.getUrl()).thenReturn("http://tfs.invalid:8080/tfs/DefaultCollection/");
-            when(this.vcc.queryWorkspaces(null, null, null, WorkspacePermissions.NONE_OR_NOT_SUPPORTED))
+            when(this.vcc.queryWorkspaces(anyString(), anyString(), anyString(), isA(WorkspacePermissions.class)))
                     .thenReturn(workspaces);
             final ListWorkspacesCommand command = new ListWorkspacesCommand(server, null) {
                 @Override

--- a/src/test/java/hudson/plugins/tfs/commands/ListWorkspacesCommandTest.java
+++ b/src/test/java/hudson/plugins/tfs/commands/ListWorkspacesCommandTest.java
@@ -56,7 +56,7 @@ public class ListWorkspacesCommandTest extends AbstractCallableCommandTest {
             when(server.getUrl()).thenReturn("http://tfs.invalid:8080/tfs/DefaultCollection/");
             when(this.vcc.queryWorkspaces(null, null, "XXXX-XXXX-007", WorkspacePermissions.NONE_OR_NOT_SUPPORTED))
                     .thenReturn(workspaces);
-            final ListWorkspacesCommand command = new ListWorkspacesCommand(server, "XXXX-XXXX-007") {
+            final ListWorkspacesCommand command = new ListWorkspacesCommand(server, "XXXX-XXXX-007", true) {
                 @Override
                 public Server createServer() {
                     return server;
@@ -103,7 +103,7 @@ public class ListWorkspacesCommandTest extends AbstractCallableCommandTest {
             when(server.getUrl()).thenReturn("http://tfs.invalid:8080/tfs/DefaultCollection/");
             when(this.vcc.queryWorkspaces(anyString(), anyString(), anyString(), isA(WorkspacePermissions.class)))
                     .thenReturn(workspaces);
-            final ListWorkspacesCommand command = new ListWorkspacesCommand(server, null) {
+            final ListWorkspacesCommand command = new ListWorkspacesCommand(server, null, true) {
                 @Override
                 public Server createServer() {
                     return server;
@@ -243,6 +243,6 @@ public class ListWorkspacesCommandTest extends AbstractCallableCommandTest {
     }
 
     @Override protected AbstractCallableCommand createCommand(final ServerConfigurationProvider serverConfig) {
-        return new ListWorkspacesCommand(serverConfig, "computer");
+        return new ListWorkspacesCommand(serverConfig, "computer", true);
     }
 }


### PR DESCRIPTION
The documentation for `VersionControlClient#queryWorkspaces(String, String, String, WorkspacePermissions)` says:

    the computer name to match, null to match all. Use
    LocalHost.getShortName() to match workspaces for this computer.

Manual testing
--------------

1. Deploy version 4.1.0 and create a job that uses TFVC, making sure it executes on an agent and not MASTER.  Queue a build and watch the list of workspaces include other computers than the selected Jenkins agent.
2. Deploy this branch as of 6df8e93 and queue the job again.  This time the list of workspaces includes only the selected Jenkins agent.
3. Deploy this branch as of 743198f4a2dc5b472ba5eeb246ea26bcc7da539a and queue the job one last time.  This time, no workspaces are listed!

Mission accomplished!