### PR TITLE
Add support for "team-build" section in structured form for /team-build/build

### DIFF
--- a/src/main/java/hudson/plugins/tfs/TeamBuildEndpoint.java
+++ b/src/main/java/hudson/plugins/tfs/TeamBuildEndpoint.java
@@ -49,6 +49,7 @@ public class TeamBuildEndpoint implements UnprotectedRootAction {
     private static final Map<String, AbstractCommand.Factory> COMMAND_FACTORIES_BY_NAME;
     public static final String URL_NAME = "team-build";
     public static final String TEAM_PARAMETERS = "team-parameters";
+    public static final String TEAM_BUILD = "team-build";
     public static final String PARAMETER = "parameter";
     static final String URL_PREFIX = "/" + URL_NAME + "/";
     private static final String JSON = "json";
@@ -219,7 +220,7 @@ public class TeamBuildEndpoint implements UnprotectedRootAction {
         if (jsonParameter != null) {
             try {
                 final JSONObject jsonObject = JSONObject.fromObject(jsonParameter);
-                if (jsonObject.containsKey(TEAM_PARAMETERS)) {
+                if (jsonObject.containsKey(TEAM_PARAMETERS) || jsonObject.containsKey(TEAM_BUILD)) {
                     return true;
                 }
             }

--- a/src/main/java/hudson/plugins/tfs/model/BuildCommand.java
+++ b/src/main/java/hudson/plugins/tfs/model/BuildCommand.java
@@ -144,7 +144,7 @@ public class BuildCommand extends AbstractCommand {
 
         final List<Action> actions = new ArrayList<Action>();
 
-        final HashMap<String, String> teamParameters = new HashMap<String, String>();
+        final HashMap<String, String> teamBuildParameters = new HashMap<String, String>();
 
         final Map<String, String[]> parameters = request.getParameterMap();
         for (final Map.Entry<String, String[]> entry : parameters.entrySet()) {
@@ -155,29 +155,11 @@ public class BuildCommand extends AbstractCommand {
                 if (valueArray == null || valueArray.length != 1) {
                     throw new IllegalArgumentException(String.format("Expected exactly 1 value for parameter '%s'.", teamParamName));
                 }
-                teamParameters.put(teamParamName, valueArray[0]);
+                teamBuildParameters.put(teamParamName, valueArray[0]);
             }
         }
 
-        if (teamParameters.containsKey(BUILD_REPOSITORY_PROVIDER) && "TfGit".equalsIgnoreCase(teamParameters.get(BUILD_REPOSITORY_PROVIDER))) {
-            final String collectionUriString = teamParameters.get(SYSTEM_TEAM_FOUNDATION_COLLECTION_URI);
-            final URI collectionUri = URI.create(collectionUriString);
-            final String repoUriString = teamParameters.get(BUILD_REPOSITORY_URI);
-            final URI repoUri = URI.create(repoUriString);
-            final String projectId = teamParameters.get(SYSTEM_TEAM_PROJECT);
-            final String repoId = teamParameters.get(BUILD_REPOSITORY_NAME);
-            final String commit = teamParameters.get(BUILD_SOURCE_VERSION);
-            final String pushedBy = teamParameters.get(BUILD_REQUESTED_FOR);
-            final GitCodePushedEventArgs args = new GitCodePushedEventArgs();
-            args.collectionUri = collectionUri;
-            args.repoUri = repoUri;
-            args.projectId = projectId;
-            args.repoId = repoId;
-            args.commit = commit;
-            args.pushedBy = pushedBy;
-            final CommitParameterAction action = new CommitParameterAction(args);
-            actions.add(action);
-        }
+        contributeTeamBuildParameterActions(teamBuildParameters, actions);
 
         //noinspection UnnecessaryLocalVariable
         final Job<?, ?> job = project;
@@ -196,5 +178,27 @@ public class BuildCommand extends AbstractCommand {
         }
 
         return innerPerform(project, delay, actions);
+    }
+
+    static void contributeTeamBuildParameterActions(final HashMap<String, String> teamBuildParameters, final List<Action> actions) {
+        if (teamBuildParameters.containsKey(BUILD_REPOSITORY_PROVIDER) && "TfGit".equalsIgnoreCase(teamBuildParameters.get(BUILD_REPOSITORY_PROVIDER))) {
+            final String collectionUriString = teamBuildParameters.get(SYSTEM_TEAM_FOUNDATION_COLLECTION_URI);
+            final URI collectionUri = URI.create(collectionUriString);
+            final String repoUriString = teamBuildParameters.get(BUILD_REPOSITORY_URI);
+            final URI repoUri = URI.create(repoUriString);
+            final String projectId = teamBuildParameters.get(SYSTEM_TEAM_PROJECT);
+            final String repoId = teamBuildParameters.get(BUILD_REPOSITORY_NAME);
+            final String commit = teamBuildParameters.get(BUILD_SOURCE_VERSION);
+            final String pushedBy = teamBuildParameters.get(BUILD_REQUESTED_FOR);
+            final GitCodePushedEventArgs args = new GitCodePushedEventArgs();
+            args.collectionUri = collectionUri;
+            args.repoUri = repoUri;
+            args.projectId = projectId;
+            args.repoId = repoId;
+            args.commit = commit;
+            args.pushedBy = pushedBy;
+            final CommitParameterAction action = new CommitParameterAction(args);
+            actions.add(action);
+        }
     }
 }

--- a/src/main/java/hudson/plugins/tfs/model/BuildCommand.java
+++ b/src/main/java/hudson/plugins/tfs/model/BuildCommand.java
@@ -95,7 +95,17 @@ public class BuildCommand extends AbstractCommand {
     public JSONObject perform(final AbstractProject project, final StaplerRequest req, final JSONObject requestPayload, final TimeDuration delay) {
 
         final List<Action> actions = new ArrayList<Action>();
-        if (requestPayload.containsKey(TeamBuildEndpoint.TEAM_PARAMETERS)) {
+
+        if (requestPayload.containsKey(TeamBuildEndpoint.TEAM_BUILD)) {
+            final HashMap<String, String> teamBuildParameters = new HashMap<String, String>();
+            final JSONObject variables = requestPayload.getJSONObject(TeamBuildEndpoint.TEAM_BUILD);
+            for (final String key : ((Map<String, Object>)variables).keySet()) {
+                final String value = variables.getString(key);
+                teamBuildParameters.put(key, value);
+            }
+            contributeTeamBuildParameterActions(teamBuildParameters, actions);
+        }
+        else if (requestPayload.containsKey(TeamBuildEndpoint.TEAM_PARAMETERS)) {
             final JSONObject eventArgsJson = requestPayload.getJSONObject(TeamBuildEndpoint.TEAM_PARAMETERS);
             final CommitParameterAction action;
             // TODO: improve the payload detection!


### PR DESCRIPTION
It turns out the Jenkins Queue Build task will use structured form submission and we decided on adding a `team-build` section to the `json` parameter.

Manual testing
--------------

1. Craft the following `buildWithTeamBuild.json` file:

    ```json
    {
        "parameter":
        [
            {"name": "id", "value": "123"},
            {"name": "verbosity", "value": "high"}
        ],
        "team-build":
        {
            "Build.Repository.Provider": "TfGit",
            "System.TeamFoundationCollectionUri": "https://mseng.visualstudio.com",
            "Build.Repository.Uri": "https://mseng.visualstudio.com/Personal/_git/olivida.gcm4ml",
            "System.TeamProject": "Personal",
            "Build.Repository.Name": "olivida.gcm4ml",
            "Build.SourceVersion": "8a76fbe5c9e087491d672c7951bf2613be35de44",
            "Build.RequestedFor": "olivida"
        }
    }
    ```

2. Use `curl` to trigger a build of the `param` parameterized job: `curl --request POST http://localhost:9090/team-build/build/param --data-urlencode json@buildWithTeamBuild.json`
    1. The console output contains `{"created":"http://localhost:9090/queue/item/1/"}`
    2. The `param` job is indeed queued and then starts.
    3. Its Jenkins job parameters are indeed recorded as `123` and `high`.
    4. The Git plugin indeed fetches the requested commit (see `Build.SourceVersion` above).
    5. Said commit in Team Services is indeed updated with the "pending" and "succeeded" statuses, pointing back to the Jenkins job.

Mission accomplished!