### PR TITLE
Support both TfGit and TfsGit providers

### DIFF
--- a/src/main/java/hudson/plugins/tfs/model/BuildCommand.java
+++ b/src/main/java/hudson/plugins/tfs/model/BuildCommand.java
@@ -190,8 +190,17 @@ public class BuildCommand extends AbstractCommand {
         return innerPerform(project, delay, actions);
     }
 
+    static boolean isTeamGit(final HashMap<String, String> teamBuildParameters) {
+        if (teamBuildParameters.containsKey(BUILD_REPOSITORY_PROVIDER)) {
+            final String provider = teamBuildParameters.get(BUILD_REPOSITORY_PROVIDER);
+            return "TfGit".equalsIgnoreCase(provider)
+                    || "TfsGit".equalsIgnoreCase(provider);
+        }
+        return false;
+    }
+
     static void contributeTeamBuildParameterActions(final HashMap<String, String> teamBuildParameters, final List<Action> actions) {
-        if (teamBuildParameters.containsKey(BUILD_REPOSITORY_PROVIDER) && "TfGit".equalsIgnoreCase(teamBuildParameters.get(BUILD_REPOSITORY_PROVIDER))) {
+        if (isTeamGit(teamBuildParameters)) {
             final String collectionUriString = teamBuildParameters.get(SYSTEM_TEAM_FOUNDATION_COLLECTION_URI);
             final URI collectionUri = URI.create(collectionUriString);
             final String repoUriString = teamBuildParameters.get(BUILD_REPOSITORY_URI);


### PR DESCRIPTION
Manual testing
--------------

1. Ran `curl --request POST http://localhost:9090/team-build/build/param --data-urlencode json@buildWithTeamBuild.json` with a payload containing a `team-build` section that had:
    1. `"Build.Repository.Provider": "TfGit",` => success!
    2. `"Build.Repository.Provider": "TfsGit",` => success!

Mission accomplished!