### PR TITLE
Add the ability to build with parameters

### DIFF
--- a/src/main/java/hudson/plugins/tfs/TeamBuildEndpoint.java
+++ b/src/main/java/hudson/plugins/tfs/TeamBuildEndpoint.java
@@ -218,7 +218,7 @@ public class TeamBuildEndpoint implements UnprotectedRootAction {
         if (jsonParameter != null) {
             try {
                 final JSONObject jsonObject = JSONObject.fromObject(jsonParameter);
-                if (jsonObject.containsKey(PARAMETER) && jsonObject.containsKey(TEAM_PARAMETERS)) {
+                if (jsonObject.containsKey(TEAM_PARAMETERS)) {
                     return true;
                 }
             }

--- a/src/main/java/hudson/plugins/tfs/TeamBuildEndpoint.java
+++ b/src/main/java/hudson/plugins/tfs/TeamBuildEndpoint.java
@@ -47,9 +47,9 @@ public class TeamBuildEndpoint implements UnprotectedRootAction {
     private static final Map<String, AbstractCommand.Factory> COMMAND_FACTORIES_BY_NAME;
     public static final String URL_NAME = "team-build";
     public static final String TEAM_PARAMETERS = "team-parameters";
+    public static final String PARAMETER = "parameter";
     static final String URL_PREFIX = "/" + URL_NAME + "/";
     private static final String JSON = "json";
-    private static final String PARAMETER = "parameter";
 
     static {
         final Map<String, AbstractCommand.Factory> map = new TreeMap<String, AbstractCommand.Factory>(String.CASE_INSENSITIVE_ORDER);

--- a/src/main/java/hudson/plugins/tfs/TeamBuildEndpoint.java
+++ b/src/main/java/hudson/plugins/tfs/TeamBuildEndpoint.java
@@ -187,7 +187,7 @@ public class TeamBuildEndpoint implements UnprotectedRootAction {
             final JSONObject response;
             if (isStructuredForm(req.getParameter(JSON))) {
                 final JSONObject formData = req.getSubmittedForm();
-                response = command.perform(project, formData, actualDelay);
+                response = command.perform(project, req, formData, actualDelay);
             }
             else {
                 response = command.perform(project, req, delay);

--- a/src/main/java/hudson/plugins/tfs/TeamBuildEndpoint.java
+++ b/src/main/java/hudson/plugins/tfs/TeamBuildEndpoint.java
@@ -190,7 +190,7 @@ public class TeamBuildEndpoint implements UnprotectedRootAction {
                 response = command.perform(project, req, formData, actualDelay);
             }
             else {
-                response = command.perform(project, req, delay);
+                response = command.perform(project, req, actualDelay);
             }
 
             rsp.setStatus(SC_OK);

--- a/src/main/java/hudson/plugins/tfs/TeamBuildEndpoint.java
+++ b/src/main/java/hudson/plugins/tfs/TeamBuildEndpoint.java
@@ -6,6 +6,7 @@ import hudson.model.Item;
 import hudson.model.UnprotectedRootAction;
 import hudson.plugins.tfs.model.AbstractCommand;
 import hudson.plugins.tfs.model.BuildCommand;
+import hudson.plugins.tfs.model.BuildWithParametersCommand;
 import hudson.plugins.tfs.model.PingCommand;
 import hudson.plugins.tfs.util.MediaType;
 import jenkins.model.Jenkins;
@@ -55,6 +56,7 @@ public class TeamBuildEndpoint implements UnprotectedRootAction {
         final Map<String, AbstractCommand.Factory> map = new TreeMap<String, AbstractCommand.Factory>(String.CASE_INSENSITIVE_ORDER);
         map.put("ping", new PingCommand.Factory());
         map.put("build", new BuildCommand.Factory());
+        map.put("buildWithParameters", new BuildWithParametersCommand.Factory());
         COMMAND_FACTORIES_BY_NAME = Collections.unmodifiableMap(map);
     }
 
@@ -238,6 +240,14 @@ public class TeamBuildEndpoint implements UnprotectedRootAction {
     }
 
     public void doBuild(
+            final StaplerRequest request,
+            final StaplerResponse response,
+            @QueryParameter final TimeDuration delay
+    ) {
+        dispatch(request, response, delay);
+    }
+
+    public void doBuildWithParameters(
             final StaplerRequest request,
             final StaplerResponse response,
             @QueryParameter final TimeDuration delay

--- a/src/main/java/hudson/plugins/tfs/TeamBuildEndpoint.java
+++ b/src/main/java/hudson/plugins/tfs/TeamBuildEndpoint.java
@@ -34,6 +34,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import static javax.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
+import static javax.servlet.http.HttpServletResponse.SC_CREATED;
 import static javax.servlet.http.HttpServletResponse.SC_INTERNAL_SERVER_ERROR;
 import static javax.servlet.http.HttpServletResponse.SC_METHOD_NOT_ALLOWED;
 import static javax.servlet.http.HttpServletResponse.SC_OK;
@@ -195,7 +196,12 @@ public class TeamBuildEndpoint implements UnprotectedRootAction {
                 response = command.perform(project, req, actualDelay);
             }
 
-            rsp.setStatus(SC_OK);
+            if (response.containsKey("created")) {
+                rsp.setStatus(SC_CREATED);
+            }
+            else {
+                rsp.setStatus(SC_OK);
+            }
             rsp.setContentType(MediaType.APPLICATION_JSON_UTF_8);
             final PrintWriter w = rsp.getWriter();
             final String responseJsonString = response.toString();

--- a/src/main/java/hudson/plugins/tfs/model/AbstractCommand.java
+++ b/src/main/java/hudson/plugins/tfs/model/AbstractCommand.java
@@ -20,12 +20,13 @@ public abstract class AbstractCommand {
      * {@code requestPayload} and returning the output as a {@link JSONObject}.
      *
      * @param project an {@link AbstractProject to operate on}
+     * @param request a {@link StaplerRequest} to help build parameter values
      * @param requestPayload a {@link JSONObject} representing the command's input
      * @param delay how long to wait before the project starts executing
      *
      * @return a {@link JSONObject} representing the hook event's output
      */
-    public abstract JSONObject perform(final AbstractProject project, final JSONObject requestPayload, final TimeDuration delay);
+    public abstract JSONObject perform(final AbstractProject project, final StaplerRequest request, final JSONObject requestPayload, final TimeDuration delay);
 
     /**
      * Actually do the work of the command, using the supplied

--- a/src/main/java/hudson/plugins/tfs/model/BuildCommand.java
+++ b/src/main/java/hudson/plugins/tfs/model/BuildCommand.java
@@ -79,7 +79,7 @@ public class BuildCommand extends AbstractCommand {
     }
 
     @Override
-    public JSONObject perform(final AbstractProject project, final JSONObject requestPayload, final TimeDuration delay) {
+    public JSONObject perform(final AbstractProject project, final StaplerRequest req, final JSONObject requestPayload, final TimeDuration delay) {
 
         final List<Action> actions = new ArrayList<Action>();
         if (requestPayload.containsKey(TeamBuildEndpoint.TEAM_PARAMETERS)) {

--- a/src/main/java/hudson/plugins/tfs/model/BuildCommand.java
+++ b/src/main/java/hudson/plugins/tfs/model/BuildCommand.java
@@ -15,13 +15,17 @@ import hudson.model.queue.ScheduleResult;
 import hudson.plugins.tfs.CommitParameterAction;
 import hudson.plugins.tfs.PullRequestParameterAction;
 import hudson.plugins.tfs.TeamBuildEndpoint;
+import hudson.plugins.tfs.util.MediaType;
 import jenkins.model.Jenkins;
 import jenkins.util.TimeDuration;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
+import org.apache.commons.io.IOUtils;
 import org.jfree.data.Values;
 import org.kohsuke.stapler.StaplerRequest;
 
+import java.io.IOException;
+import java.io.InputStream;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -52,17 +56,17 @@ public class BuildCommand extends AbstractCommand {
 
         @Override
         public String getSampleRequestPayload() {
-            return "{\n" +
-                    "    \"team-parameters\":\n" +
-                    "    {\n" +
-                    "        \"collectionUri\":\"https://fabrikam-fiber-inc.visualstudio.com\",\n" +
-                    "        \"repoUri\":\"https://fabrikam-fiber-inc.visualstudio.com/Personal/_git/olivida.tfs-plugin\",\n" +
-                    "        \"projectId\":\"Personal\",\n" +
-                    "        \"repoId\":\"olivida.tfs-plugin\",\n" +
-                    "        \"commit\":\"6a23fc7afec31f0a14bade6544bed4f16492e6d2\",\n" +
-                    "        \"pushedBy\":\"olivida\"\n" +
-                    "    }\n" +
-                    "}";
+            final Class<? extends Factory> me = this.getClass();
+            final InputStream stream = me.getResourceAsStream("BuildCommand.json");
+            try {
+                return IOUtils.toString(stream, MediaType.UTF_8);
+            }
+            catch (final IOException e) {
+                throw new Error(e);
+            }
+            finally {
+                IOUtils.closeQuietly(stream);
+            }
         }
     }
 

--- a/src/main/java/hudson/plugins/tfs/model/BuildCommand.java
+++ b/src/main/java/hudson/plugins/tfs/model/BuildCommand.java
@@ -153,9 +153,6 @@ public class BuildCommand extends AbstractCommand {
                 }
                 teamParameters.put(teamParamName, valueArray[0]);
             }
-            else {
-                // TODO: implement when we add support for parameterized builds
-            }
         }
 
         if (teamParameters.containsKey(BUILD_REPOSITORY_PROVIDER) && "TfGit".equalsIgnoreCase(teamParameters.get(BUILD_REPOSITORY_PROVIDER))) {
@@ -175,6 +172,22 @@ public class BuildCommand extends AbstractCommand {
             args.commit = commit;
             args.pushedBy = pushedBy;
             final CommitParameterAction action = new CommitParameterAction(args);
+            actions.add(action);
+        }
+
+        //noinspection UnnecessaryLocalVariable
+        final Job<?, ?> job = project;
+        final ParametersDefinitionProperty pp = job.getProperty(ParametersDefinitionProperty.class);
+        if (pp != null) {
+            final List<ParameterDefinition> parameterDefinitions = pp.getParameterDefinitions();
+            final List<ParameterValue> values = new ArrayList<ParameterValue>();
+            for (final ParameterDefinition d : parameterDefinitions) {
+                final ParameterValue value = d.createValue(request);
+                if (value != null) {
+                    values.add(value);
+                }
+            }
+            final ParametersAction action = new ParametersAction(values);
             actions.add(action);
         }
 

--- a/src/main/java/hudson/plugins/tfs/model/BuildCommand.java
+++ b/src/main/java/hudson/plugins/tfs/model/BuildCommand.java
@@ -165,47 +165,16 @@ public class BuildCommand extends AbstractCommand {
             final String projectId = teamParameters.get(SYSTEM_TEAM_PROJECT);
             final String commit = teamParameters.get(BUILD_SOURCE_VERSION);
             final String pushedBy = teamParameters.get(BUILD_REQUESTED_FOR);
-            final Integer pullRequestId = determinePullRequestId(teamParameters);
-            final CommitParameterAction action;
-            if (pullRequestId != null) {
-                final PullRequestMergeCommitCreatedEventArgs args = new PullRequestMergeCommitCreatedEventArgs();
-                args.collectionUri = collectionUri;
-                args.repoUri = repoUri;
-                args.projectId = projectId;
-                args.commit = commit;
-                args.pushedBy = pushedBy;
-                args.pullRequestId = pullRequestId;
-                args.iterationId = -1 /* TODO: the pull request iteration ID is missing! */;
-                action = new PullRequestParameterAction(args);
-            }
-            else {
-                final GitCodePushedEventArgs args = new GitCodePushedEventArgs();
-                args.collectionUri = collectionUri;
-                args.repoUri = repoUri;
-                args.projectId = projectId;
-                args.commit = commit;
-                args.pushedBy = pushedBy;
-                action = new CommitParameterAction(args);
-            }
+            final GitCodePushedEventArgs args = new GitCodePushedEventArgs();
+            args.collectionUri = collectionUri;
+            args.repoUri = repoUri;
+            args.projectId = projectId;
+            args.commit = commit;
+            args.pushedBy = pushedBy;
+            final CommitParameterAction action = new CommitParameterAction(args);
             actions.add(action);
         }
 
         return innerPerform(project, delay, actions);
-    }
-
-    static Integer determinePullRequestId(final HashMap<String, String> teamParameters) {
-        Integer pullRequestId = null;
-        if (teamParameters.containsKey(BUILD_SOURCE_BRANCH)) {
-            final String sourceBranch = teamParameters.get(BUILD_SOURCE_BRANCH);
-            if (sourceBranch.startsWith(REFS_PULL_SLASH)) {
-                final String idSlashMerge = sourceBranch.substring(REFS_PULL_SLASH_LENGTH);
-                final int nextSlash = idSlashMerge.indexOf('/');
-                if (nextSlash > 0) {
-                    final String pullRequestIdString = idSlashMerge.substring(0, nextSlash);
-                    pullRequestId = Integer.valueOf(pullRequestIdString, 10);
-                }
-            }
-        }
-        return pullRequestId;
     }
 }

--- a/src/main/java/hudson/plugins/tfs/model/BuildCommand.java
+++ b/src/main/java/hudson/plugins/tfs/model/BuildCommand.java
@@ -38,6 +38,7 @@ public class BuildCommand extends AbstractCommand {
     private static final String REFS_PULL_SLASH = "refs/pull/";
     private static final int REFS_PULL_SLASH_LENGTH = REFS_PULL_SLASH.length();
     private static final String BUILD_REPOSITORY_URI = "Build.Repository.Uri";
+    private static final String BUILD_REPOSITORY_NAME = "Build.Repository.Name";
     private static final String SYSTEM_TEAM_PROJECT = "System.TeamProject";
     private static final String BUILD_SOURCE_VERSION = "Build.SourceVersion";
     private static final String BUILD_REQUESTED_FOR = "Build.RequestedFor";
@@ -163,12 +164,14 @@ public class BuildCommand extends AbstractCommand {
             final String repoUriString = teamParameters.get(BUILD_REPOSITORY_URI);
             final URI repoUri = URI.create(repoUriString);
             final String projectId = teamParameters.get(SYSTEM_TEAM_PROJECT);
+            final String repoId = teamParameters.get(BUILD_REPOSITORY_NAME);
             final String commit = teamParameters.get(BUILD_SOURCE_VERSION);
             final String pushedBy = teamParameters.get(BUILD_REQUESTED_FOR);
             final GitCodePushedEventArgs args = new GitCodePushedEventArgs();
             args.collectionUri = collectionUri;
             args.repoUri = repoUri;
             args.projectId = projectId;
+            args.repoId = repoId;
             args.commit = commit;
             args.pushedBy = pushedBy;
             final CommitParameterAction action = new CommitParameterAction(args);

--- a/src/main/java/hudson/plugins/tfs/model/BuildWithParametersCommand.java
+++ b/src/main/java/hudson/plugins/tfs/model/BuildWithParametersCommand.java
@@ -1,0 +1,33 @@
+package hudson.plugins.tfs.model;
+
+import hudson.plugins.tfs.util.MediaType;
+import org.apache.commons.io.IOUtils;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+public class BuildWithParametersCommand extends BuildCommand {
+
+    public static class Factory implements AbstractCommand.Factory {
+
+        @Override
+        public AbstractCommand create() {
+            return new BuildWithParametersCommand();
+        }
+
+        @Override
+        public String getSampleRequestPayload() {
+            final Class<? extends Factory> me = this.getClass();
+            final InputStream stream = me.getResourceAsStream("BuildWithParametersCommand.json");
+            try {
+                return IOUtils.toString(stream, MediaType.UTF_8);
+            }
+            catch (final IOException e) {
+                throw new Error(e);
+            }
+            finally {
+                IOUtils.closeQuietly(stream);
+            }
+        }
+    }
+}

--- a/src/main/java/hudson/plugins/tfs/model/PingCommand.java
+++ b/src/main/java/hudson/plugins/tfs/model/PingCommand.java
@@ -34,7 +34,7 @@ public class PingCommand extends AbstractCommand {
     }
 
     @Override
-    public JSONObject perform(final AbstractProject project, final JSONObject requestPayload, final TimeDuration delay) {
+    public JSONObject perform(final AbstractProject project, final StaplerRequest request, final JSONObject requestPayload, final TimeDuration delay) {
         return requestPayload;
     }
 

--- a/src/main/resources/hudson/plugins/tfs/model/BuildCommand.json
+++ b/src/main/resources/hudson/plugins/tfs/model/BuildCommand.json
@@ -1,0 +1,11 @@
+{
+  "team-parameters":
+  {
+    "collectionUri":"https://fabrikam-fiber-inc.visualstudio.com",
+    "repoUri":"https://fabrikam-fiber-inc.visualstudio.com/Personal/_git/olivida.tfs-plugin",
+    "projectId":"Personal",
+    "repoId":"olivida.tfs-plugin",
+    "commit":"6a23fc7afec31f0a14bade6544bed4f16492e6d2",
+    "pushedBy":"olivida"
+  }
+}

--- a/src/main/resources/hudson/plugins/tfs/model/BuildWithParametersCommand.json
+++ b/src/main/resources/hudson/plugins/tfs/model/BuildWithParametersCommand.json
@@ -1,0 +1,16 @@
+{
+  "parameter":
+  [
+    {"name":"id","value":"123"},
+    {"name":"verbosity","value":"high"}
+  ],
+  "team-parameters":
+  {
+    "collectionUri":"https://fabrikam-fiber-inc.visualstudio.com",
+    "repoUri":"https://fabrikam-fiber-inc.visualstudio.com/Personal/_git/olivida.tfs-plugin",
+    "projectId":"Personal",
+    "repoId":"olivida.tfs-plugin",
+    "commit":"6a23fc7afec31f0a14bade6544bed4f16492e6d2",
+    "pushedBy":"olivida"
+  }
+}


### PR DESCRIPTION
The `/team-build/` endpoint now supports `/team-build/buildWithParameters/JOB_NAME` in both structured form and legacy form modes.

Manual testing
--------------

1. Given the following `buildWithParameters.json` file:

    ```json
    {
        "parameter":
        [
            {"name": "id", "value": "123"},
            {"name": "verbosity", "value": "high"}
        ],
        "team-parameters":
        {
            "collectionUri":"https://mseng.visualstudio.com",
            "repoUri":"https://mseng.visualstudio.com/Personal/_git/olivida.gcm4ml",
            "projectId":"Personal",
            "repoId":"olivida.gcm4ml",
            "commit":"8a76fbe5c9e087491d672c7951bf2613be35de44",
            "pushedBy":"olivida"
        }
    }
    ```
...run the following command to test the structured form mode: `curl --request PUT http://localhost:9090/team-build/build/param --data-urlencode json@buildWithParameters.json --user remote:92e9d8998a8c005697d252f09a2a311b` and notice that:
    1. the `param` job is indeed triggered
    2. the job's parameters are set as specified
    3. the specified commit is fetched by the Git plugin
    4. the specified commit in Team Services has statuses added for the build being pending and then successful
2. Run the following command for the complete equivalent in legacy form mode: `curl --request PUT http://localhost:9090/team-build/build/param --data id=123 --data verbosity=high --data _team-build_Build.Repository.Provider=TfGit --data _team-build_System.TeamFoundationCollectionUri=https://mseng.visualstudio.com --data _team-build_Build.Repository.Uri=https://mseng.visualstudio.com/Personal/_git/olivida.gcm4ml --data _team-build_System.TeamProject=Personal --data _team-build_Build.Repository.Name=olivida.gcm4ml --data _team-build_Build.SourceVersion=8a76fbe5c9e087491d672c7951bf2613be35de44 --data _team-build_Build.RequestedFor=olivida --user remote:92e9d8998a8c005697d252f09a2a311b`
...and notice it has the exact same consequences!

Mission accomplished!