### PR TITLE
Link back to the TFS/Team Services build that triggered the Jenkins build

### DIFF
--- a/src/main/java/hudson/plugins/tfs/TeamBuildDetailsAction.java
+++ b/src/main/java/hudson/plugins/tfs/TeamBuildDetailsAction.java
@@ -59,7 +59,8 @@ public class TeamBuildDetailsAction implements Action, Serializable {
 
     @Override
     public String getUrlName() {
-        return "team-build";
+        // TODO: set this once we add an index.jelly with useful information
+        return null;
     }
 
     // the following methods are called from this/summary.jelly

--- a/src/main/java/hudson/plugins/tfs/TeamBuildDetailsAction.java
+++ b/src/main/java/hudson/plugins/tfs/TeamBuildDetailsAction.java
@@ -1,9 +1,13 @@
 package hudson.plugins.tfs;
 
 import hudson.model.Action;
+import hudson.plugins.tfs.util.QueryString;
+import hudson.plugins.tfs.util.UriHelper;
+import org.kohsuke.stapler.export.Exported;
 import org.kohsuke.stapler.export.ExportedBean;
 
 import java.io.Serializable;
+import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -15,8 +19,30 @@ public class TeamBuildDetailsAction implements Action, Serializable {
     private static final long serialVersionUID = 1L;
 
     public Map<String, String> buildVariables = new HashMap<String, String>();
+    public String buildUrl;
 
     public TeamBuildDetailsAction() {
+
+    }
+
+    public TeamBuildDetailsAction(final Map<String, String> buildVariables) {
+        this.buildVariables = new HashMap<String, String>(buildVariables);
+        this.buildUrl = determineBuildUrl(buildVariables).toString();
+    }
+
+    static URI determineBuildUrl(final Map<String, String> buildVariables) {
+        // TODO: eventually call the build REST API to obtain the proper web URL
+        final String collectionUri = buildVariables.get("System.TeamFoundationCollectionUri");
+        final String projectName = buildVariables.get("System.TeamProject");
+        final String buildId = buildVariables.get("Build.BuildId");
+        final QueryString query = new QueryString("buildId", buildId);
+        final URI result = UriHelper.join(
+                collectionUri,
+                projectName,
+                "_build",
+                "index",
+                query);
+        return result;
 
     }
 
@@ -34,5 +60,22 @@ public class TeamBuildDetailsAction implements Action, Serializable {
     @Override
     public String getUrlName() {
         return "team-build";
+    }
+
+    // the following methods are called from this/summary.jelly
+
+    @Exported
+    public String getBuildNumber() {
+        return buildVariables.get("Build.BuildNumber");
+    }
+
+    @Exported
+    public String getBuildDefinitionName() {
+        return buildVariables.get("Build.DefinitionName");
+    }
+
+    @Exported
+    public String getBuildUrl() {
+        return buildUrl;
     }
 }

--- a/src/main/java/hudson/plugins/tfs/TeamBuildDetailsAction.java
+++ b/src/main/java/hudson/plugins/tfs/TeamBuildDetailsAction.java
@@ -1,0 +1,38 @@
+package hudson.plugins.tfs;
+
+import hudson.model.Action;
+import org.kohsuke.stapler.export.ExportedBean;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Captures the details of the TFS/Team Services build which triggered us.
+ */
+@ExportedBean(defaultVisibility = 999)
+public class TeamBuildDetailsAction implements Action, Serializable {
+    private static final long serialVersionUID = 1L;
+
+    public Map<String, String> buildVariables = new HashMap<String, String>();
+
+    public TeamBuildDetailsAction() {
+
+    }
+
+    @Override
+    public String getIconFileName() {
+        // TODO: find an appropriate icon
+        return "clipboard.png";
+    }
+
+    @Override
+    public String getDisplayName() {
+        return "TFS/Team Services build";
+    }
+
+    @Override
+    public String getUrlName() {
+        return "team-build";
+    }
+}

--- a/src/main/java/hudson/plugins/tfs/TeamCompletedStatusPostBuildAction.java
+++ b/src/main/java/hudson/plugins/tfs/TeamCompletedStatusPostBuildAction.java
@@ -35,7 +35,7 @@ public class TeamCompletedStatusPostBuildAction extends Notifier implements Simp
             @Nonnull final TaskListener listener
     ) throws InterruptedException, IOException {
         try {
-            TeamStatus.createFromRun(run);
+            TeamStatus.createFromRun(run, listener);
         }
         catch (final IllegalArgumentException e) {
             listener.error(e.getMessage());

--- a/src/main/java/hudson/plugins/tfs/TeamPendingStatusBuildStep.java
+++ b/src/main/java/hudson/plugins/tfs/TeamPendingStatusBuildStep.java
@@ -33,7 +33,7 @@ public class TeamPendingStatusBuildStep extends Builder implements SimpleBuildSt
             @Nonnull final TaskListener listener
     ) throws InterruptedException, IOException {
         try {
-            TeamStatus.createFromRun(run);
+            TeamStatus.createFromRun(run, listener);
         }
         catch (final IllegalArgumentException e) {
             listener.error(e.getMessage());

--- a/src/main/java/hudson/plugins/tfs/UnsupportedIntegrationAction.java
+++ b/src/main/java/hudson/plugins/tfs/UnsupportedIntegrationAction.java
@@ -1,0 +1,41 @@
+package hudson.plugins.tfs;
+
+import hudson.model.Action;
+import hudson.model.InvisibleAction;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import hudson.plugins.tfs.model.BuildCommand;
+
+import javax.annotation.Nonnull;
+import java.io.Serializable;
+import java.util.List;
+
+/**
+ * Contributed to a build whenever the rich TFS/Team Services integration endpoints
+ * are used with unsupported parameters.
+ */
+public class UnsupportedIntegrationAction extends InvisibleAction implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private final String reason;
+
+    public UnsupportedIntegrationAction(final String reason) {
+        this.reason = reason;
+    }
+
+    public static boolean isSupported(@Nonnull final Run<?, ?> run, @Nonnull final TaskListener listener) {
+        final UnsupportedIntegrationAction action = run.getAction(UnsupportedIntegrationAction.class);
+        if (action != null) {
+            final String message = BuildCommand.formatUnsupportedReason(action.reason);
+            listener.error(message);
+            return false;
+        }
+        return true;
+    }
+
+    public static void addToBuild(final List<Action> actions, final String reason) {
+        final UnsupportedIntegrationAction action = new UnsupportedIntegrationAction(reason);
+        actions.add(action);
+    }
+
+}

--- a/src/main/java/hudson/plugins/tfs/model/BuildCommand.java
+++ b/src/main/java/hudson/plugins/tfs/model/BuildCommand.java
@@ -17,6 +17,7 @@ import hudson.model.SimpleParameterDefinition;
 import hudson.model.queue.ScheduleResult;
 import hudson.plugins.tfs.CommitParameterAction;
 import hudson.plugins.tfs.PullRequestParameterAction;
+import hudson.plugins.tfs.TeamBuildDetailsAction;
 import hudson.plugins.tfs.TeamBuildEndpoint;
 import hudson.plugins.tfs.model.servicehooks.Event;
 import hudson.plugins.tfs.util.MediaType;
@@ -216,6 +217,9 @@ public class BuildCommand extends AbstractCommand {
             args.pushedBy = pushedBy;
             final CommitParameterAction action = new CommitParameterAction(args);
             actions.add(action);
+
+            final Action teamBuildDetails = new TeamBuildDetailsAction(teamBuildParameters);
+            actions.add(teamBuildDetails);
         }
     }
 }

--- a/src/main/java/hudson/plugins/tfs/model/BuildCommand.java
+++ b/src/main/java/hudson/plugins/tfs/model/BuildCommand.java
@@ -20,6 +20,7 @@ import hudson.plugins.tfs.PullRequestParameterAction;
 import hudson.plugins.tfs.TeamBuildDetailsAction;
 import hudson.plugins.tfs.TeamBuildEndpoint;
 import hudson.plugins.tfs.model.servicehooks.Event;
+import hudson.plugins.tfs.UnsupportedIntegrationAction;
 import hudson.plugins.tfs.util.MediaType;
 import jenkins.model.Jenkins;
 import jenkins.util.TimeDuration;
@@ -228,6 +229,7 @@ public class BuildCommand extends AbstractCommand {
             else {
                 final String reason = String.format(
                         "The '%s' build variable has a value of '%s', which is not supported.", BUILD_REPOSITORY_PROVIDER, provider);
+                UnsupportedIntegrationAction.addToBuild(actions, reason);
                 LOGGER.warning(formatUnsupportedReason(reason));
             }
         }
@@ -235,6 +237,7 @@ public class BuildCommand extends AbstractCommand {
             final String reason = String.format(
                     "There was no value provided for the '%s' build variable.",
                     BUILD_REPOSITORY_PROVIDER);
+            UnsupportedIntegrationAction.addToBuild(actions, reason);
             LOGGER.warning(formatUnsupportedReason(reason));
         }
     }

--- a/src/main/java/hudson/plugins/tfs/model/BuildCommand.java
+++ b/src/main/java/hudson/plugins/tfs/model/BuildCommand.java
@@ -223,6 +223,8 @@ public class BuildCommand extends AbstractCommand {
                 final CommitParameterAction action = new CommitParameterAction(args);
                 actions.add(action);
 
+                UnsupportedIntegrationAction.addToBuild(actions, "Posting build status is not supported for builds triggered by the 'Jenkins Queue Job' task.");
+
                 final Action teamBuildDetails = new TeamBuildDetailsAction(teamBuildParameters);
                 actions.add(teamBuildDetails);
             }

--- a/src/main/java/hudson/plugins/tfs/model/BuildCommand.java
+++ b/src/main/java/hudson/plugins/tfs/model/BuildCommand.java
@@ -34,8 +34,11 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.logging.Logger;
 
 public class BuildCommand extends AbstractCommand {
+
+    private static final Logger LOGGER = Logger.getLogger(BuildCommand.class.getName());
 
     private static final Action[] EMPTY_ACTION_ARRAY = new Action[0];
     private static final String BUILD_REPOSITORY_PROVIDER = "Build.Repository.Provider";
@@ -47,6 +50,12 @@ public class BuildCommand extends AbstractCommand {
     private static final String SYSTEM_TEAM_FOUNDATION_COLLECTION_URI = "System.TeamFoundationCollectionUri";
     private static final String COMMIT_ID = "commitId";
     private static final String PULL_REQUEST_ID = "pullRequestId";
+    private static final String UNSUPPORTED_TEMPLATE =
+            "The rich integration with TFS/Team Services is not supported. Reason: %s";
+
+    public static String formatUnsupportedReason(final String reason) {
+        return String.format(UNSUPPORTED_TEMPLATE, reason);
+    }
 
     public static class Factory implements AbstractCommand.Factory {
         @Override
@@ -189,37 +198,44 @@ public class BuildCommand extends AbstractCommand {
         return innerPerform(project, delay, actions);
     }
 
-    static boolean isTeamGit(final Map<String, String> teamBuildParameters) {
+    static void contributeTeamBuildParameterActions(final Map<String, String> teamBuildParameters, final List<Action> actions) {
         if (teamBuildParameters.containsKey(BUILD_REPOSITORY_PROVIDER)) {
             final String provider = teamBuildParameters.get(BUILD_REPOSITORY_PROVIDER);
-            return "TfGit".equalsIgnoreCase(provider)
+            final boolean isTeamGit = "TfGit".equalsIgnoreCase(provider)
                     || "TfsGit".equalsIgnoreCase(provider);
+            if (isTeamGit) {
+                final String collectionUriString = teamBuildParameters.get(SYSTEM_TEAM_FOUNDATION_COLLECTION_URI);
+                final URI collectionUri = URI.create(collectionUriString);
+                final String repoUriString = teamBuildParameters.get(BUILD_REPOSITORY_URI);
+                final URI repoUri = URI.create(repoUriString);
+                final String projectId = teamBuildParameters.get(SYSTEM_TEAM_PROJECT);
+                final String repoId = teamBuildParameters.get(BUILD_REPOSITORY_NAME);
+                final String commit = teamBuildParameters.get(BUILD_SOURCE_VERSION);
+                final String pushedBy = teamBuildParameters.get(BUILD_REQUESTED_FOR);
+                final GitCodePushedEventArgs args = new GitCodePushedEventArgs();
+                args.collectionUri = collectionUri;
+                args.repoUri = repoUri;
+                args.projectId = projectId;
+                args.repoId = repoId;
+                args.commit = commit;
+                args.pushedBy = pushedBy;
+                final CommitParameterAction action = new CommitParameterAction(args);
+                actions.add(action);
+
+                final Action teamBuildDetails = new TeamBuildDetailsAction(teamBuildParameters);
+                actions.add(teamBuildDetails);
+            }
+            else {
+                final String reason = String.format(
+                        "The '%s' build variable has a value of '%s', which is not supported.", BUILD_REPOSITORY_PROVIDER, provider);
+                LOGGER.warning(formatUnsupportedReason(reason));
+            }
         }
-        return false;
-    }
-
-    static void contributeTeamBuildParameterActions(final Map<String, String> teamBuildParameters, final List<Action> actions) {
-        if (isTeamGit(teamBuildParameters)) {
-            final String collectionUriString = teamBuildParameters.get(SYSTEM_TEAM_FOUNDATION_COLLECTION_URI);
-            final URI collectionUri = URI.create(collectionUriString);
-            final String repoUriString = teamBuildParameters.get(BUILD_REPOSITORY_URI);
-            final URI repoUri = URI.create(repoUriString);
-            final String projectId = teamBuildParameters.get(SYSTEM_TEAM_PROJECT);
-            final String repoId = teamBuildParameters.get(BUILD_REPOSITORY_NAME);
-            final String commit = teamBuildParameters.get(BUILD_SOURCE_VERSION);
-            final String pushedBy = teamBuildParameters.get(BUILD_REQUESTED_FOR);
-            final GitCodePushedEventArgs args = new GitCodePushedEventArgs();
-            args.collectionUri = collectionUri;
-            args.repoUri = repoUri;
-            args.projectId = projectId;
-            args.repoId = repoId;
-            args.commit = commit;
-            args.pushedBy = pushedBy;
-            final CommitParameterAction action = new CommitParameterAction(args);
-            actions.add(action);
-
-            final Action teamBuildDetails = new TeamBuildDetailsAction(teamBuildParameters);
-            actions.add(teamBuildDetails);
+        else {
+            final String reason = String.format(
+                    "There was no value provided for the '%s' build variable.",
+                    BUILD_REPOSITORY_PROVIDER);
+            LOGGER.warning(formatUnsupportedReason(reason));
         }
     }
 }

--- a/src/main/java/hudson/plugins/tfs/util/TeamStatus.java
+++ b/src/main/java/hudson/plugins/tfs/util/TeamStatus.java
@@ -2,9 +2,11 @@ package hudson.plugins.tfs.util;
 
 import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
 import hudson.model.Run;
+import hudson.model.TaskListener;
 import hudson.plugins.tfs.CommitParameterAction;
 import hudson.plugins.tfs.PullRequestParameterAction;
 import hudson.plugins.tfs.TeamCollectionConfiguration;
+import hudson.plugins.tfs.UnsupportedIntegrationAction;
 import hudson.plugins.tfs.model.GitCodePushedEventArgs;
 import hudson.plugins.tfs.model.PullRequestMergeCommitCreatedEventArgs;
 import hudson.plugins.tfs.model.TeamGitStatus;
@@ -14,8 +16,12 @@ import java.io.IOException;
 import java.net.URI;
 
 public class TeamStatus {
-    public static void createFromRun(@Nonnull final Run<?, ?> run) throws IOException {
-        // TODO: also add support for a build triggered from a pull request
+    public static void createFromRun(@Nonnull final Run<?, ?> run, @Nonnull final TaskListener listener) throws IOException {
+
+        if (!UnsupportedIntegrationAction.isSupported(run, listener)) {
+            return;
+        }
+
         final CommitParameterAction commitParameter = run.getAction(CommitParameterAction.class);
         final GitCodePushedEventArgs gitCodePushedEventArgs;
         final PullRequestMergeCommitCreatedEventArgs pullRequestMergeCommitCreatedEventArgs;

--- a/src/main/resources/hudson/plugins/tfs/TeamBuildDetailsAction/summary.jelly
+++ b/src/main/resources/hudson/plugins/tfs/TeamBuildDetailsAction/summary.jelly
@@ -1,0 +1,9 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler"
+	xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson"
+	xmlns:f="/lib/form" xmlns:i="jelly:fmt">
+	<t:summary>
+
+ 	Triggered by TFS/Team Services build <a href="${it.buildUrl}">${it.buildNumber} of '${it.buildDefinitionName}'</a>
+	</t:summary>
+</j:jelly>

--- a/src/main/resources/hudson/plugins/tfs/TeamBuildDetailsAction/summary.jelly
+++ b/src/main/resources/hudson/plugins/tfs/TeamBuildDetailsAction/summary.jelly
@@ -2,7 +2,7 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler"
 	xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson"
 	xmlns:f="/lib/form" xmlns:i="jelly:fmt">
-	<t:summary>
+	<t:summary icon="${it.iconFileName}">
 
  	Triggered by TFS/Team Services build <a href="${it.buildUrl}">${it.buildNumber} of '${it.buildDefinitionName}'</a>
 	</t:summary>


### PR DESCRIPTION
This pull request makes it so that a POST to `/team-build/build` with a payload that contains a `team-build` section will now contribute the `TeamBuildDetailsAction` to the build.  This new action manifests itself as (see the screenshot following for an example):

1. An (unlinked) entry on the left-hand side of the build labelled **TFS/Team Services build**.
2. An addition to the build summary, where we can read **Triggered by TFS/Team Services build ${Build.BuildNumber} of '${Build.BuildDefinitionName}'**, hyperlinked to the build in TFS/Team Services.

![image](https://cloud.githubusercontent.com/assets/297515/17577333/4b39beee-5f4a-11e6-8c22-3bab15f8bfac.png)


Since this was originally posted, a discrepancy was noticed between the integration specification and the implementation, plus an improvement was made in the user experience.

For the latter, commits 9c2599ef2cefcf7d9ae743fe8d8d862f66972fb6 and c31f75b0ec8e2df0f9ca96ad6351a9d90b06df95 make it so that a warning will now be emitted in the Jenkins log.  This was tested by manipulating the `team-build` section of a payload to the `/team-build/build/` endpoint and produced the following results:

    Aug 18, 2016 9:00:17 AM hudson.plugins.tfs.model.BuildCommand contributeTeamBuildParameterActions
    WARNING: The rich integration with TFS/Team Services is not supported. Reason: There was no value provided for the 'Build.Repository.Provider' build variable.
    Aug 18, 2016 9:00:52 AM hudson.plugins.tfs.model.BuildCommand contributeTeamBuildParameterActions
    WARNING: The rich integration with TFS/Team Services is not supported. Reason: The 'Build.Repository.Provider' build variable has a value of 'Git', which is not supported.


For the former, commit 67c45afe9a73ebdcf7d10f0612d9a0bd041f9e28 will now emit an error in the build output if the job is triggered by the _Jenkins Queue Job_ build task AND the job contained the **Set build pending status in TFS/Team Services** build step or the **Set build completion status in TFS/Team Services** post-build action.  This was tested with exactly those conditions and the output indeed contained the following at the beginning and end of the build output:

   ```
   ERROR: The rich integration with TFS/Team Services is not supported. Reason: Posting build status is not supported for builds triggered by the 'Jenkins Queue Job' task.
   ```

Mission accomplished!