### PR TITLE
Deactivate logging of each resource get in build log

### DIFF
--- a/src/test/java/hudson/plugins/tfs/commands/GetFilesToWorkFolderCommandTest.java
+++ b/src/test/java/hudson/plugins/tfs/commands/GetFilesToWorkFolderCommandTest.java
@@ -33,7 +33,7 @@ public class GetFilesToWorkFolderCommandTest extends AbstractCallableCommandTest
         final GetEvent getEvent = mock(GetEvent.class);
         final String pathToFile = "C:\\.jenkins\\jobs\\typical\\workspace\\TODO.txt";
         when(getEvent.getTargetLocalItem()).thenReturn(pathToFile);
-        final GetFilesToWorkFolderCommand cut = new GetFilesToWorkFolderCommand(server, null, null);
+        final GetFilesToWorkFolderCommand cut = new GetFilesToWorkFolderCommand(server, null, null, true);
         cut.setLogger(new PrintStream(this.outputStream));
 
         cut.onGet(getEvent);


### PR DESCRIPTION
Use the same approach as in the list workspaces command.

- wrapped flag around logging
- set flag to false by default
- added comment to add property at later stage if desired
- updated unit test

Also added count of resources downloaded and added that to the log.

Verified in dev instance of Jenkins with numerous validations jobs. Also should pass cloudbees build.
