### PR TITLE
Support non-specific pull request status

### DIFF
--- a/src/main/java/hudson/plugins/tfs/model/PullRequestMergeCommitCreatedEventArgs.java
+++ b/src/main/java/hudson/plugins/tfs/model/PullRequestMergeCommitCreatedEventArgs.java
@@ -271,7 +271,7 @@ public class PullRequestMergeCommitCreatedEventArgs extends GitCodePushedEventAr
         "    ]\n" +
         "}";
     public int pullRequestId;
-    public int iterationId;
+    public int iterationId = -1;
 
     public static PullRequestMergeCommitCreatedEventArgs fromJsonString(final String jsonString) {
         final JSONObject jsonObject = JSONObject.fromObject(jsonString);

--- a/src/main/java/hudson/plugins/tfs/util/TeamRestClient.java
+++ b/src/main/java/hudson/plugins/tfs/util/TeamRestClient.java
@@ -183,6 +183,27 @@ public class TeamRestClient {
         }
     }
 
+    public TeamGitStatus addPullRequestStatus(final PullRequestMergeCommitCreatedEventArgs args, final TeamGitStatus status) throws IOException {
+
+        final QueryString qs = new QueryString(API_VERSION, "3.0-preview.1");
+        final URI requestUri = UriHelper.join(
+            collectionUri, args.projectId,
+            "_apis", "git",
+            "repositories", args.repoId,
+            "pullRequests", args.pullRequestId,
+            "statuses",
+            qs);
+
+        final MorpherRegistry registry = JSONUtils.getMorpherRegistry();
+        registry.registerMorpher(GitStatusStateMorpher.INSTANCE);
+        try {
+            return request(TeamGitStatus.class, HttpMethod.POST, requestUri, status);
+        }
+        finally {
+            registry.deregisterMorpher(GitStatusStateMorpher.INSTANCE);
+        }
+    }
+
     public TeamGitStatus addPullRequestIterationStatus(final PullRequestMergeCommitCreatedEventArgs args, final TeamGitStatus status) throws IOException {
 
         final QueryString qs = new QueryString(API_VERSION, "3.0-preview.1");

--- a/src/main/java/hudson/plugins/tfs/util/TeamStatus.java
+++ b/src/main/java/hudson/plugins/tfs/util/TeamStatus.java
@@ -42,7 +42,12 @@ public class TeamStatus {
         final TeamGitStatus status = TeamGitStatus.fromRun(run);
         // TODO: when code is pushed and polling happens, are we sure we built against the requested commit?
         if (pullRequestMergeCommitCreatedEventArgs != null) {
-            client.addPullRequestIterationStatus(pullRequestMergeCommitCreatedEventArgs, status);
+            if (pullRequestMergeCommitCreatedEventArgs.iterationId == -1) {
+                client.addPullRequestStatus(pullRequestMergeCommitCreatedEventArgs, status);
+            }
+            else {
+                client.addPullRequestIterationStatus(pullRequestMergeCommitCreatedEventArgs, status);
+            }
         }
         if (gitCodePushedEventArgs != null) {
             client.addCommitStatus(gitCodePushedEventArgs, status);


### PR DESCRIPTION
It turns out we don't always know which pull request iteration a build might be requested for, so added a method for that REST endpoint and now calling it accordingly.

Manual testing
--------------

1. Using curl, POST a `pullRequestMergeCommitCreated` event as before and notice that the corresponding pull request iteration status is still reported as before this change.
2. Temporarily remove `iterationId` from the payload, repeat the above test and notice that the corresponding pull request status (without an iterationId) is now reported.

Mission accomplished!