### PR TITLE
Bypass polling when pullRequestMergeCommitCreated event is posted

### DIFF
--- a/src/main/java/hudson/plugins/tfs/model/GitCodePushedHookEvent.java
+++ b/src/main/java/hudson/plugins/tfs/model/GitCodePushedHookEvent.java
@@ -50,7 +50,7 @@ public class GitCodePushedHookEvent extends AbstractHookEvent {
     public JSONObject perform(final JSONObject requestPayload) {
         final GitCodePushedEventArgs args = GitCodePushedEventArgs.fromJsonObject(requestPayload);
         final CommitParameterAction parameterAction = new CommitParameterAction(args);
-        final List<GitStatus.ResponseContributor> contributors = pollOrQueueFromEvent(args, parameterAction);
+        final List<GitStatus.ResponseContributor> contributors = pollOrQueueFromEvent(args, parameterAction, false);
         final JSONObject response = fromResponseContributors(contributors);
         return response;
     }
@@ -76,7 +76,7 @@ public class GitCodePushedHookEvent extends AbstractHookEvent {
     }
 
     // TODO: it would be easiest if pollOrQueueFromEvent built a JSONObject directly
-    List<GitStatus.ResponseContributor> pollOrQueueFromEvent(final GitCodePushedEventArgs gitCodePushedEventArgs, final CommitParameterAction commitParameterAction) {
+    List<GitStatus.ResponseContributor> pollOrQueueFromEvent(final GitCodePushedEventArgs gitCodePushedEventArgs, final CommitParameterAction commitParameterAction, final boolean bypassPolling) {
         List<GitStatus.ResponseContributor> result = new ArrayList<GitStatus.ResponseContributor>();
         final String commit = gitCodePushedEventArgs.commit;
         final URIish uri = gitCodePushedEventArgs.getRepoURIish();
@@ -142,7 +142,7 @@ public class GitCodePushedHookEvent extends AbstractHookEvent {
                                 if (!triggered) {
                                     final TeamPushTrigger pushTrigger = TeamWebHook.findTrigger(job, TeamPushTrigger.class);
                                     if (pushTrigger != null) {
-                                        pushTrigger.execute(gitCodePushedEventArgs, commitParameterAction);
+                                        pushTrigger.execute(gitCodePushedEventArgs, commitParameterAction, bypassPolling);
                                         result.add(new TeamWebHook.PollingScheduledResponseContributor(project));
                                         triggered = true;
                                     }

--- a/src/main/java/hudson/plugins/tfs/model/GitCodePushedHookEvent.java
+++ b/src/main/java/hudson/plugins/tfs/model/GitCodePushedHookEvent.java
@@ -122,17 +122,16 @@ public class GitCodePushedHookEvent extends AbstractHookEvent {
                             if (project instanceof Job) {
                                 // TODO: Add default parameters defined in the job
                                 final Job job = (Job) project;
+                                final int quietPeriod = scmTriggerItem.getQuietPeriod();
 
                                 boolean triggered = false;
                                 if (!triggered) {
                                     // TODO: check global override here
                                 }
-
                                 if (!triggered) {
                                     final SCMTrigger scmTrigger = TeamWebHook.findTrigger(job, SCMTrigger.class);
                                     if (scmTrigger != null && !scmTrigger.isIgnorePostCommitHooks()) {
                                         // queue build without first polling
-                                        final int quietPeriod = scmTriggerItem.getQuietPeriod();
                                         final Cause cause = new TeamHookCause(commit);
                                         final CauseAction causeAction = new CauseAction(cause);
                                         scmTriggerItem.scheduleBuild2(quietPeriod, causeAction, commitParameterAction);

--- a/src/main/java/hudson/plugins/tfs/model/GitCodePushedHookEvent.java
+++ b/src/main/java/hudson/plugins/tfs/model/GitCodePushedHookEvent.java
@@ -143,7 +143,14 @@ public class GitCodePushedHookEvent extends AbstractHookEvent {
                                     final TeamPushTrigger pushTrigger = TeamWebHook.findTrigger(job, TeamPushTrigger.class);
                                     if (pushTrigger != null) {
                                         pushTrigger.execute(gitCodePushedEventArgs, commitParameterAction, bypassPolling);
-                                        result.add(new TeamWebHook.PollingScheduledResponseContributor(project));
+                                        final GitStatus.ResponseContributor response;
+                                        if (bypassPolling) {
+                                            response = new TeamWebHook.ScheduledResponseContributor(project);
+                                        }
+                                        else {
+                                            response = new TeamWebHook.PollingScheduledResponseContributor(project);
+                                        }
+                                        result.add(response);
                                         triggered = true;
                                     }
                                 }

--- a/src/main/java/hudson/plugins/tfs/model/PullRequestMergeCommitCreatedHookEvent.java
+++ b/src/main/java/hudson/plugins/tfs/model/PullRequestMergeCommitCreatedHookEvent.java
@@ -23,7 +23,7 @@ public class PullRequestMergeCommitCreatedHookEvent extends GitCodePushedHookEve
     public JSONObject perform(final JSONObject requestPayload) {
         final PullRequestMergeCommitCreatedEventArgs args = PullRequestMergeCommitCreatedEventArgs.fromJsonObject(requestPayload);
         final PullRequestParameterAction parameterAction = new PullRequestParameterAction(args);
-        final List<GitStatus.ResponseContributor> contributors = pollOrQueueFromEvent(args, parameterAction);
+        final List<GitStatus.ResponseContributor> contributors = pollOrQueueFromEvent(args, parameterAction, true);
         final JSONObject response = fromResponseContributors(contributors);
         return response;
     }


### PR DESCRIPTION
Upon review of the Jenkins integration specification, it was discovered that there's a need to be able to queue another Jenkins build related to a given pull request if a previous associated build was determined to have failed due to circumstances unrelated to the changes in the pull request, such as a race condition in an unrelated unit test.

Manual testing
--------------

1. Using curl, POST a `gitCodePushed` event and notice that the reply is "Scheduled polling <project>", with no build actually started (because there hasn't been anything new).
2. Using curl, POST a `pullRequestMergeCommitCreated ` event and notice that the reply is "Scheduled <project>", with a corresponding build started, hence bypassing polling.

Mission accomplished!