### PR TITLE
Reduce the chance of error with Team Services URLs

### DIFF
--- a/src/main/java/hudson/plugins/tfs/TeamCollectionConfiguration.java
+++ b/src/main/java/hudson/plugins/tfs/TeamCollectionConfiguration.java
@@ -70,6 +70,10 @@ public class TeamCollectionConfiguration extends AbstractDescribableImpl<TeamCol
                 return FormValidation.error("Malformed TFS/Team Services collection URL (%s)", e.getMessage());
             }
 
+            final String hostName = uri.getHost();
+            if (isTeamServices(hostName)) {
+                return checkTeamServices(uri);
+            }
             // TODO: check that it's not a deep URL to a repository, work item, API endpoint, etc.
 
             return FormValidation.ok();
@@ -131,6 +135,16 @@ public class TeamCollectionConfiguration extends AbstractDescribableImpl<TeamCol
                     .withEmptySelection()
                     .withAll(matches);
         }
+    }
+
+    static FormValidation checkTeamServices(final URI uri) {
+        final String path = uri.getPath();
+        if (path != null) {
+            if (path.length() > 0 && !path.equals("/")) {
+                return FormValidation.error("A Team Services collection URL must have an empty path.");
+            }
+        }
+        return FormValidation.ok();
     }
 
     static boolean isTeamServices(final String hostName) {

--- a/src/main/java/hudson/plugins/tfs/TeamCollectionConfiguration.java
+++ b/src/main/java/hudson/plugins/tfs/TeamCollectionConfiguration.java
@@ -138,11 +138,8 @@ public class TeamCollectionConfiguration extends AbstractDescribableImpl<TeamCol
     }
 
     static FormValidation checkTeamServices(final URI uri) {
-        final String path = uri.getPath();
-        if (path != null) {
-            if (path.length() > 0 && !path.equals("/")) {
-                return FormValidation.error("A Team Services collection URL must have an empty path.");
-            }
+        if (UriHelper.hasPath(uri)) {
+            return FormValidation.error("A Team Services collection URL must have an empty path.");
         }
         return FormValidation.ok();
     }

--- a/src/main/java/hudson/plugins/tfs/TeamCollectionConfiguration.java
+++ b/src/main/java/hudson/plugins/tfs/TeamCollectionConfiguration.java
@@ -11,8 +11,8 @@ import hudson.Extension;
 import hudson.model.AbstractDescribableImpl;
 import hudson.model.Descriptor;
 import hudson.plugins.tfs.util.StringHelper;
-import hudson.plugins.tfs.util.UriHelper;
 import hudson.plugins.tfs.util.TeamRestClient;
+import hudson.plugins.tfs.util.UriHelper;
 import hudson.security.ACL;
 import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
@@ -21,9 +21,8 @@ import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 
 import java.io.IOException;
-import java.net.MalformedURLException;
 import java.net.URI;
-import java.net.URL;
+import java.net.URISyntaxException;
 import java.util.Collections;
 import java.util.List;
 
@@ -63,10 +62,11 @@ public class TeamCollectionConfiguration extends AbstractDescribableImpl<TeamCol
         public FormValidation doCheckCollectionUrl(
                 @QueryParameter final String value) {
 
+            final URI uri;
             try {
-                new URL(value);
+                uri = new URI(value);
             }
-            catch (MalformedURLException e) {
+            catch (final URISyntaxException e) {
                 return FormValidation.error("Malformed TFS/Team Services collection URL (%s)", e.getMessage());
             }
 
@@ -84,10 +84,10 @@ public class TeamCollectionConfiguration extends AbstractDescribableImpl<TeamCol
 
             String hostName = null;
             try {
-                final URL url = new URL(collectionUrl);
-                hostName = url.getHost();
+                final URI uri = new URI(collectionUrl);
+                hostName = uri.getHost();
             }
-            catch (final MalformedURLException e) {
+            catch (final URISyntaxException e) {
                 return FormValidation.error(errorTemplate, e.getMessage());
             }
 
@@ -116,10 +116,10 @@ public class TeamCollectionConfiguration extends AbstractDescribableImpl<TeamCol
 
             String hostName = null;
             try {
-                final URL url = new URL(collectionUrl);
-                hostName = url.getHost();
+                final URI uri = new URI(collectionUrl);
+                hostName = uri.getHost();
             }
-            catch (final MalformedURLException ignored) {
+            catch (final URISyntaxException ignored) {
             }
 
             if (hostName == null || !jenkins.hasPermission(Jenkins.ADMINISTER)) {

--- a/src/main/java/hudson/plugins/tfs/TeamCollectionConfiguration.java
+++ b/src/main/java/hudson/plugins/tfs/TeamCollectionConfiguration.java
@@ -147,7 +147,7 @@ public class TeamCollectionConfiguration extends AbstractDescribableImpl<TeamCol
         return FormValidation.ok();
     }
 
-    static boolean isTeamServices(final String hostName) {
+    public static boolean isTeamServices(final String hostName) {
         return StringHelper.endsWithIgnoreCase(hostName, ".visualstudio.com");
     }
 

--- a/src/main/java/hudson/plugins/tfs/TeamCollectionConfiguration.java
+++ b/src/main/java/hudson/plugins/tfs/TeamCollectionConfiguration.java
@@ -144,6 +144,23 @@ public class TeamCollectionConfiguration extends AbstractDescribableImpl<TeamCol
         return FormValidation.ok();
     }
 
+    static boolean areSameCollectionUri(final URI a, final URI b) {
+        if (a == null) {
+            throw new IllegalArgumentException("Parameter 'a' is null");
+        }
+        if (b == null) {
+            throw new IllegalArgumentException("Parameter 'b' is null");
+        }
+
+        final String aHost = a.getHost();
+        final String bHost = b.getHost();
+        if (isTeamServices(aHost) && isTeamServices(bHost)) {
+            return StringHelper.equalIgnoringCase(aHost, bHost);
+        }
+
+        return UriHelper.areSame(a, b);
+    }
+
     public static boolean isTeamServices(final String hostName) {
         return StringHelper.endsWithIgnoreCase(hostName, ".visualstudio.com");
     }
@@ -196,7 +213,7 @@ public class TeamCollectionConfiguration extends AbstractDescribableImpl<TeamCol
         for (final TeamCollectionConfiguration pair : pairs) {
             final String candidateCollectionUrlString = pair.getCollectionUrl();
             final URI candidateCollectionUri = URI.create(candidateCollectionUrlString);
-            if (UriHelper.areSame(candidateCollectionUri, collectionUri)) {
+            if (areSameCollectionUri(candidateCollectionUri, collectionUri)) {
                 final String credentialsId = pair.credentialsId;
                 if (credentialsId != null) {
                     return findCredentialsById(credentialsId);

--- a/src/main/java/hudson/plugins/tfs/TeamCollectionConfiguration.java
+++ b/src/main/java/hudson/plugins/tfs/TeamCollectionConfiguration.java
@@ -93,7 +93,7 @@ public class TeamCollectionConfiguration extends AbstractDescribableImpl<TeamCol
 
             try {
                 final StandardUsernamePasswordCredentials credential = findCredential(hostName, credentialsId);
-                if (StringHelper.endsWithIgnoreCase(hostName, ".visualstudio.com")) {
+                if (isTeamServices(hostName)) {
                     if (credential == null) {
                         return FormValidation.error(errorTemplate, "Team Services accounts need credentials, preferably a Personal Access Token");
                     }
@@ -131,6 +131,10 @@ public class TeamCollectionConfiguration extends AbstractDescribableImpl<TeamCol
                     .withEmptySelection()
                     .withAll(matches);
         }
+    }
+
+    static boolean isTeamServices(final String hostName) {
+        return StringHelper.endsWithIgnoreCase(hostName, ".visualstudio.com");
     }
 
     static void testConnection(final URI collectionUri, final StandardUsernamePasswordCredentials credentials) throws IOException {

--- a/src/main/java/hudson/plugins/tfs/TeamPushTrigger.java
+++ b/src/main/java/hudson/plugins/tfs/TeamPushTrigger.java
@@ -123,7 +123,7 @@ public class TeamPushTrigger extends Trigger<Job<?, ?>> {
             }
             if (shouldSchedule) {
                 final SCMTriggerItem p = job();
-                final String name = " #" + p.getNextBuildNumber();
+                final String name = "#" + p.getNextBuildNumber();
                 final String pushedBy = gitCodePushedEventArgs.pushedBy;
                 TeamPushCause cause;
                 try {

--- a/src/main/java/hudson/plugins/tfs/TeamPushTrigger.java
+++ b/src/main/java/hudson/plugins/tfs/TeamPushTrigger.java
@@ -118,6 +118,9 @@ public class TeamPushTrigger extends Trigger<Job<?, ?>> {
                     shouldSchedule = true;
                 }
             }
+            else {
+                changesDetected = "Polling bypassed for " + job.getFullDisplayName() + ". ";;
+            }
             if (shouldSchedule) {
                 final SCMTriggerItem p = job();
                 final String name = " #" + p.getNextBuildNumber();

--- a/src/main/java/hudson/plugins/tfs/model/AbstractHookEvent.java
+++ b/src/main/java/hudson/plugins/tfs/model/AbstractHookEvent.java
@@ -10,10 +10,12 @@ import hudson.plugins.git.GitSCM;
 import hudson.plugins.git.GitStatus;
 import hudson.plugins.git.extensions.impl.IgnoreNotifyCommit;
 import hudson.plugins.tfs.CommitParameterAction;
+import hudson.plugins.tfs.TeamCollectionConfiguration;
 import hudson.plugins.tfs.TeamEventsEndpoint;
 import hudson.plugins.tfs.TeamHookCause;
 import hudson.plugins.tfs.TeamPushTrigger;
 import hudson.plugins.tfs.model.servicehooks.Event;
+import hudson.plugins.tfs.util.StringHelper;
 import hudson.scm.SCM;
 import hudson.security.ACL;
 import hudson.triggers.SCMTrigger;
@@ -178,6 +180,34 @@ public abstract class AbstractHookEvent {
         finally {
             SecurityContextHolder.setContext(old);
         }
+    }
+
+    // TODO: find a better home for this method
+    static boolean isTeamServicesNearMatch(final URIish a, final URIish b) {
+        final String aHost = a.getHost();
+        final String bHost = b.getHost();
+        if (TeamCollectionConfiguration.isTeamServices(aHost)
+                && TeamCollectionConfiguration.isTeamServices(bHost)) {
+            final String aPath = normalizePath(a.getPath());
+            final String bPath = normalizePath(b.getPath());
+            if (StringHelper.endsWithIgnoreCase(aPath, bPath)
+                    || StringHelper.endsWithIgnoreCase(bPath, aPath)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    static String normalizePath(String path) {
+        if(path.startsWith("/")) {
+            path = path.substring(1);
+        }
+
+        if(path.endsWith("/")) {
+            path = path.substring(0, path.length() - 1);
+        }
+
+        return path;
     }
 
 }

--- a/src/main/java/hudson/plugins/tfs/model/AbstractHookEvent.java
+++ b/src/main/java/hudson/plugins/tfs/model/AbstractHookEvent.java
@@ -79,6 +79,7 @@ public abstract class AbstractHookEvent {
 
     // TODO: it would be easiest if pollOrQueueFromEvent built a JSONObject directly
     List<GitStatus.ResponseContributor> pollOrQueueFromEvent(final GitCodePushedEventArgs gitCodePushedEventArgs, final CommitParameterAction commitParameterAction, final boolean bypassPolling) {
+        final String almostMatchTemplate = "Remote URL '%s' of job '%s' almost matched event URL '%s'.";
         List<GitStatus.ResponseContributor> result = new ArrayList<GitStatus.ResponseContributor>();
         final String commit = gitCodePushedEventArgs.commit;
         final URIish uri = gitCodePushedEventArgs.getRepoURIish();
@@ -115,6 +116,15 @@ public abstract class AbstractHookEvent {
                                 repositoryMatches = true;
                                 totalRepositoryMatches++;
                                 break;
+                            }
+                        }
+
+                        if (!repositoryMatches) {
+                            for (URIish remoteURL : repository.getURIs()) {
+                                if (isTeamServicesNearMatch(uri, remoteURL)) {
+                                    final String message = String.format(almostMatchTemplate, uri, project.getFullDisplayName(), remoteURL);
+                                    LOGGER.warning(message);
+                                }
                             }
                         }
 

--- a/src/main/java/hudson/plugins/tfs/model/AbstractHookEvent.java
+++ b/src/main/java/hudson/plugins/tfs/model/AbstractHookEvent.java
@@ -93,6 +93,7 @@ public abstract class AbstractHookEvent {
                 LOGGER.severe("Jenkins.getInstance() is null");
                 return result;
             }
+            int totalRepositoryMatches = 0;
             for (final Item project : Jenkins.getInstance().getAllItems()) {
                 final SCMTriggerItem scmTriggerItem = SCMTriggerItem.SCMTriggerItems.asSCMTriggerItem(project);
                 if (scmTriggerItem == null) {
@@ -110,6 +111,7 @@ public abstract class AbstractHookEvent {
                         for (URIish remoteURL : repository.getURIs()) {
                             if (GitStatus.looselyMatches(uri, remoteURL)) {
                                 repositoryMatches = true;
+                                totalRepositoryMatches++;
                                 break;
                             }
                         }
@@ -164,6 +166,11 @@ public abstract class AbstractHookEvent {
             }
             if (!scmFound) {
                 result.add(new GitStatus.MessageResponseContributor("No Git jobs found"));
+            }
+            else if (totalRepositoryMatches == 0) {
+                final String template = "No Git jobs matched the remote URL '%s' requested by an event.";
+                final String message = String.format(template, uri);
+                LOGGER.warning(message);
             }
 
             return result;

--- a/src/main/java/hudson/plugins/tfs/util/TeamRestClient.java
+++ b/src/main/java/hudson/plugins/tfs/util/TeamRestClient.java
@@ -3,6 +3,7 @@ package hudson.plugins.tfs.util;
 import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import hudson.plugins.tfs.TeamCollectionConfiguration;
 import hudson.plugins.tfs.model.GitCodePushedEventArgs;
 import hudson.plugins.tfs.model.HttpMethod;
 import hudson.plugins.tfs.model.PullRequestMergeCommitCreatedEventArgs;
@@ -40,7 +41,7 @@ public class TeamRestClient {
     public TeamRestClient(final URI collectionUri, final StandardUsernamePasswordCredentials credentials) {
         this.collectionUri = collectionUri;
         final String hostName = collectionUri.getHost();
-        isHosted = StringHelper.endsWithIgnoreCase(hostName, ".visualstudio.com");
+        isHosted = TeamCollectionConfiguration.isTeamServices(hostName);
         if (credentials != null) {
             authorization = createAuthorization(credentials);
         }

--- a/src/main/java/hudson/plugins/tfs/util/TeamRestClient.java
+++ b/src/main/java/hudson/plugins/tfs/util/TeamRestClient.java
@@ -38,6 +38,19 @@ public class TeamRestClient {
     private final boolean isTeamServices;
     private final String authorization;
 
+    public TeamRestClient(final URI collectionUri) {
+        this.collectionUri = collectionUri;
+        final String hostName = collectionUri.getHost();
+        isTeamServices = TeamCollectionConfiguration.isTeamServices(hostName);
+        final StandardUsernamePasswordCredentials credentials = TeamCollectionConfiguration.findCredentialsForCollection(collectionUri);
+        if (credentials != null) {
+            authorization = createAuthorization(credentials);
+        }
+        else {
+            authorization = null;
+        }
+    }
+
     public TeamRestClient(final URI collectionUri, final StandardUsernamePasswordCredentials credentials) {
         this.collectionUri = collectionUri;
         final String hostName = collectionUri.getHost();

--- a/src/main/java/hudson/plugins/tfs/util/TeamRestClient.java
+++ b/src/main/java/hudson/plugins/tfs/util/TeamRestClient.java
@@ -35,13 +35,13 @@ public class TeamRestClient {
     }
 
     private final URI collectionUri;
-    private final boolean isHosted;
+    private final boolean isTeamServices;
     private final String authorization;
 
     public TeamRestClient(final URI collectionUri, final StandardUsernamePasswordCredentials credentials) {
         this.collectionUri = collectionUri;
         final String hostName = collectionUri.getHost();
-        isHosted = TeamCollectionConfiguration.isTeamServices(hostName);
+        isTeamServices = TeamCollectionConfiguration.isTeamServices(hostName);
         if (credentials != null) {
             authorization = createAuthorization(credentials);
         }
@@ -164,7 +164,7 @@ public class TeamRestClient {
 
     public String ping() throws IOException {
         final URI requestUri;
-        if (isHosted) {
+        if (isTeamServices) {
             requestUri = UriHelper.join(collectionUri, "_apis", "connectiondata");
         }
         else {

--- a/src/main/java/hudson/plugins/tfs/util/TeamStatus.java
+++ b/src/main/java/hudson/plugins/tfs/util/TeamStatus.java
@@ -35,9 +35,7 @@ public class TeamStatus {
         }
 
         final URI collectionUri = gitCodePushedEventArgs.collectionUri;
-        final StandardUsernamePasswordCredentials credentials =
-                TeamCollectionConfiguration.findCredentialsForCollection(collectionUri);
-        final TeamRestClient client = new TeamRestClient(collectionUri, credentials);
+        final TeamRestClient client = new TeamRestClient(collectionUri);
 
         final TeamGitStatus status = TeamGitStatus.fromRun(run);
         // TODO: when code is pushed and polling happens, are we sure we built against the requested commit?

--- a/src/main/java/hudson/plugins/tfs/util/UriHelper.java
+++ b/src/main/java/hudson/plugins/tfs/util/UriHelper.java
@@ -106,6 +106,16 @@ public class UriHelper {
         return path;
     }
 
+    public static boolean hasPath(final URI uri) {
+        final String path = uri.getPath();
+        if (path != null) {
+            if (path.length() > 0 && !path.equals("/")) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     public static boolean isWellFormedUriString(final String uriString) {
         try {
             new URI(uriString);

--- a/src/test/java/hudson/plugins/tfs/IntegrationTestHelper.java
+++ b/src/test/java/hudson/plugins/tfs/IntegrationTestHelper.java
@@ -40,7 +40,7 @@ public class IntegrationTestHelper {
 
     public IntegrationTestHelper(final String tfsServerName, final String tfsUserName, final String tfsUserPassword) throws URISyntaxException {
         final URI serverUri;
-        if (tfsServerName.endsWith(".visualstudio.com")) {
+        if (TeamCollectionConfiguration.isTeamServices(tfsServerName)) {
             serverUri = new URI("https", null, tfsServerName, 443, "/", null, null);
             this.userName = tfsUserName;
             this.userPassword = tfsUserPassword;

--- a/src/test/java/hudson/plugins/tfs/TeamCollectionConfigurationTest.java
+++ b/src/test/java/hudson/plugins/tfs/TeamCollectionConfigurationTest.java
@@ -11,6 +11,46 @@ import java.net.URI;
  */
 public class TeamCollectionConfigurationTest {
 
+    private static void assertSameCollectionUri(final String a, final String b) {
+        areSameCollectionUri(a, b, true);
+    }
+
+    private static void areSameCollectionUri(final String a, final String b, boolean expected) {
+        final URI uriA = a == null ? null : URI.create(a);
+        final URI uriB = b == null ? null : URI.create(b);
+        final String template = "Expected '%s' and '%s' to be considered%s the same.";
+        final String message = String.format(template, a, b, expected ? "" : " NOT");
+        Assert.assertEquals(message, expected, TeamCollectionConfiguration.areSameCollectionUri(uriA, uriB));
+        Assert.assertEquals(message, expected, TeamCollectionConfiguration.areSameCollectionUri(uriB, uriA));
+    }
+
+    @Test public void areSameCollectionUri_identity() throws Exception {
+        final String input = "https://fabrikam-fiber-inc.visualstudio.com/";
+        assertSameCollectionUri(input, input);
+    }
+
+    @Test public void areSameCollectionUri_typical() throws Exception {
+        final String a = "https://fabrikam-fiber-inc.visualstudio.com/";
+        final String b = "https://fabrikam-fiber-inc.visualstudio.com/DefaultCollection";
+
+        assertSameCollectionUri(a, b);
+    }
+
+    @Test public void areSameCollectionUri_withSlashes() throws Exception {
+        final String a = "https://fabrikam-fiber-inc.visualstudio.com/";
+        final String b = "https://fabrikam-fiber-inc.visualstudio.com/DefaultCollection/";
+
+        assertSameCollectionUri(a, b);
+    }
+
+    @Test public void areSameCollectionUri_withoutSlashes() throws Exception {
+        final String a = "https://fabrikam-fiber-inc.visualstudio.com";
+        final String b = "https://fabrikam-fiber-inc.visualstudio.com/DefaultCollection";
+
+        assertSameCollectionUri(a, b);
+    }
+
+
     @Test public void checkTeamServices_serverOnly() throws Exception {
         final URI input = URI.create("https://fabrikam-fiber-inc.visualstudio.com");
 

--- a/src/test/java/hudson/plugins/tfs/TeamCollectionConfigurationTest.java
+++ b/src/test/java/hudson/plugins/tfs/TeamCollectionConfigurationTest.java
@@ -1,8 +1,54 @@
 package hudson.plugins.tfs;
 
+import hudson.util.FormValidation;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.net.URI;
+
 /**
  * A class to test {@link TeamCollectionConfiguration}.
  */
 public class TeamCollectionConfigurationTest {
+
+    @Test public void checkTeamServices_serverOnly() throws Exception {
+        final URI input = URI.create("https://fabrikam-fiber-inc.visualstudio.com");
+
+        final FormValidation actual = TeamCollectionConfiguration.checkTeamServices(input);
+
+        Assert.assertEquals(FormValidation.Kind.OK, actual.kind);
+    }
+
+    @Test public void checkTeamServices_serverWithSlash() throws Exception {
+        final URI input = URI.create("https://fabrikam-fiber-inc.visualstudio.com/");
+
+        final FormValidation actual = TeamCollectionConfiguration.checkTeamServices(input);
+
+        Assert.assertEquals(FormValidation.Kind.OK, actual.kind);
+    }
+
+    @Test public void checkTeamServices_serverWithDefaultCollection() throws Exception {
+        final URI input = URI.create("https://fabrikam-fiber-inc.visualstudio.com/DefaultCollection");
+
+        final FormValidation actual = TeamCollectionConfiguration.checkTeamServices(input);
+
+        Assert.assertEquals(FormValidation.Kind.ERROR, actual.kind);
+    }
+
+    @Test public void checkTeamServices_serverWithDefaultCollectionSlash() throws Exception {
+        final URI input = URI.create("https://fabrikam-fiber-inc.visualstudio.com/DefaultCollection/");
+
+        final FormValidation actual = TeamCollectionConfiguration.checkTeamServices(input);
+
+        Assert.assertEquals(FormValidation.Kind.ERROR, actual.kind);
+    }
+
+    @Test public void checkTeamServices_gitUrl() throws Exception {
+        final URI input = URI.create("https://fabrikam-fiber-inc.visualstudio.com/_git/Fabrikam");
+
+        final FormValidation actual = TeamCollectionConfiguration.checkTeamServices(input);
+
+        Assert.assertEquals(FormValidation.Kind.ERROR, actual.kind);
+    }
 
 }

--- a/src/test/java/hudson/plugins/tfs/model/AbstractHookEventTest.java
+++ b/src/test/java/hudson/plugins/tfs/model/AbstractHookEventTest.java
@@ -1,0 +1,69 @@
+package hudson.plugins.tfs.model;
+
+import org.eclipse.jgit.transport.URIish;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * A class to test {@link AbstractHookEvent}.
+ */
+public class AbstractHookEventTest {
+
+    private static void isTeamServicesNearMatch(final String a, final String b, final boolean expected) throws Exception {
+        final URIish uriA = a == null ? null : new URIish(a);
+        final URIish uriB = b == null ? null : new URIish(b);
+        final String template = "Expected '%s' and '%s' to be considered%s the same.";
+        final String message = String.format(template, a, b, expected ? "" : " NOT");
+        Assert.assertEquals(message, expected, AbstractHookEvent.isTeamServicesNearMatch(uriA, uriB));
+        Assert.assertEquals(message, expected, AbstractHookEvent.isTeamServicesNearMatch(uriB, uriA));
+    }
+
+    private static void assertIsTeamServicesNearMatch(final String a, final String b) throws Exception {
+        isTeamServicesNearMatch(a, b, true);
+    }
+
+    private static void assertIsNotTeamServicesNearMatch(final String a, final String b) throws Exception {
+        isTeamServicesNearMatch(a, b, false);
+    }
+
+    @Test public void isTeamServicesNearMatch_identity() throws Exception {
+        final String a = "https://fabrikam-fiber-inc.visualstudio.com/Project/_git/Fabrikam";
+        assertIsTeamServicesNearMatch(a, a);
+    }
+
+    @Test public void isTeamServicesNearMatch_typical() throws Exception {
+        final String a = "https://fabrikam-fiber-inc.visualstudio.com/Project/_git/Fabrikam";
+        final String b = "https://fabrikam-fiber-inc.visualstudio.com/DefaultCollection/Project/_git/Fabrikam";
+
+        assertIsTeamServicesNearMatch(a, b);
+    }
+
+    @Test public void isTeamServicesNearMatch_typicalWithSlashWithoutSlash() throws Exception {
+        final String a = "https://fabrikam-fiber-inc.visualstudio.com/Project/_git/Fabrikam/";
+        final String b = "https://fabrikam-fiber-inc.visualstudio.com/DefaultCollection/Project/_git/Fabrikam";
+
+        assertIsTeamServicesNearMatch(a, b);
+    }
+
+    @Test public void isTeamServicesNearMatch_typicalWithoutSlashWithSlash() throws Exception {
+        final String a = "https://fabrikam-fiber-inc.visualstudio.com/Project/_git/Fabrikam";
+        final String b = "https://fabrikam-fiber-inc.visualstudio.com/DefaultCollection/Project/_git/Fabrikam/";
+
+        assertIsTeamServicesNearMatch(a, b);
+    }
+
+    @Test public void isTeamServicesNearMatch_tfs() throws Exception {
+        final String a = "http://tfs:8080/tfs/DefaultCollection/Project/_git/Fabrikam";
+        final String b = "http://tfs:8080/tfs/DefaultCollection/Project/_git/Fabrikam/";
+
+        assertIsNotTeamServicesNearMatch(a, b);
+    }
+
+    @Test public void isTeamServicesNearMatch_gitHub() throws Exception {
+        final String a = "https://github.com/jenkinsci/tfs-plugin.git";
+        final String b = "git@github.com:jenkinsci/tfs-plugin.git";
+
+        assertIsNotTeamServicesNearMatch(a, b);
+    }
+
+}

--- a/src/test/java/hudson/plugins/tfs/util/UriHelperTest.java
+++ b/src/test/java/hudson/plugins/tfs/util/UriHelperTest.java
@@ -122,6 +122,40 @@ public class UriHelperTest {
         assertNotSame("http://one.example.com/path?q=example#top", "http://one.example.com/path?q=example#bottom");
     }
 
+
+    @Test public void hasPath_hostOnly() throws Exception {
+        final URI input = URI.create("https://fabrikam-fiber-inc.visualstudio.com");
+
+        final boolean actual = UriHelper.hasPath(input);
+
+        Assert.assertEquals(false, actual);
+    }
+
+    @Test public void hasPath_hostSlash() throws Exception {
+        final URI input = URI.create("https://fabrikam-fiber-inc.visualstudio.com/");
+
+        final boolean actual = UriHelper.hasPath(input);
+
+        Assert.assertEquals(false, actual);
+    }
+
+    @Test public void hasPath_path() throws Exception {
+        final URI input = URI.create("https://fabrikam-fiber-inc.visualstudio.com/DefaultCollection");
+
+        final boolean actual = UriHelper.hasPath(input);
+
+        Assert.assertEquals(true, actual);
+    }
+
+    @Test public void hasPath_pathSlash() throws Exception {
+        final URI input = URI.create("https://fabrikam-fiber-inc.visualstudio.com/DefaultCollection/");
+
+        final boolean actual = UriHelper.hasPath(input);
+
+        Assert.assertEquals(true, actual);
+    }
+
+
     @Test public void join_uriNoSlash_pathComponents() throws Exception {
         final URI collectionUri = URI.create("https://fabrikam-fiber-inc.visualstudio.com");
 


### PR DESCRIPTION
TFS eventually acquired the concept of Team Project Collections to allow isolation between groups/projects (on the same server) and Visual Studio Team Services initially inherited this functionality by requiring `/DefaultCollection` in the URL.  After a while, Team Services removed the requirement of specifying `/DefaultCollection` in the URL while still supporting URLs with it.  This lead to a situation where the plugin would consider two functionally-identical URLs as different collections.

This pull request aims to mitigate the confusion by:

1. Enforcing the lack of a path in Team Services collection URLs in the global configuration.
2. Emitting warnings when jobs _almost match_ a given event URL.
3. Emitting warnings when no jobs exactly matched a given event URL.

Manual testing
--------------
The test cases are in the same order as the mitigations above.

1. Attempted to add `/DefaultCollection` to a Team Services collection URL: ![image](https://cloud.githubusercontent.com/assets/297515/17529119/13724824-5e40-11e6-9d6c-409136bec023.png) (no such error was shown when the URL's host name did not end with `.visualstudio.com`)
2. Purposely added a `/DefaultCollection` to the value of the `remoteUrl` in an event payload of type `git.pullrequest.merged` and then POSTed it to the `/team-events/gitPullRequestMerged` endpoint.  My jobs that were configured with a remote URL equivalent to the same repository (minus the `/DefaultCollection`) were logged as _almost matched_ in a warning and were not triggered.
3. Since none of the jobs had `/DefaultCollection` in a Git remote URL, there was a warning saying exactly that.

Mission accomplished!