### PR TITLE
Add gitPush and gitPullRequestMerged events that accept Team Services payloads

### DIFF
--- a/src/main/java/hudson/plugins/tfs/TeamBuildEndpoint.java
+++ b/src/main/java/hudson/plugins/tfs/TeamBuildEndpoint.java
@@ -48,6 +48,7 @@ public class TeamBuildEndpoint implements UnprotectedRootAction {
     private static final Logger LOGGER = Logger.getLogger(TeamBuildEndpoint.class.getName());
     private static final Map<String, AbstractCommand.Factory> COMMAND_FACTORIES_BY_NAME;
     public static final String URL_NAME = "team-build";
+    public static final String TEAM_EVENT = "team-event";
     public static final String TEAM_PARAMETERS = "team-parameters";
     public static final String TEAM_BUILD = "team-build";
     public static final String PARAMETER = "parameter";
@@ -220,7 +221,7 @@ public class TeamBuildEndpoint implements UnprotectedRootAction {
         if (jsonParameter != null) {
             try {
                 final JSONObject jsonObject = JSONObject.fromObject(jsonParameter);
-                if (jsonObject.containsKey(TEAM_PARAMETERS) || jsonObject.containsKey(TEAM_BUILD)) {
+                if (jsonObject.containsKey(TEAM_PARAMETERS) || jsonObject.containsKey(TEAM_BUILD) || jsonObject.containsKey(TEAM_EVENT)) {
                     return true;
                 }
             }

--- a/src/main/java/hudson/plugins/tfs/TeamEventsEndpoint.java
+++ b/src/main/java/hudson/plugins/tfs/TeamEventsEndpoint.java
@@ -7,6 +7,7 @@ import hudson.model.UnprotectedRootAction;
 import hudson.plugins.git.GitStatus;
 import hudson.plugins.tfs.model.AbstractHookEvent;
 import hudson.plugins.tfs.model.GitCodePushedHookEvent;
+import hudson.plugins.tfs.model.GitPushEvent;
 import hudson.plugins.tfs.model.PingHookEvent;
 import hudson.plugins.tfs.model.PullRequestMergeCommitCreatedHookEvent;
 import hudson.plugins.tfs.util.MediaType;
@@ -54,6 +55,7 @@ public class TeamEventsEndpoint implements UnprotectedRootAction {
                 new TreeMap<String, AbstractHookEvent.Factory>(String.CASE_INSENSITIVE_ORDER);
         eventMap.put("ping", new PingHookEvent.Factory());
         eventMap.put("gitCodePushed", new GitCodePushedHookEvent.Factory());
+        eventMap.put("gitPush", new GitPushEvent.Factory());
         eventMap.put("pullRequestMergeCommitCreated", new PullRequestMergeCommitCreatedHookEvent.Factory());
         HOOK_EVENT_FACTORIES_BY_NAME = Collections.unmodifiableMap(eventMap);
     }
@@ -171,6 +173,13 @@ public class TeamEventsEndpoint implements UnprotectedRootAction {
 
     @RequirePOST
     public HttpResponse doGitCodePushed(
+            final HttpServletRequest request,
+            @StringBodyParameter @Nonnull final String body) {
+        return dispatch(request, body);
+    }
+
+    @RequirePOST
+    public HttpResponse doGitPush(
             final HttpServletRequest request,
             @StringBodyParameter @Nonnull final String body) {
         return dispatch(request, body);

--- a/src/main/java/hudson/plugins/tfs/TeamEventsEndpoint.java
+++ b/src/main/java/hudson/plugins/tfs/TeamEventsEndpoint.java
@@ -7,6 +7,7 @@ import hudson.model.UnprotectedRootAction;
 import hudson.plugins.git.GitStatus;
 import hudson.plugins.tfs.model.AbstractHookEvent;
 import hudson.plugins.tfs.model.GitCodePushedHookEvent;
+import hudson.plugins.tfs.model.GitPullRequestMergedEvent;
 import hudson.plugins.tfs.model.GitPushEvent;
 import hudson.plugins.tfs.model.PingHookEvent;
 import hudson.plugins.tfs.model.PullRequestMergeCommitCreatedHookEvent;
@@ -55,6 +56,7 @@ public class TeamEventsEndpoint implements UnprotectedRootAction {
                 new TreeMap<String, AbstractHookEvent.Factory>(String.CASE_INSENSITIVE_ORDER);
         eventMap.put("ping", new PingHookEvent.Factory());
         eventMap.put("gitCodePushed", new GitCodePushedHookEvent.Factory());
+        eventMap.put("gitPullRequestMerged", new GitPullRequestMergedEvent.Factory());
         eventMap.put("gitPush", new GitPushEvent.Factory());
         eventMap.put("pullRequestMergeCommitCreated", new PullRequestMergeCommitCreatedHookEvent.Factory());
         HOOK_EVENT_FACTORIES_BY_NAME = Collections.unmodifiableMap(eventMap);
@@ -173,6 +175,13 @@ public class TeamEventsEndpoint implements UnprotectedRootAction {
 
     @RequirePOST
     public HttpResponse doGitCodePushed(
+            final HttpServletRequest request,
+            @StringBodyParameter @Nonnull final String body) {
+        return dispatch(request, body);
+    }
+
+    @RequirePOST
+    public HttpResponse doGitPullRequestMerged(
             final HttpServletRequest request,
             @StringBodyParameter @Nonnull final String body) {
         return dispatch(request, body);

--- a/src/main/java/hudson/plugins/tfs/model/BuildCommand.java
+++ b/src/main/java/hudson/plugins/tfs/model/BuildCommand.java
@@ -5,12 +5,12 @@ import hudson.model.Action;
 import hudson.model.Cause;
 import hudson.model.CauseAction;
 import hudson.model.Job;
-import hudson.model.JobProperty;
 import hudson.model.ParameterDefinition;
 import hudson.model.ParameterValue;
 import hudson.model.ParametersAction;
 import hudson.model.ParametersDefinitionProperty;
 import hudson.model.Queue;
+import hudson.model.SimpleParameterDefinition;
 import hudson.model.queue.ScheduleResult;
 import hudson.plugins.tfs.CommitParameterAction;
 import hudson.plugins.tfs.PullRequestParameterAction;
@@ -21,7 +21,6 @@ import jenkins.util.TimeDuration;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
 import org.apache.commons.io.IOUtils;
-import org.jfree.data.Values;
 import org.kohsuke.stapler.StaplerRequest;
 
 import java.io.IOException;
@@ -47,6 +46,8 @@ public class BuildCommand extends AbstractCommand {
     private static final String BUILD_SOURCE_VERSION = "Build.SourceVersion";
     private static final String BUILD_REQUESTED_FOR = "Build.RequestedFor";
     private static final String SYSTEM_TEAM_FOUNDATION_COLLECTION_URI = "System.TeamFoundationCollectionUri";
+    private static final String COMMIT_ID = "commitId";
+    private static final String PULL_REQUEST_ID = "pullRequestId";
 
     public static class Factory implements AbstractCommand.Factory {
         @Override
@@ -94,6 +95,10 @@ public class BuildCommand extends AbstractCommand {
     @Override
     public JSONObject perform(final AbstractProject project, final StaplerRequest req, final JSONObject requestPayload, final TimeDuration delay) {
 
+        // These values are for optional parameters of the same name, for the git.pullrequest.merged event
+        String commitId = null;
+        String pullRequestId = null;
+
         final List<Action> actions = new ArrayList<Action>();
 
         if (requestPayload.containsKey(TeamBuildEndpoint.TEAM_BUILD)) {
@@ -115,6 +120,9 @@ public class BuildCommand extends AbstractCommand {
             }
             else if ("git.pullrequest.merged".equals(eventType)) {
                 final PullRequestMergeCommitCreatedEventArgs args = GitPullRequestMergedEvent.decodeGitPullRequestMerged(teamEventJson);
+                // record the values for the special optional parameters
+                commitId = args.commit;
+                pullRequestId = Integer.toString(args.pullRequestId, 10);
                 final Action action = new PullRequestParameterAction(args);
                 actions.add(action);
             }
@@ -123,7 +131,7 @@ public class BuildCommand extends AbstractCommand {
             final JSONObject eventArgsJson = requestPayload.getJSONObject(TeamBuildEndpoint.TEAM_PARAMETERS);
             final CommitParameterAction action;
             // TODO: improve the payload detection!
-            if (eventArgsJson.containsKey("pullRequestId")) {
+            if (eventArgsJson.containsKey(PULL_REQUEST_ID)) {
                 final PullRequestMergeCommitCreatedEventArgs args = PullRequestMergeCommitCreatedEventArgs.fromJsonObject(eventArgsJson);
                 action = new PullRequestParameterAction(args);
             }
@@ -148,7 +156,24 @@ public class BuildCommand extends AbstractCommand {
                 final ParameterDefinition d = pp.getParameterDefinition(name);
                 if (d == null)
                     throw new IllegalArgumentException("No such parameter definition: " + name);
-                final ParameterValue parameterValue = d.createValue(req, jo);
+                final ParameterValue parameterValue;
+                // commitId and pullRequestId are special and override any user-provided value
+                // when the team-event's eventType was "git.pullrequest.merged"
+                if (name.equals(COMMIT_ID) && commitId != null && d instanceof SimpleParameterDefinition) {
+                    final SimpleParameterDefinition spd = (SimpleParameterDefinition) d;
+                    parameterValue = spd.createValue(commitId);
+                    // erase value to avoid adding it a second time
+                    commitId = null;
+                }
+                else if (name.equals(PULL_REQUEST_ID) && pullRequestId != null & d instanceof SimpleParameterDefinition) {
+                    final SimpleParameterDefinition spd = (SimpleParameterDefinition) d;
+                    parameterValue = spd.createValue(pullRequestId);
+                    // erase value to avoid adding it a second time
+                    pullRequestId = null;
+                }
+                else {
+                    parameterValue = d.createValue(req, jo);
+                }
                 if (parameterValue != null) {
                     values.add(parameterValue);
                 }
@@ -156,6 +181,25 @@ public class BuildCommand extends AbstractCommand {
                     throw new IllegalArgumentException("Cannot retrieve the parameter value: " + name);
                 }
             }
+
+            // typical case: set optional "git.pullrequest.merged" parameters
+            if (commitId != null) {
+                final ParameterDefinition d = pp.getParameterDefinition(COMMIT_ID);
+                if (d != null && d instanceof SimpleParameterDefinition) {
+                    final SimpleParameterDefinition spd = (SimpleParameterDefinition) d;
+                    final ParameterValue parameterValue = spd.createValue(commitId);
+                    values.add(parameterValue);
+                }
+            }
+            if (pullRequestId != null) {
+                final ParameterDefinition d = pp.getParameterDefinition(PULL_REQUEST_ID);
+                if (d != null && d instanceof SimpleParameterDefinition) {
+                    final SimpleParameterDefinition spd = (SimpleParameterDefinition) d;
+                    final ParameterValue parameterValue = spd.createValue(pullRequestId);
+                    values.add(parameterValue);
+                }
+            }
+
             final ParametersAction action = new ParametersAction(values);
             actions.add(action);
         }

--- a/src/main/java/hudson/plugins/tfs/model/BuildCommand.java
+++ b/src/main/java/hudson/plugins/tfs/model/BuildCommand.java
@@ -105,6 +105,20 @@ public class BuildCommand extends AbstractCommand {
             }
             contributeTeamBuildParameterActions(teamBuildParameters, actions);
         }
+        else if (requestPayload.containsKey(TeamBuildEndpoint.TEAM_EVENT)) {
+            final JSONObject teamEventJson = requestPayload.getJSONObject(TeamBuildEndpoint.TEAM_EVENT);
+            final String eventType = teamEventJson.getString("eventType");
+            if ("git.push".equals(eventType)) {
+                final GitCodePushedEventArgs args = GitPushEvent.decodeGitPush(teamEventJson);
+                final Action action = new CommitParameterAction(args);
+                actions.add(action);
+            }
+            else if ("git.pullrequest.merged".equals(eventType)) {
+                final PullRequestMergeCommitCreatedEventArgs args = GitPullRequestMergedEvent.decodeGitPullRequestMerged(teamEventJson);
+                final Action action = new PullRequestParameterAction(args);
+                actions.add(action);
+            }
+        }
         else if (requestPayload.containsKey(TeamBuildEndpoint.TEAM_PARAMETERS)) {
             final JSONObject eventArgsJson = requestPayload.getJSONObject(TeamBuildEndpoint.TEAM_PARAMETERS);
             final CommitParameterAction action;

--- a/src/main/java/hudson/plugins/tfs/model/GitPullRequestMergedEvent.java
+++ b/src/main/java/hudson/plugins/tfs/model/GitPullRequestMergedEvent.java
@@ -84,7 +84,7 @@ public class GitPullRequestMergedEvent extends GitPushEvent {
     public JSONObject perform(final JSONObject requestPayload) {
         final PullRequestMergeCommitCreatedEventArgs args = decodeGitPullRequestMerged(requestPayload);
         final PullRequestParameterAction parameterAction = new PullRequestParameterAction(args);
-        final List<GitStatus.ResponseContributor> contributors = pollOrQueueFromEvent(args, parameterAction, false);
+        final List<GitStatus.ResponseContributor> contributors = pollOrQueueFromEvent(args, parameterAction, true);
         final JSONObject response = fromResponseContributors(contributors);
         return response;
     }

--- a/src/main/java/hudson/plugins/tfs/model/GitPullRequestMergedEvent.java
+++ b/src/main/java/hudson/plugins/tfs/model/GitPullRequestMergedEvent.java
@@ -1,13 +1,19 @@
 package hudson.plugins.tfs.model;
 
+import hudson.plugins.git.GitStatus;
+import hudson.plugins.tfs.PullRequestParameterAction;
 import hudson.plugins.tfs.util.MediaType;
 import net.sf.json.JSONObject;
 import org.apache.commons.io.IOUtils;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URI;
+import java.util.List;
 
 public class GitPullRequestMergedEvent extends GitPushEvent {
+
+    private static final String GIT_PULLREQUEST_MERGED = "git.pullrequest.merged";
 
     public static class Factory implements AbstractHookEvent.Factory {
 
@@ -34,5 +40,44 @@ public class GitPullRequestMergedEvent extends GitPushEvent {
 
     public GitPullRequestMergedEvent(final JSONObject requestPayload) {
         super(requestPayload);
+    }
+
+    static String determineCreatedBy(final JSONObject resource) {
+        final JSONObject createdBy = resource.getJSONObject("createdBy");
+        final String result = createdBy.getString("displayName");
+        return result;
+    }
+
+    @Override
+    public JSONObject perform(final JSONObject requestPayload) {
+        final PullRequestMergeCommitCreatedEventArgs args = decodeGitPullRequestMerged(requestPayload);
+        final PullRequestParameterAction parameterAction = new PullRequestParameterAction(args);
+        final List<GitStatus.ResponseContributor> contributors = pollOrQueueFromEvent(args, parameterAction, false);
+        final JSONObject response = fromResponseContributors(contributors);
+        return response;
+    }
+
+    static PullRequestMergeCommitCreatedEventArgs decodeGitPullRequestMerged(final JSONObject gitPullRequestMergedJson) {
+        assertEquals(gitPullRequestMergedJson, EVENT_TYPE, GIT_PULLREQUEST_MERGED);
+        final JSONObject resource = gitPullRequestMergedJson.getJSONObject(RESOURCE);
+        final JSONObject repository = resource.getJSONObject(REPOSITORY);
+        final URI collectionUri = determineCollectionUri(repository);
+        final String repoUriString = repository.getString(REMOTE_URL);
+        final URI repoUri = URI.create(repoUriString);
+        final String projectId = determineProjectId(repository);
+        final String repoId = repository.getString(NAME);
+        final String commit = determineCommit(resource);
+        final String pushedBy = determineCreatedBy(resource);
+        final int pullRequestId = resource.getInt("pullRequestId");
+
+        final PullRequestMergeCommitCreatedEventArgs args = new PullRequestMergeCommitCreatedEventArgs();
+        args.collectionUri = collectionUri;
+        args.repoUri = repoUri;
+        args.projectId = projectId;
+        args.repoId = repoId;
+        args.commit = commit;
+        args.pushedBy = pushedBy;
+        args.pullRequestId = pullRequestId;
+        return args;
     }
 }

--- a/src/main/java/hudson/plugins/tfs/model/GitPullRequestMergedEvent.java
+++ b/src/main/java/hudson/plugins/tfs/model/GitPullRequestMergedEvent.java
@@ -1,0 +1,38 @@
+package hudson.plugins.tfs.model;
+
+import hudson.plugins.tfs.util.MediaType;
+import net.sf.json.JSONObject;
+import org.apache.commons.io.IOUtils;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+public class GitPullRequestMergedEvent extends GitPushEvent {
+
+    public static class Factory implements AbstractHookEvent.Factory {
+
+        @Override
+        public AbstractHookEvent create(final JSONObject requestPayload) {
+            return new GitPullRequestMergedEvent(requestPayload);
+        }
+
+        @Override
+        public String getSampleRequestPayload() {
+            final Class<? extends Factory> me = this.getClass();
+            final InputStream stream = me.getResourceAsStream("GitPullRequestMergedEvent.json");
+            try {
+                return IOUtils.toString(stream, MediaType.UTF_8);
+            }
+            catch (final IOException e) {
+                throw new Error(e);
+            }
+            finally {
+                IOUtils.closeQuietly(stream);
+            }
+        }
+    }
+
+    public GitPullRequestMergedEvent(final JSONObject requestPayload) {
+        super(requestPayload);
+    }
+}

--- a/src/main/java/hudson/plugins/tfs/model/GitPushEvent.java
+++ b/src/main/java/hudson/plugins/tfs/model/GitPushEvent.java
@@ -1,0 +1,29 @@
+package hudson.plugins.tfs.model;
+
+import net.sf.json.JSONObject;
+
+public class GitPushEvent extends AbstractHookEvent {
+
+    public static class Factory implements AbstractHookEvent.Factory {
+
+        @Override
+        public AbstractHookEvent create(final JSONObject requestPayload) {
+            return new GitPushEvent(requestPayload);
+        }
+
+        @Override
+        public String getSampleRequestPayload() {
+            return "TODO";
+        }
+    }
+
+    public GitPushEvent(final JSONObject requestPayload) {
+        super(requestPayload);
+    }
+
+    @Override
+    public JSONObject perform(final JSONObject requestPayload) {
+        // TODO: implement
+        return null;
+    }
+}

--- a/src/main/java/hudson/plugins/tfs/model/GitPushEvent.java
+++ b/src/main/java/hudson/plugins/tfs/model/GitPushEvent.java
@@ -1,8 +1,19 @@
 package hudson.plugins.tfs.model;
 
+import hudson.plugins.git.GitStatus;
+import hudson.plugins.tfs.CommitParameterAction;
+import hudson.plugins.tfs.util.MediaType;
+import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
+import org.apache.commons.io.IOUtils;
 
-public class GitPushEvent extends AbstractHookEvent {
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.List;
+
+public class GitPushEvent extends GitCodePushedHookEvent {
 
     public static class Factory implements AbstractHookEvent.Factory {
 
@@ -13,7 +24,17 @@ public class GitPushEvent extends AbstractHookEvent {
 
         @Override
         public String getSampleRequestPayload() {
-            return "TODO";
+            final Class<? extends Factory> me = this.getClass();
+            final InputStream stream = me.getResourceAsStream("GitPushEvent.json");
+            try {
+                return IOUtils.toString(stream, MediaType.UTF_8);
+            }
+            catch (final IOException e) {
+                throw new Error(e);
+            }
+            finally {
+                IOUtils.closeQuietly(stream);
+            }
         }
     }
 
@@ -23,7 +44,95 @@ public class GitPushEvent extends AbstractHookEvent {
 
     @Override
     public JSONObject perform(final JSONObject requestPayload) {
-        // TODO: implement
-        return null;
+        final GitCodePushedEventArgs args = decodeGitPush(requestPayload);
+        final CommitParameterAction parameterAction = new CommitParameterAction(args);
+        final List<GitStatus.ResponseContributor> contributors = pollOrQueueFromEvent(args, parameterAction, false);
+        final JSONObject response = fromResponseContributors(contributors);
+        return response;
+    }
+
+    static void assertEquals(final JSONObject jsonObject, final String key, final String expectedValue) {
+        final String template = "Expected key '%s' to be equal to %s in object:\n%s\n";
+        final String message = String.format(template, key, expectedValue, jsonObject);
+        if (!jsonObject.containsKey(key)) {
+            throw new IllegalArgumentException(message);
+        }
+        final Object actualValue = jsonObject.get(key);
+        if (actualValue instanceof String) {
+            final String actualStringValue = (String) actualValue;
+            if (!expectedValue.equals(actualStringValue)) {
+                throw new IllegalArgumentException(message);
+            }
+        }
+        else {
+            throw new IllegalArgumentException(message);
+        }
+    }
+
+    static URI determineCollectionUri(final URI repoApiUri) {
+        final String path = repoApiUri.getPath();
+        final int i = path.indexOf("_apis/");
+        if (i == -1) {
+            final String template = "Repository url '%s' did not contain '_apis/'.";
+            throw new IllegalArgumentException(String.format(template, repoApiUri));
+        }
+        final String pathBeforeApis = path.substring(0, i);
+        final URI uri;
+        try {
+            uri = new URI(repoApiUri.getScheme(), repoApiUri.getAuthority(), pathBeforeApis, repoApiUri.getQuery(), repoApiUri.getFragment());
+        }
+        catch (final URISyntaxException e) {
+            throw new Error(e);
+        }
+        return uri;
+    }
+
+    static URI determineCollectionUri(final JSONObject repository) {
+        final String repoApiUrlString = repository.getString("url");
+        final URI repoApiUri = URI.create(repoApiUrlString);
+        return determineCollectionUri(repoApiUri);
+    }
+
+    static String determineProjectId(final JSONObject repository) {
+        final JSONObject project = repository.getJSONObject("project");
+        final String result = project.getString("name");
+        return result;
+    }
+
+    static String determineCommit(final JSONObject resource) {
+        final JSONArray commits = resource.getJSONArray("commits");
+        if (commits.size() < 1) {
+            throw new IllegalArgumentException("No commits found");
+        }
+        final JSONObject commitObject = commits.getJSONObject(0);
+        return commitObject.getString("commitId");
+    }
+
+    static String determinePushedBy(final JSONObject resource) {
+        final JSONObject pushedBy = resource.getJSONObject("pushedBy");
+        final String result = pushedBy.getString("displayName");
+        return result;
+    }
+
+    static GitCodePushedEventArgs decodeGitPush(final JSONObject gitPushJson) {
+        assertEquals(gitPushJson, "eventType", "git.push");
+        final JSONObject resource = gitPushJson.getJSONObject("resource");
+        final JSONObject repository = resource.getJSONObject("repository");
+        final URI collectionUri = determineCollectionUri(repository);
+        final String repoUriString = repository.getString("remoteUrl");
+        final URI repoUri = URI.create(repoUriString);
+        final String projectId = determineProjectId(repository);
+        final String repoId = repository.getString("name");
+        final String commit = determineCommit(resource);
+        final String pushedBy = determinePushedBy(resource);
+
+        final GitCodePushedEventArgs args = new GitCodePushedEventArgs();
+        args.collectionUri = collectionUri;
+        args.repoUri = repoUri;
+        args.projectId = projectId;
+        args.repoId = repoId;
+        args.commit = commit;
+        args.pushedBy = pushedBy;
+        return args;
     }
 }

--- a/src/main/java/hudson/plugins/tfs/model/GitPushEvent.java
+++ b/src/main/java/hudson/plugins/tfs/model/GitPushEvent.java
@@ -15,6 +15,14 @@ import java.util.List;
 
 public class GitPushEvent extends GitCodePushedHookEvent {
 
+    static final String EVENT_TYPE = "eventType";
+    static final String RESOURCE = "resource";
+    static final String REPOSITORY = "repository";
+    static final String REMOTE_URL = "remoteUrl";
+    static final String NAME = "name";
+
+    private static final String GIT_PUSH = "git.push";
+
     public static class Factory implements AbstractHookEvent.Factory {
 
         @Override
@@ -115,14 +123,14 @@ public class GitPushEvent extends GitCodePushedHookEvent {
     }
 
     static GitCodePushedEventArgs decodeGitPush(final JSONObject gitPushJson) {
-        assertEquals(gitPushJson, "eventType", "git.push");
-        final JSONObject resource = gitPushJson.getJSONObject("resource");
-        final JSONObject repository = resource.getJSONObject("repository");
+        assertEquals(gitPushJson, EVENT_TYPE, GIT_PUSH);
+        final JSONObject resource = gitPushJson.getJSONObject(RESOURCE);
+        final JSONObject repository = resource.getJSONObject(REPOSITORY);
         final URI collectionUri = determineCollectionUri(repository);
-        final String repoUriString = repository.getString("remoteUrl");
+        final String repoUriString = repository.getString(REMOTE_URL);
         final URI repoUri = URI.create(repoUriString);
         final String projectId = determineProjectId(repository);
-        final String repoId = repository.getString("name");
+        final String repoId = repository.getString(NAME);
         final String commit = determineCommit(resource);
         final String pushedBy = determinePushedBy(resource);
 

--- a/src/main/resources/hudson/plugins/tfs/model/GitPullRequestMergedEvent.json
+++ b/src/main/resources/hudson/plugins/tfs/model/GitPullRequestMergedEvent.json
@@ -1,0 +1,91 @@
+{
+  "id": "6872ee8c-b333-4eff-bfb9-0d5274943566",
+  "eventType": "git.pullrequest.merged",
+  "publisherId": "tfs",
+  "message": {
+    "text": "Jamal Hartnett has created a pull request merge commit",
+    "html": "Jamal Hartnett has created a pull request merge commit",
+    "markdown": "Jamal Hartnett has created a pull request merge commit"
+  },
+  "detailedMessage": {
+    "text": "Jamal Hartnett has created a pull request merge commit\r\n\r\n- Merge status: Succeeded\r\n- Merge commit: eef717(https://fabrikam.visualstudio.com/DefaultCollection/_apis/git/repositories/4bc14d40-c903-45e2-872e-0462c7748079/commits/eef717f69257a6333f221566c1c987dc94cc0d72)\r\n",
+    "html": "Jamal Hartnett has created a pull request merge commit\r\n<ul>\r\n<li>Merge status: Succeeded</li>\r\n<li>Merge commit: <a href=\"https://fabrikam.visualstudio.com/DefaultCollection/_apis/git/repositories/4bc14d40-c903-45e2-872e-0462c7748079/commits/eef717f69257a6333f221566c1c987dc94cc0d72\">eef717</a></li>\r\n</ul>",
+    "markdown": "Jamal Hartnett has created a pull request merge commit\r\n\r\n+ Merge status: Succeeded\r\n+ Merge commit: [eef717](https://fabrikam.visualstudio.com/DefaultCollection/_apis/git/repositories/4bc14d40-c903-45e2-872e-0462c7748079/commits/eef717f69257a6333f221566c1c987dc94cc0d72)\r\n"
+  },
+  "resource": {
+    "repository": {
+      "id": "4bc14d40-c903-45e2-872e-0462c7748079",
+      "name": "Fabrikam",
+      "url": "https://fabrikam.visualstudio.com/DefaultCollection/_apis/git/repositories/4bc14d40-c903-45e2-872e-0462c7748079",
+      "project": {
+        "id": "6ce954b1-ce1f-45d1-b94d-e6bf2464ba2c",
+        "name": "Fabrikam",
+        "url": "https://fabrikam.visualstudio.com/DefaultCollection/_apis/projects/6ce954b1-ce1f-45d1-b94d-e6bf2464ba2c",
+        "state": "wellFormed"
+      },
+      "defaultBranch": "refs/heads/master",
+      "remoteUrl": "https://fabrikam.visualstudio.com/DefaultCollection/_git/Fabrikam"
+    },
+    "pullRequestId": 1,
+    "status": "completed",
+    "createdBy": {
+      "id": "54d125f7-69f7-4191-904f-c5b96b6261c8",
+      "displayName": "Jamal Hartnett",
+      "uniqueName": "fabrikamfiber4@hotmail.com",
+      "url": "https://fabrikam.vssps.visualstudio.com/_apis/Identities/54d125f7-69f7-4191-904f-c5b96b6261c8",
+      "imageUrl": "https://fabrikam.visualstudio.com/DefaultCollection/_api/_common/identityImage?id=54d125f7-69f7-4191-904f-c5b96b6261c8"
+    },
+    "creationDate": "2014-06-17T16:55:46.589889Z",
+    "closedDate": "2014-06-30T18:59:12.3660573Z",
+    "title": "my first pull request",
+    "description": " - test2\r\n",
+    "sourceRefName": "refs/heads/mytopic",
+    "targetRefName": "refs/heads/master",
+    "mergeStatus": "succeeded",
+    "mergeId": "a10bb228-6ba6-4362-abd7-49ea21333dbd",
+    "lastMergeSourceCommit": {
+      "commitId": "53d54ac915144006c2c9e90d2c7d3880920db49c",
+      "url": "https://fabrikam.visualstudio.com/DefaultCollection/_apis/git/repositories/4bc14d40-c903-45e2-872e-0462c7748079/commits/53d54ac915144006c2c9e90d2c7d3880920db49c"
+    },
+    "lastMergeTargetCommit": {
+      "commitId": "a511f535b1ea495ee0c903badb68fbc83772c882",
+      "url": "https://fabrikam.visualstudio.com/DefaultCollection/_apis/git/repositories/4bc14d40-c903-45e2-872e-0462c7748079/commits/a511f535b1ea495ee0c903badb68fbc83772c882"
+    },
+    "lastMergeCommit": {
+      "commitId": "eef717f69257a6333f221566c1c987dc94cc0d72",
+      "url": "https://fabrikam.visualstudio.com/DefaultCollection/_apis/git/repositories/4bc14d40-c903-45e2-872e-0462c7748079/commits/eef717f69257a6333f221566c1c987dc94cc0d72"
+    },
+    "reviewers": [
+      {
+        "reviewerUrl": null,
+        "vote": 0,
+        "id": "2ea2d095-48f9-4cd6-9966-62f6f574096c",
+        "displayName": "[Mobile]\\Mobile Team",
+        "uniqueName": "vstfs:///Classification/TeamProject/f0811a3b-8c8a-4e43-a3bf-9a049b4835bd\\Mobile Team",
+        "url": "https://fabrikam.vssps.visualstudio.com/_apis/Identities/2ea2d095-48f9-4cd6-9966-62f6f574096c",
+        "imageUrl": "https://fabrikam.visualstudio.com/DefaultCollection/_api/_common/identityImage?id=2ea2d095-48f9-4cd6-9966-62f6f574096c",
+        "isContainer": true
+      }
+    ],
+    "commits": [
+      {
+        "commitId": "53d54ac915144006c2c9e90d2c7d3880920db49c",
+        "url": "https://fabrikam.visualstudio.com/DefaultCollection/_apis/git/repositories/4bc14d40-c903-45e2-872e-0462c7748079/commits/53d54ac915144006c2c9e90d2c7d3880920db49c"
+      }
+    ],
+    "url": "https://fabrikam.visualstudio.com/DefaultCollection/_apis/git/repositories/4bc14d40-c903-45e2-872e-0462c7748079/pullRequests/1"
+  },
+  "resourceVersion": "3.0-preview.1",
+  "resourceContainers": {
+    "collection": {
+      "id": "c12d0eb8-e382-443b-9f9c-c52cba5014c2"
+    },
+    "account": {
+      "id": "f844ec47-a9db-4511-8281-8b63f4eaf94e"
+    },
+    "project": {
+      "id": "be9b3917-87e6-42a4-a549-2bc06a7a878f"
+    }
+  },
+  "createdDate": "2016-06-10T16:32:22.6325371Z"
+}

--- a/src/main/resources/hudson/plugins/tfs/model/GitPushEvent.json
+++ b/src/main/resources/hudson/plugins/tfs/model/GitPushEvent.json
@@ -1,0 +1,75 @@
+{
+  "id": "03c164c2-8912-4d5e-8009-3707d5f83734",
+  "eventType": "git.push",
+  "publisherId": "tfs",
+  "message": {
+    "text": "Jamal Hartnett pushed updates to branch master of repository Fabrikam-Fiber-Git.",
+    "html": "Jamal Hartnett pushed updates to branch master of repository Fabrikam-Fiber-Git.",
+    "markdown": "Jamal Hartnett pushed updates to branch `master` of repository `Fabrikam-Fiber-Git`."
+  },
+  "detailedMessage": {
+    "text": "Jamal Hartnett pushed 1 commit to branch master of repository Fabrikam-Fiber-Git.\n - Fixed bug in web.config file 33b55f7c",
+    "html": "Jamal Hartnett pushed 1 commit to branch <a href=\"https://fabrikam-fiber-inc.visualstudio.com/DefaultCollection/_git/Fabrikam-Fiber-Git/#version=GBmaster\">master</a> of repository <a href=\"https://fabrikam-fiber-inc.visualstudio.com/DefaultCollection/_git/Fabrikam-Fiber-Git/\">Fabrikam-Fiber-Git</a>.\n<ul>\n<li>Fixed bug in web.config file <a href=\"https://fabrikam-fiber-inc.visualstudio.com/DefaultCollection/_git/Fabrikam-Fiber-Git/commit/33b55f7cb7e7e245323987634f960cf4a6e6bc74\">33b55f7c</a>\n</ul>",
+    "markdown": "Jamal Hartnett pushed 1 commit to branch [master](https://fabrikam-fiber-inc.visualstudio.com/DefaultCollection/_git/Fabrikam-Fiber-Git/#version=GBmaster) of repository [Fabrikam-Fiber-Git](https://fabrikam-fiber-inc.visualstudio.com/DefaultCollection/_git/Fabrikam-Fiber-Git/).\n* Fixed bug in web.config file [33b55f7c](https://fabrikam-fiber-inc.visualstudio.com/DefaultCollection/_git/Fabrikam-Fiber-Git/commit/33b55f7cb7e7e245323987634f960cf4a6e6bc74)"
+  },
+  "resource": {
+    "commits": [
+      {
+        "commitId": "33b55f7cb7e7e245323987634f960cf4a6e6bc74",
+        "author": {
+          "name": "Jamal Hartnett",
+          "email": "fabrikamfiber4@hotmail.com",
+          "date": "2015-02-25T19:01:00Z"
+        },
+        "committer": {
+          "name": "Jamal Hartnett",
+          "email": "fabrikamfiber4@hotmail.com",
+          "date": "2015-02-25T19:01:00Z"
+        },
+        "comment": "Fixed bug in web.config file",
+        "url": "https://fabrikam-fiber-inc.visualstudio.com/DefaultCollection/_git/Fabrikam-Fiber-Git/commit/33b55f7cb7e7e245323987634f960cf4a6e6bc74"
+      }
+    ],
+    "refUpdates": [
+      {
+        "name": "refs/heads/master",
+        "oldObjectId": "aad331d8d3b131fa9ae03cf5e53965b51942618a",
+        "newObjectId": "33b55f7cb7e7e245323987634f960cf4a6e6bc74"
+      }
+    ],
+    "repository": {
+      "id": "278d5cd2-584d-4b63-824a-2ba458937249",
+      "name": "Fabrikam-Fiber-Git",
+      "url": "https://fabrikam-fiber-inc.visualstudio.com/DefaultCollection/_apis/git/repositories/278d5cd2-584d-4b63-824a-2ba458937249",
+      "project": {
+        "id": "6ce954b1-ce1f-45d1-b94d-e6bf2464ba2c",
+        "name": "Fabrikam-Fiber-Git",
+        "url": "https://fabrikam-fiber-inc.visualstudio.com/DefaultCollection/_apis/projects/6ce954b1-ce1f-45d1-b94d-e6bf2464ba2c",
+        "state": "wellFormed"
+      },
+      "defaultBranch": "refs/heads/master",
+      "remoteUrl": "https://fabrikam-fiber-inc.visualstudio.com/DefaultCollection/_git/Fabrikam-Fiber-Git"
+    },
+    "pushedBy": {
+      "id": "00067FFED5C7AF52@Live.com",
+      "displayName": "Jamal Hartnett",
+      "uniqueName": "Windows Live ID\\fabrikamfiber4@hotmail.com"
+    },
+    "pushId": 14,
+    "date": "2014-05-02T19:17:13.3309587Z",
+    "url": "https://fabrikam-fiber-inc.visualstudio.com/DefaultCollection/_apis/git/repositories/278d5cd2-584d-4b63-824a-2ba458937249/pushes/14"
+  },
+  "resourceVersion": "3.0-preview.1",
+  "resourceContainers": {
+    "collection": {
+      "id": "c12d0eb8-e382-443b-9f9c-c52cba5014c2"
+    },
+    "account": {
+      "id": "f844ec47-a9db-4511-8281-8b63f4eaf94e"
+    },
+    "project": {
+      "id": "be9b3917-87e6-42a4-a549-2bc06a7a878f"
+    }
+  },
+  "createdDate": "2016-06-10T16:32:21.0569909Z"
+}

--- a/src/test/java/hudson/plugins/tfs/model/GitPullRequestMergedEventTest.java
+++ b/src/test/java/hudson/plugins/tfs/model/GitPullRequestMergedEventTest.java
@@ -1,11 +1,31 @@
 package hudson.plugins.tfs.model;
 
+import net.sf.json.JSONObject;
 import org.junit.Assert;
 import org.junit.Test;
+
+import java.net.URI;
 
 /**
  * A class to test {@link GitPullRequestMergedEvent}.
  */
 public class GitPullRequestMergedEventTest {
 
+    @Test
+    public void decodeGitPullRequestMerged() throws Exception {
+        final GitPullRequestMergedEvent.Factory factory = new GitPullRequestMergedEvent.Factory();
+        final String inputString = factory.getSampleRequestPayload();
+        final JSONObject input = JSONObject.fromObject(inputString);
+
+        final PullRequestMergeCommitCreatedEventArgs actual = GitPullRequestMergedEvent.decodeGitPullRequestMerged(input);
+
+        Assert.assertEquals(URI.create("https://fabrikam.visualstudio.com/DefaultCollection/"), actual.collectionUri);
+        Assert.assertEquals(URI.create("https://fabrikam.visualstudio.com/DefaultCollection/_git/Fabrikam"), actual.repoUri);
+        Assert.assertEquals("Fabrikam", actual.projectId);
+        Assert.assertEquals("Fabrikam", actual.repoId);
+        Assert.assertEquals("53d54ac915144006c2c9e90d2c7d3880920db49c", actual.commit);
+        Assert.assertEquals("Jamal Hartnett", actual.pushedBy);
+        Assert.assertEquals(1, actual.pullRequestId);
+        Assert.assertEquals(-1, actual.iterationId);
+    }
 }

--- a/src/test/java/hudson/plugins/tfs/model/GitPullRequestMergedEventTest.java
+++ b/src/test/java/hudson/plugins/tfs/model/GitPullRequestMergedEventTest.java
@@ -23,7 +23,7 @@ public class GitPullRequestMergedEventTest {
         Assert.assertEquals(URI.create("https://fabrikam.visualstudio.com/DefaultCollection/_git/Fabrikam"), actual.repoUri);
         Assert.assertEquals("Fabrikam", actual.projectId);
         Assert.assertEquals("Fabrikam", actual.repoId);
-        Assert.assertEquals("53d54ac915144006c2c9e90d2c7d3880920db49c", actual.commit);
+        Assert.assertEquals("eef717f69257a6333f221566c1c987dc94cc0d72", actual.commit);
         Assert.assertEquals("Jamal Hartnett", actual.pushedBy);
         Assert.assertEquals(1, actual.pullRequestId);
         Assert.assertEquals(-1, actual.iterationId);

--- a/src/test/java/hudson/plugins/tfs/model/GitPullRequestMergedEventTest.java
+++ b/src/test/java/hudson/plugins/tfs/model/GitPullRequestMergedEventTest.java
@@ -1,0 +1,11 @@
+package hudson.plugins.tfs.model;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * A class to test {@link GitPullRequestMergedEvent}.
+ */
+public class GitPullRequestMergedEventTest {
+
+}

--- a/src/test/java/hudson/plugins/tfs/model/GitPushEventTest.java
+++ b/src/test/java/hudson/plugins/tfs/model/GitPushEventTest.java
@@ -1,0 +1,40 @@
+package hudson.plugins.tfs.model;
+
+import net.sf.json.JSONObject;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.net.URI;
+
+/**
+ * A class to test {@link GitPushEvent}.
+ */
+public class GitPushEventTest {
+
+    @Test
+    public void determineCollectionUri_sample() throws Exception {
+        final URI input = URI.create("https://fabrikam-fiber-inc.visualstudio.com/DefaultCollection/_apis/git/repositories/278d5cd2-584d-4b63-824a-2ba458937249");
+
+        final URI actual = GitPushEvent.determineCollectionUri(input);
+
+        final URI expected = URI.create("https://fabrikam-fiber-inc.visualstudio.com/DefaultCollection/");
+        Assert.assertEquals(expected, actual);
+    }
+
+    @Test
+    public void decodeGitPush() throws Exception {
+        final GitPushEvent.Factory factory = new GitPushEvent.Factory();
+        final String inputString = factory.getSampleRequestPayload();
+        final JSONObject input = JSONObject.fromObject(inputString);
+
+        final GitCodePushedEventArgs actual = GitPushEvent.decodeGitPush(input);
+
+        Assert.assertEquals(URI.create("https://fabrikam-fiber-inc.visualstudio.com/DefaultCollection/"), actual.collectionUri);
+        Assert.assertEquals(URI.create("https://fabrikam-fiber-inc.visualstudio.com/DefaultCollection/_git/Fabrikam-Fiber-Git"), actual.repoUri);
+        Assert.assertEquals("Fabrikam-Fiber-Git", actual.projectId);
+        Assert.assertEquals("Fabrikam-Fiber-Git", actual.repoId);
+        Assert.assertEquals("33b55f7cb7e7e245323987634f960cf4a6e6bc74", actual.commit);
+        Assert.assertEquals("Jamal Hartnett", actual.pushedBy);
+    }
+
+}


### PR DESCRIPTION
To simplify the event processing on the Team Services end, accept the Team Services event payloads as provided and map them to the corresponding *EventArgs classes.

Manual testing
--------------

1. Crafted the following `gitPush.json` file, which simulates a subset of the `git.push` payload one may get from Team Services:

    ```json
    {
      "eventType": "git.push",
      "resource": {
        "commits": [
          {
            "commitId": "6a23fc7afec31f0a14bade6544bed4f16492e6d2"
          }
        ],
        "repository": {
          "name": "olivida.gcm4ml",
          "url": "https://mseng.visualstudio.com/_apis/git/repositories/278d5cd2-584d-4b63-824a-2ba458937249",
          "project": {
            "name": "Personal"
          },
          "remoteUrl": "https://mseng.visualstudio.com/Personal/_git/olivida.gcm4ml"
        },
        "pushedBy": {
          "displayName": "olivida"
        }
      }
    }
    ```

2. Ran `curl` as follows to hit the new `/team-events/gitPush` event endpoint with the above payload: `curl --request POST http://localhost:9090/team-events/gitPush --header 'Content-Type: application/json' --data-binary @gitPush.json`
    1. The console contained `{"messages":["Scheduled polling of Git\r\n"]}`
    2. The "TFS/Team Services hook log" indicated that it ran and that changes were found (I had just pushed to the Git repo to arrange for that to happen).
    3. The "Git" job was queued and then started.
    4. It built the specified commit.
    5. The associated commit's statuses now included a "pending", and when the build completed, a "succeeded".
3. Crafted the following `gitPullRequestMerged.json` file, which simulates a subset of the `git.pullrequest.merged` payload one may get from Team Services:

    ```json
    {
      "eventType": "git.pullrequest.merged",
      "resource": {
        "repository": {
          "name": "olivida.gcm4ml",
          "url": "https://mseng.visualstudio.com/_apis/git/repositories/278d5cd2-584d-4b63-824a-2ba458937249",
          "project": {
            "name": "Personal"
          },
          "remoteUrl": "https://mseng.visualstudio.com/Personal/_git/olivida.gcm4ml"
        },
        "pullRequestId": 120904,
        "createdBy": {
          "displayName": "olivida"
        },
        "lastMergeCommit": {
          "commitId": "6a23fc7afec31f0a14bade6544bed4f16492e6d2"
        }
      }
    }
    ```

4. Ran `curl` as follows to hit the new `/team-events/gitPullRequestMerged` event endpoint with the above payload: `curl --request POST http://localhost:9090/team-events/gitPullRequestMerged --header 'Content-Type: application/json' --data-binary @gitPullRequestMerged.json`
    1. The console contained `{"messages":["Scheduled Git\r\n"]}` (this event bypasses polling)
    2. The "Git" job was queued and then started.
    3. It built the specified commit.
    4. The associated pull request's statuses now included a "pending", and when the build completed, a "succeeded".
    5. The associated commit's statuses now included a "pending", and when the build completed, a "succeeded".
5. Crafted the following `buildWithTeamEvent.json` file, which simulates a subset of the `git.push` payload _inside_ the payload for a parameterized `build` command:

    ```json
    {
      "parameter":
      [
        {"name": "id", "value": "123"},
        {"name": "verbosity", "value": "high"}
      ],
      "team-event":
      {
        "eventType": "git.push",
        "resource": {
          "commits": [
            {
              "commitId": "6a23fc7afec31f0a14bade6544bed4f16492e6d2"
            }
          ],
          "repository": {
            "name": "olivida.gcm4ml",
            "url": "https://mseng.visualstudio.com/_apis/git/repositories/278d5cd2-584d-4b63-824a-2ba458937249",
            "project": {
              "name": "Personal"
            },
            "remoteUrl": "https://mseng.visualstudio.com/Personal/_git/olivida.gcm4ml"
          },
          "pushedBy": {
            "displayName": "olivida"
          }
        }
      }
    }
    ```

6. Ran `curl` as follows to hit the `/team-build/build/` command endpoint for the `param` job with the above payload: `curl --request POST http://localhost:9090/team-build/build/param --data-urlencode json@buildWithTeamEvent.json`
    1. The console contained `{"created":"http://localhost:9090/queue/item/1/"}`
    2. The `param` job is indeed queued and then starts.
    3. Its Jenkins job parameters are indeed recorded as `123` and `high`.
    4. The Git plugin indeed fetches the requested commit (see `team-event/resource/commits[0]/commitId` above).
    5. Said commit in Team Services is indeed updated with the "pending" and "succeeded" statuses, pointing back to the Jenkins job.
7. After adding the "Handle special pull request event parameters" commit, ran the following `curl`-based tests:
    1. Build jobs with the four combinations of `commitId` and `pullRequestId` being defined  (or not) as parameters in a job, verifying that they indeed obtained values from the payload with an _eventType_ of `git.pullrequest.merged`.
    2. Build the job that defines `commitId` and `pullRequestId` as parameters, this time providing values for those parameters in the `parameter` section of the payload.  Their values were indeed overridden by what's in the `team-event` section of the payload, if and only if _eventType_ is `git.pullrequest.merged`.

Mission accomplished!