### PR TITLE
Detect missing team project collection configuration

### DIFF
--- a/src/main/java/hudson/plugins/tfs/TeamCollectionConfiguration.java
+++ b/src/main/java/hudson/plugins/tfs/TeamCollectionConfiguration.java
@@ -189,6 +189,10 @@ public class TeamCollectionConfiguration extends AbstractDescribableImpl<TeamCol
                 return null;
             }
         }
-        return null;
+        final String template = "There is no team project collection configured for the URL '%1$s'.\n" +
+                "Please go to Jenkins > Manage Jenkins > Configure System and then " +
+                "add a Team Project Collection with a Collection URL of '%1$s'.";
+        final String message = String.format(template, collectionUri);
+        throw new IllegalArgumentException(message);
     }
 }

--- a/src/main/java/hudson/plugins/tfs/TeamCompletedStatusPostBuildAction.java
+++ b/src/main/java/hudson/plugins/tfs/TeamCompletedStatusPostBuildAction.java
@@ -37,6 +37,9 @@ public class TeamCompletedStatusPostBuildAction extends Notifier implements Simp
         try {
             TeamStatus.createFromRun(run);
         }
+        catch (final IllegalArgumentException e) {
+            listener.error(e.getMessage());
+        }
         catch (final Exception e) {
             e.printStackTrace(listener.error("Error while trying to update completion status in TFS/Team Services"));
         }

--- a/src/main/java/hudson/plugins/tfs/TeamPendingStatusBuildStep.java
+++ b/src/main/java/hudson/plugins/tfs/TeamPendingStatusBuildStep.java
@@ -35,6 +35,9 @@ public class TeamPendingStatusBuildStep extends Builder implements SimpleBuildSt
         try {
             TeamStatus.createFromRun(run);
         }
+        catch (final IllegalArgumentException e) {
+            listener.error(e.getMessage());
+        }
         catch (final Exception e) {
             e.printStackTrace(listener.error("Error while trying to update pending status in TFS/Team Services"));
         }


### PR DESCRIPTION
Without the changes in this branch, if the **Set build pending status in TFS/Team Services** build step or the **Set build completion status in TFS/Team Services** post-build action were added _without_ adding the corresponding Team Project Collection URL in the global configuration, the build output would contain:

    ERROR: Error while trying to update pending status in TFS/Team Services
    net.sf.json.JSONException: A JSONObject text must begin with '{' at character 1 of <!DOCTYPE(...)>
    (...)
    <html xmlns="http://www.w3.org/1999/xhtml">
    <head><title>
            Visual Studio Team Services | Sign In
    (...lots of HTML...)
    </html>
    	at net.sf.json.util.JSONTokener.syntaxError(JSONTokener.java:499)
        at net.sf.json.JSONObject._fromJSONTokener(JSONObject.java:919)
        at net.sf.json.JSONObject.fromObject(JSONObject.java:156)
        at net.sf.json.JSONObject.fromObject(JSONObject.java:132)
        at hudson.plugins.tfs.util.TeamRestClient.request(TeamRestClient.java:101)
        at hudson.plugins.tfs.util.TeamRestClient.addPullRequestStatus(TeamRestClient.java:200)
        at hudson.plugins.tfs.util.TeamStatus.createFromRun(TeamStatus.java:46)
        at hudson.plugins.tfs.TeamPendingStatusBuildStep.perform(TeamPendingStatusBuildStep.java:36)
        at hudson.tasks.BuildStepCompatibilityLayer.perform(BuildStepCompatibilityLayer.java:78)
        at hudson.tasks.BuildStepMonitor$1.perform(BuildStepMonitor.java:20)
        at hudson.model.AbstractBuild$AbstractBuildExecution.perform(AbstractBuild.java:782)
        at hudson.model.Build$BuildExecution.build(Build.java:205)
        at hudson.model.Build$BuildExecution.doRun(Build.java:162)
        at hudson.model.AbstractBuild$AbstractBuildExecution.run(AbstractBuild.java:534)
        at hudson.model.Run.execute(Run.java:1738)
        at hudson.model.FreeStyleBuild.run(FreeStyleBuild.java:43)
        at hudson.model.ResourceController.execute(ResourceController.java:98)
        at hudson.model.Executor.run(Executor.java:410)

...whereas with these changes, the build output contains:

`ERROR: There is no team project collection configured for the URL 'https://mseng.visualstudio.com/'.`
`Please go to Jenkins > Manage Jenkins > Configure System and then add a Team Project Collection with a Collection URL of 'https://mseng.visualstudio.com/'.`

Mission accomplished!
