### PR TITLE
Display "pull request merged" event details in build summary & details

### DIFF
--- a/src/main/java/hudson/plugins/tfs/TeamEventsEndpoint.java
+++ b/src/main/java/hudson/plugins/tfs/TeamEventsEndpoint.java
@@ -164,8 +164,10 @@ public class TeamEventsEndpoint implements UnprotectedRootAction {
         }
         final AbstractHookEvent.Factory factory = factoriesByName.get(eventName);
         final Event serviceHookEvent = deserializeEvent(body);
+        final String message = serviceHookEvent.getMessage().getText();
+        final String detailedMessage = serviceHookEvent.getDetailedMessage().getText();
         final AbstractHookEvent hookEvent = factory.create();
-        return hookEvent.perform(MAPPER, serviceHookEvent);
+        return hookEvent.perform(MAPPER, serviceHookEvent, message, detailedMessage);
     }
 
     public static Event deserializeEvent(final String input) throws IOException {

--- a/src/main/java/hudson/plugins/tfs/TeamPullRequestMergedDetailsAction.java
+++ b/src/main/java/hudson/plugins/tfs/TeamPullRequestMergedDetailsAction.java
@@ -1,7 +1,8 @@
 package hudson.plugins.tfs;
 
-import com.microsoft.teamfoundation.sourcecontrol.webapi.model.GitPullRequest;
+import com.microsoft.visualstudio.services.webapi.model.ResourceRef;
 import hudson.model.Action;
+import hudson.plugins.tfs.model.GitPullRequestEx;
 import org.kohsuke.stapler.export.Exported;
 import org.kohsuke.stapler.export.ExportedBean;
 
@@ -15,7 +16,7 @@ public class TeamPullRequestMergedDetailsAction implements Action, Serializable 
     private static final long serialVersionUID = 1L;
     private static final String URL_NAME = "team-pullRequestMergedDetails";
 
-    public GitPullRequest gitPullRequest;
+    public GitPullRequestEx gitPullRequest;
     public String message;
     public String detailedMessage;
 
@@ -23,7 +24,7 @@ public class TeamPullRequestMergedDetailsAction implements Action, Serializable 
 
     }
 
-    public TeamPullRequestMergedDetailsAction(final GitPullRequest gitPullRequest, final String message, final String detailedMessage) {
+    public TeamPullRequestMergedDetailsAction(final GitPullRequestEx gitPullRequest, final String message, final String detailedMessage) {
         this.gitPullRequest = gitPullRequest;
         this.message = message;
         this.detailedMessage = detailedMessage;

--- a/src/main/java/hudson/plugins/tfs/TeamPullRequestMergedDetailsAction.java
+++ b/src/main/java/hudson/plugins/tfs/TeamPullRequestMergedDetailsAction.java
@@ -57,4 +57,15 @@ public class TeamPullRequestMergedDetailsAction implements Action, Serializable 
     public String getDetailedMessage() {
         return detailedMessage;
     }
+
+    @Exported
+    public ResourceRef[] getWorkItems() {
+        return gitPullRequest.getWorkItemRefs();
+    }
+
+    @Exported
+    public boolean hasWorkItems() {
+        final ResourceRef[] workItemRefs = gitPullRequest.getWorkItemRefs();
+        return workItemRefs != null && workItemRefs.length > 0;
+    }
 }

--- a/src/main/java/hudson/plugins/tfs/TeamPullRequestMergedDetailsAction.java
+++ b/src/main/java/hudson/plugins/tfs/TeamPullRequestMergedDetailsAction.java
@@ -1,0 +1,57 @@
+package hudson.plugins.tfs;
+
+import com.microsoft.teamfoundation.sourcecontrol.webapi.model.GitPullRequest;
+import hudson.model.Action;
+import org.kohsuke.stapler.export.Exported;
+import org.kohsuke.stapler.export.ExportedBean;
+
+import java.io.Serializable;
+
+/**
+ * Captures details of the TFS/Team Services pull request event which triggered us.
+ */
+@ExportedBean(defaultVisibility = 999)
+public class TeamPullRequestMergedDetailsAction implements Action, Serializable {
+    private static final long serialVersionUID = 1L;
+    private static final String URL_NAME = "team-pullRequestMergedDetails";
+
+    public GitPullRequest gitPullRequest;
+    public String message;
+    public String detailedMessage;
+
+    public TeamPullRequestMergedDetailsAction() {
+
+    }
+
+    public TeamPullRequestMergedDetailsAction(final GitPullRequest gitPullRequest, final String message, final String detailedMessage) {
+        this.gitPullRequest = gitPullRequest;
+    }
+
+    @Override
+    public String getIconFileName() {
+        // TODO: find an appropriate icon
+        return "clipboard.png";
+    }
+
+    @Override
+    public String getDisplayName() {
+        return "TFS/Team Services pull request";
+    }
+
+    @Override
+    public String getUrlName() {
+        return URL_NAME;
+    }
+
+    // the following methods are called from this/summary.jelly and/or this/index.jelly
+
+    @Exported
+    public String getMessage() {
+        return message;
+    }
+
+    @Exported
+    public String getDetailedMessage() {
+        return detailedMessage;
+    }
+}

--- a/src/main/java/hudson/plugins/tfs/TeamPullRequestMergedDetailsAction.java
+++ b/src/main/java/hudson/plugins/tfs/TeamPullRequestMergedDetailsAction.java
@@ -25,6 +25,8 @@ public class TeamPullRequestMergedDetailsAction implements Action, Serializable 
 
     public TeamPullRequestMergedDetailsAction(final GitPullRequest gitPullRequest, final String message, final String detailedMessage) {
         this.gitPullRequest = gitPullRequest;
+        this.message = message;
+        this.detailedMessage = detailedMessage;
     }
 
     @Override

--- a/src/main/java/hudson/plugins/tfs/model/AbstractHookEvent.java
+++ b/src/main/java/hudson/plugins/tfs/model/AbstractHookEvent.java
@@ -54,10 +54,12 @@ public abstract class AbstractHookEvent {
      * @param mapper an {@link ObjectMapper} instance to use to convert the {@link Event#resource}
      * @param serviceHookEvent an {@link Event} that represents the request payload
      *                         and from which the {@link Event#resource} can be obtained
+     * @param message a simple description of the event
+     * @param detailedMessage a longer description of the event, with some details
      *
      * @return a {@link JSONObject} representing the hook event's output
      */
-    public abstract JSONObject perform(final ObjectMapper mapper, final Event serviceHookEvent);
+    public abstract JSONObject perform(final ObjectMapper mapper, final Event serviceHookEvent, final String message, final String detailedMessage);
 
     static JSONObject fromResponseContributors(final List<GitStatus.ResponseContributor> contributors) {
         final JSONObject result = new JSONObject();

--- a/src/main/java/hudson/plugins/tfs/model/BuildCommand.java
+++ b/src/main/java/hudson/plugins/tfs/model/BuildCommand.java
@@ -21,6 +21,7 @@ import hudson.plugins.tfs.TeamBuildDetailsAction;
 import hudson.plugins.tfs.TeamBuildEndpoint;
 import hudson.plugins.tfs.model.servicehooks.Event;
 import hudson.plugins.tfs.UnsupportedIntegrationAction;
+import hudson.plugins.tfs.util.ActionHelper;
 import hudson.plugins.tfs.util.MediaType;
 import jenkins.model.Jenkins;
 import jenkins.util.TimeDuration;
@@ -41,7 +42,6 @@ public class BuildCommand extends AbstractCommand {
 
     private static final Logger LOGGER = Logger.getLogger(BuildCommand.class.getName());
 
-    private static final Action[] EMPTY_ACTION_ARRAY = new Action[0];
     private static final String BUILD_REPOSITORY_PROVIDER = "Build.Repository.Provider";
     private static final String BUILD_REPOSITORY_URI = "Build.Repository.Uri";
     private static final String BUILD_REPOSITORY_NAME = "Build.Repository.Name";
@@ -87,12 +87,7 @@ public class BuildCommand extends AbstractCommand {
         final Queue queue = jenkins.getQueue();
         final Cause cause = new Cause.UserIdCause();
         final CauseAction causeAction = new CauseAction(cause);
-        final List<Action> actions = new ArrayList<Action>();
-        actions.add(causeAction);
-
-        actions.addAll(extraActions);
-
-        final Action[] actionArray = actions.toArray(EMPTY_ACTION_ARRAY);
+        final Action[] actionArray = ActionHelper.create(extraActions, causeAction);
         final ScheduleResult scheduleResult = queue.schedule2(project, delay.getTime(), actionArray);
         final Queue.Item item = scheduleResult.getItem();
         if (item != null) {

--- a/src/main/java/hudson/plugins/tfs/model/GitPullRequestEx.java
+++ b/src/main/java/hudson/plugins/tfs/model/GitPullRequestEx.java
@@ -1,0 +1,20 @@
+package hudson.plugins.tfs.model;
+
+import com.microsoft.teamfoundation.sourcecontrol.webapi.model.GitPullRequest;
+import com.microsoft.visualstudio.services.webapi.model.ResourceRef;
+
+/**
+ * Work around some missing fields in the version of vso-httpclient-java
+ * by extending {@link GitPullRequest}.
+ */
+public class GitPullRequestEx extends GitPullRequest {
+    private ResourceRef[] workItemRefs;
+
+    public ResourceRef[] getWorkItemRefs() {
+        return workItemRefs;
+    }
+
+    public void setWorkItemRefs(final ResourceRef[] workItemRefs) {
+        this.workItemRefs = workItemRefs;
+    }
+}

--- a/src/main/java/hudson/plugins/tfs/model/GitPullRequestMergedEvent.java
+++ b/src/main/java/hudson/plugins/tfs/model/GitPullRequestMergedEvent.java
@@ -77,7 +77,7 @@ public class GitPullRequestMergedEvent extends GitPushEvent {
 
         final PullRequestMergeCommitCreatedEventArgs args = decodeGitPullRequest(gitPullRequest, serviceHookEvent);
         final PullRequestParameterAction parameterAction = new PullRequestParameterAction(args);
-        final Action teamPullRequestMergedDetailsAction = new TeamPullRequestMergedDetailsAction(gitPullRequest, message, detailedMessage);
+        final Action teamPullRequestMergedDetailsAction = new TeamPullRequestMergedDetailsAction(gitPullRequest, message, detailedMessage, args.collectionUri.toString());
         final ArrayList<Action> actions = new ArrayList<Action>();
         actions.add(parameterAction);
         actions.add(teamPullRequestMergedDetailsAction);

--- a/src/main/java/hudson/plugins/tfs/model/GitPullRequestMergedEvent.java
+++ b/src/main/java/hudson/plugins/tfs/model/GitPullRequestMergedEvent.java
@@ -73,7 +73,7 @@ public class GitPullRequestMergedEvent extends GitPushEvent {
     @Override
     public JSONObject perform(final ObjectMapper mapper, final Event serviceHookEvent, final String message, final String detailedMessage) {
         final Object resource = serviceHookEvent.getResource();
-        final GitPullRequest gitPullRequest = mapper.convertValue(resource, GitPullRequest.class);
+        final GitPullRequestEx gitPullRequest = mapper.convertValue(resource, GitPullRequestEx.class);
 
         final PullRequestMergeCommitCreatedEventArgs args = decodeGitPullRequest(gitPullRequest, serviceHookEvent);
         final PullRequestParameterAction parameterAction = new PullRequestParameterAction(args);

--- a/src/main/java/hudson/plugins/tfs/model/GitPullRequestMergedEvent.java
+++ b/src/main/java/hudson/plugins/tfs/model/GitPullRequestMergedEvent.java
@@ -5,6 +5,7 @@ import com.microsoft.teamfoundation.sourcecontrol.webapi.model.GitCommitRef;
 import com.microsoft.teamfoundation.sourcecontrol.webapi.model.GitPullRequest;
 import com.microsoft.teamfoundation.sourcecontrol.webapi.model.GitRepository;
 import com.microsoft.visualstudio.services.webapi.model.IdentityRef;
+import hudson.model.Action;
 import hudson.plugins.git.GitStatus;
 import hudson.plugins.tfs.PullRequestParameterAction;
 import hudson.plugins.tfs.model.servicehooks.Event;
@@ -12,6 +13,7 @@ import hudson.plugins.tfs.util.ResourceHelper;
 import net.sf.json.JSONObject;
 
 import java.net.URI;
+import java.util.ArrayList;
 import java.util.List;
 
 public class GitPullRequestMergedEvent extends GitPushEvent {
@@ -74,7 +76,9 @@ public class GitPullRequestMergedEvent extends GitPushEvent {
 
         final PullRequestMergeCommitCreatedEventArgs args = decodeGitPullRequest(gitPullRequest, serviceHookEvent);
         final PullRequestParameterAction parameterAction = new PullRequestParameterAction(args);
-        final List<GitStatus.ResponseContributor> contributors = pollOrQueueFromEvent(args, parameterAction, true);
+        final ArrayList<Action> actions = new ArrayList<Action>();
+        actions.add(parameterAction);
+        final List<GitStatus.ResponseContributor> contributors = pollOrQueueFromEvent(args, actions, true);
         final JSONObject response = fromResponseContributors(contributors);
         return response;
     }

--- a/src/main/java/hudson/plugins/tfs/model/GitPullRequestMergedEvent.java
+++ b/src/main/java/hudson/plugins/tfs/model/GitPullRequestMergedEvent.java
@@ -10,6 +10,7 @@ import hudson.plugins.git.GitStatus;
 import hudson.plugins.tfs.PullRequestParameterAction;
 import hudson.plugins.tfs.model.servicehooks.Event;
 import hudson.plugins.tfs.util.ResourceHelper;
+import hudson.plugins.tfs.TeamPullRequestMergedDetailsAction;
 import net.sf.json.JSONObject;
 
 import java.net.URI;
@@ -70,14 +71,16 @@ public class GitPullRequestMergedEvent extends GitPushEvent {
     }
 
     @Override
-    public JSONObject perform(final ObjectMapper mapper, final Event serviceHookEvent) {
+    public JSONObject perform(final ObjectMapper mapper, final Event serviceHookEvent, final String message, final String detailedMessage) {
         final Object resource = serviceHookEvent.getResource();
         final GitPullRequest gitPullRequest = mapper.convertValue(resource, GitPullRequest.class);
 
         final PullRequestMergeCommitCreatedEventArgs args = decodeGitPullRequest(gitPullRequest, serviceHookEvent);
         final PullRequestParameterAction parameterAction = new PullRequestParameterAction(args);
+        final Action teamPullRequestMergedDetailsAction = new TeamPullRequestMergedDetailsAction(gitPullRequest, message, detailedMessage);
         final ArrayList<Action> actions = new ArrayList<Action>();
         actions.add(parameterAction);
+        actions.add(teamPullRequestMergedDetailsAction);
         final List<GitStatus.ResponseContributor> contributors = pollOrQueueFromEvent(args, actions, true);
         final JSONObject response = fromResponseContributors(contributors);
         return response;

--- a/src/main/java/hudson/plugins/tfs/model/GitPushEvent.java
+++ b/src/main/java/hudson/plugins/tfs/model/GitPushEvent.java
@@ -6,6 +6,7 @@ import com.microsoft.teamfoundation.sourcecontrol.webapi.model.GitCommitRef;
 import com.microsoft.teamfoundation.sourcecontrol.webapi.model.GitPush;
 import com.microsoft.teamfoundation.sourcecontrol.webapi.model.GitRepository;
 import com.microsoft.visualstudio.services.webapi.model.IdentityRef;
+import hudson.model.Action;
 import hudson.plugins.git.GitStatus;
 import hudson.plugins.tfs.CommitParameterAction;
 import hudson.plugins.tfs.model.servicehooks.Event;
@@ -16,6 +17,7 @@ import org.apache.commons.lang.StringUtils;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -41,7 +43,9 @@ public class GitPushEvent extends AbstractHookEvent {
 
         final GitCodePushedEventArgs args = decodeGitPush(gitPush, serviceHookEvent);
         final CommitParameterAction parameterAction = new CommitParameterAction(args);
-        final List<GitStatus.ResponseContributor> contributors = pollOrQueueFromEvent(args, parameterAction, false);
+        final ArrayList<Action> actions = new ArrayList<Action>();
+        actions.add(parameterAction);
+        final List<GitStatus.ResponseContributor> contributors = pollOrQueueFromEvent(args, actions, false);
         final JSONObject response = fromResponseContributors(contributors);
         return response;
     }

--- a/src/main/java/hudson/plugins/tfs/model/GitPushEvent.java
+++ b/src/main/java/hudson/plugins/tfs/model/GitPushEvent.java
@@ -37,7 +37,7 @@ public class GitPushEvent extends AbstractHookEvent {
     }
 
     @Override
-    public JSONObject perform(final ObjectMapper mapper, final Event serviceHookEvent) {
+    public JSONObject perform(final ObjectMapper mapper, final Event serviceHookEvent, final String message, final String detailedMessage) {
         final Object resource = serviceHookEvent.getResource();
         final GitPush gitPush = mapper.convertValue(resource, GitPush.class);
 

--- a/src/main/java/hudson/plugins/tfs/model/PingHookEvent.java
+++ b/src/main/java/hudson/plugins/tfs/model/PingHookEvent.java
@@ -25,7 +25,7 @@ public class PingHookEvent extends AbstractHookEvent {
     }
 
     @Override
-    public JSONObject perform(final ObjectMapper mapper, final Event serviceHookEvent) {
+    public JSONObject perform(final ObjectMapper mapper, final Event serviceHookEvent, final String message, final String detailedMessage) {
         return JSONObject.fromObject(serviceHookEvent);
     }
 }

--- a/src/main/java/hudson/plugins/tfs/util/ActionHelper.java
+++ b/src/main/java/hudson/plugins/tfs/util/ActionHelper.java
@@ -1,0 +1,21 @@
+package hudson.plugins.tfs.util;
+
+import hudson.model.Action;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+public class ActionHelper {
+
+    public static Action[] create(final Collection<Action> actions, final Action... additionalActions) {
+        final int totalCount = actions.size() + additionalActions.length;
+        final List<Action> allActions = new ArrayList<Action>(totalCount);
+        allActions.addAll(actions);
+        Collections.addAll(allActions, additionalActions);
+        final Action[] result = allActions.toArray(new Action[totalCount]);
+        return result;
+    }
+
+}

--- a/src/main/resources/hudson/plugins/tfs/TeamPullRequestMergedDetailsAction/index.jelly
+++ b/src/main/resources/hudson/plugins/tfs/TeamPullRequestMergedDetailsAction/index.jelly
@@ -1,0 +1,33 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+    <l:layout>
+        <l:main-panel>
+        <h2>${it.displayName}</h2>
+
+        <dl>
+            <dt>Pull request</dt>
+            <dd><a href="${it.pullRequestUrl}">#${it.gitPullRequest.pullRequestId}</a>, created by ${it.gitPullRequest.createdBy.displayName}</dd>
+
+            <dt>Message</dt>
+            <dd><pre>${it.detailedMessage}</pre></dd>
+
+            <dt>Git repository</dt>
+            <dd><a href="${it.gitPullRequest.repository.remoteUrl}">${it.gitPullRequest.repository.name}</a></dd>
+
+            <dt>Project</dt>
+            <dd>${it.gitPullRequest.repository.project.name}</dd>
+
+            <j:if test="${it.hasWorkItems()}">
+                <dt>Associated work items</dt>
+                <dd>
+                    <ul>
+                    <j:forEach var="workItem" items="${it.workItems}">
+                        <li><a href="${workItem.url}">${workItem.id}</a></li>
+                    </j:forEach>
+                    </ul>
+                </dd>
+            </j:if>
+        </dl>
+        </l:main-panel>
+    </l:layout>
+</j:jelly>

--- a/src/main/resources/hudson/plugins/tfs/TeamPullRequestMergedDetailsAction/index.jelly
+++ b/src/main/resources/hudson/plugins/tfs/TeamPullRequestMergedDetailsAction/index.jelly
@@ -6,7 +6,10 @@
 
         <dl>
             <dt>Pull request</dt>
-            <dd><a href="${it.pullRequestUrl}">#${it.gitPullRequest.pullRequestId}</a>, created by ${it.gitPullRequest.createdBy.displayName}</dd>
+            <dd><a href="${it.pullRequestUrl}">#${it.gitPullRequest.pullRequestId}</a>: '${it.gitPullRequest.title}', created by ${it.gitPullRequest.createdBy.displayName}</dd>
+
+            <dt>Description</dt>
+            <dd><pre>${it.gitPullRequest.description}</pre></dd>
 
             <dt>Message</dt>
             <dd><pre>${it.detailedMessage}</pre></dd>

--- a/src/main/resources/hudson/plugins/tfs/TeamPullRequestMergedDetailsAction/summary.jelly
+++ b/src/main/resources/hudson/plugins/tfs/TeamPullRequestMergedDetailsAction/summary.jelly
@@ -4,7 +4,7 @@
     xmlns:f="/lib/form" xmlns:i="jelly:fmt">
     <t:summary icon="${it.iconFileName}">
 
-    ${it.message}
+    Triggered by TFS/Team Services pull request <a href="${it.pullRequestUrl}">#${it.gitPullRequest.pullRequestId}</a>: '${it.gitPullRequest.title}', created by ${it.gitPullRequest.createdBy.displayName}
     <j:if test="${it.hasWorkItems()}">
         <br />
         Associated work items:

--- a/src/main/resources/hudson/plugins/tfs/TeamPullRequestMergedDetailsAction/summary.jelly
+++ b/src/main/resources/hudson/plugins/tfs/TeamPullRequestMergedDetailsAction/summary.jelly
@@ -1,0 +1,18 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler"
+    xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson"
+    xmlns:f="/lib/form" xmlns:i="jelly:fmt">
+    <t:summary icon="${it.iconFileName}">
+
+    ${it.message}
+    <j:if test="${it.hasWorkItems()}">
+        <br />
+        Associated work items:
+        <ul>
+        <j:forEach var="workItem" items="${it.workItems}">
+            <li><a href="${workItem.url}">${workItem.id}</a></li>
+        </j:forEach>
+        </ul>
+    </j:if>
+    </t:summary>
+</j:jelly>

--- a/src/test/java/hudson/plugins/tfs/TeamEventsEndpointTest.java
+++ b/src/test/java/hudson/plugins/tfs/TeamEventsEndpointTest.java
@@ -56,7 +56,7 @@ public class TeamEventsEndpointTest {
         };
 
         @Override
-        public JSONObject perform(final ObjectMapper mapper, final Event serviceHookEvent) {
+        public JSONObject perform(final ObjectMapper mapper, final Event serviceHookEvent, final String message, final String detailedMessage) {
             final Object resource = serviceHookEvent.getResource();
             final GitPush actual = mapper.convertValue(resource, GitPush.class);
             Assert.assertEquals(ProjectState.WELL_FORMED, actual.getRepository().getProject().getState());


### PR DESCRIPTION
This pull request enhances both the `/team-events/` and `/team-build/` endpoints to contribute the new `TeamPullRequestMergedDetailsAction`, which manifests itself as:

1. A **TFS/Team Services pull request** link in the side-panel:
![image](https://cloud.githubusercontent.com/assets/297515/17671954/a7437234-62e7-11e6-84d9-1d2746c1332b.png)
2. A section in the build summary page that displays a link to the pull request, its title & author and, if any were provided, links to associated work items:
![image](https://cloud.githubusercontent.com/assets/297515/17673122/bd00cfbc-62ed-11e6-8e4e-cc59f9f1c05e.png)
3. A **TFS/Team Services pull request** page, linked from # 1 above, with a few more details and links:
![image](https://cloud.githubusercontent.com/assets/297515/17673088/95a6b3e6-62ed-11e6-9da3-b4e24095179a.png)
4. Some metadata in a build's `build.xml` file, from which # 2 and # 3 above are possible.

Manual testing
--------------

1. Using `curl`, crafted a payload for the `/team-events/pullRequestMerged` endpoint and posted it.  A build of the "Git" job was queued and the results are seen in screenshot # 2 above.
2. Using `curl`, crafted a similar payload for the `/team-build/build/` endpoint and posted it.  A build of the "param" job was queued and the results are seen in screenshot # 3 above.

Mission accomplished!