### PR TITLE
Add support for per-computer TFVC configuration folders

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ To make use of the Git integration with TFS/Team Services, it is necessary to fi
 
 ### Advanced
 
-In some environments, the "home" directory is mounted over a network and shared between many build nodes, which eventually leads to corruption of the configuration directory used for TFVC workspaces. If you have such an environment, check the box next to **Store TFVC configuration in node-specific folders** to use a sub-directory for each node. :warning: WARNING :warning: Turning this on is equivalent to setting the `TEE_PROFILE_DIRECTORY` environment variable and thus any manual operations performed on nodes using the Command-Line Client (CLC) will need to be performed with the `TEE_PROFILE_DIRECTORY` environment variable set accordingly.
+In some environments, the "home" directory is mounted over a network and shared between many computers, including Jenkins servers and their associated build nodes, which eventually leads to corruption of the configuration directory used for TFVC workspaces.  If you have such an environment, check the box next to **Store TFVC configuration in computer-specific folders** to use a sub-directory for each computer. :warning: WARNING :warning: Turning this on is equivalent to setting the `TEE_PROFILE_DIRECTORY` environment variable and thus any manual operations performed using the Command-Line Client (CLC) will need to be performed with the `TEE_PROFILE_DIRECTORY` environment variable set accordingly.
 
 ## Job configuration
 

--- a/README.md
+++ b/README.md
@@ -111,6 +111,10 @@ To make use of the Git integration with TFS/Team Services, it is necessary to fi
         3. Click **Test Connection**.
     3. Click **Save**
 
+### Advanced
+
+In some environments, the "home" directory is mounted over a network and shared between many build nodes, which eventually leads to corruption of the configuration directory used for TFVC workspaces. If you have such an environment, check the box next to **Store TFVC configuration in node-specific folders** to use a sub-directory for each node. :warning: WARNING :warning: Turning this on is equivalent to setting the `TEE_PROFILE_DIRECTORY` environment variable and thus any manual operations performed on nodes using the Command-Line Client (CLC) will need to be performed with the `TEE_PROFILE_DIRECTORY` environment variable set accordingly.
+
 ## Job configuration
 
 ### Team Foundation Version Control

--- a/src/main/java/hudson/plugins/tfs/TeamPluginGlobalConfig.java
+++ b/src/main/java/hudson/plugins/tfs/TeamPluginGlobalConfig.java
@@ -23,6 +23,7 @@ public class TeamPluginGlobalConfig extends GlobalConfiguration {
 
     private List<TeamCollectionConfiguration> collectionConfigurations = new ArrayList<TeamCollectionConfiguration>();
 
+    private boolean configFolderPerNode;
 
     public TeamPluginGlobalConfig() {
         load();
@@ -45,6 +46,14 @@ public class TeamPluginGlobalConfig extends GlobalConfiguration {
 
     public void setCollectionConfigurations(final List<TeamCollectionConfiguration> collectionConfigurations) {
         this.collectionConfigurations = collectionConfigurations;
+    }
+
+    public boolean isConfigFolderPerNode() {
+        return configFolderPerNode;
+    }
+
+    public void setConfigFolderPerNode(final boolean configFolderPerNode) {
+        this.configFolderPerNode = configFolderPerNode;
     }
 
     @Override

--- a/src/main/java/hudson/plugins/tfs/TeamPluginGlobalConfig.java
+++ b/src/main/java/hudson/plugins/tfs/TeamPluginGlobalConfig.java
@@ -3,6 +3,7 @@ package hudson.plugins.tfs;
 import hudson.Extension;
 import hudson.ExtensionList;
 import jenkins.model.GlobalConfiguration;
+import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
 import org.apache.commons.lang3.ObjectUtils;
 import org.kohsuke.stapler.StaplerRequest;
@@ -19,14 +20,20 @@ import java.util.logging.Logger;
 public class TeamPluginGlobalConfig extends GlobalConfiguration {
 
     private static final Logger LOGGER = Logger.getLogger(TeamPluginGlobalConfig.class.getName());
-    private static final TeamPluginGlobalConfig DEFAULT_CONFIG = new TeamPluginGlobalConfig();
+    private static final TeamPluginGlobalConfig DEFAULT_CONFIG = new TeamPluginGlobalConfig(false);
 
     private List<TeamCollectionConfiguration> collectionConfigurations = new ArrayList<TeamCollectionConfiguration>();
 
     private boolean configFolderPerNode;
 
     public TeamPluginGlobalConfig() {
-        load();
+        this(true);
+    }
+
+    TeamPluginGlobalConfig(final boolean shouldLoadConfig) {
+        if (shouldLoadConfig) {
+            load();
+        }
     }
 
     public TeamPluginGlobalConfig(final List<TeamCollectionConfiguration> collectionConfigurations) {
@@ -34,9 +41,12 @@ public class TeamPluginGlobalConfig extends GlobalConfiguration {
     }
 
     public static TeamPluginGlobalConfig get() {
-        final ExtensionList<GlobalConfiguration> configurationExtensions = all();
-        final TeamPluginGlobalConfig config = configurationExtensions.get(TeamPluginGlobalConfig.class);
-        final TeamPluginGlobalConfig result = ObjectUtils.defaultIfNull(config, DEFAULT_CONFIG);
+        TeamPluginGlobalConfig result = DEFAULT_CONFIG;
+        if (Jenkins.getInstance() != null) {
+            final ExtensionList<GlobalConfiguration> configurationExtensions = all();
+            final TeamPluginGlobalConfig config = configurationExtensions.get(TeamPluginGlobalConfig.class);
+            result = ObjectUtils.defaultIfNull(config, DEFAULT_CONFIG);
+        }
         return result;
     }
 

--- a/src/main/java/hudson/plugins/tfs/TeamPluginGlobalConfig.java
+++ b/src/main/java/hudson/plugins/tfs/TeamPluginGlobalConfig.java
@@ -20,7 +20,7 @@ import java.util.logging.Logger;
 public class TeamPluginGlobalConfig extends GlobalConfiguration {
 
     private static final Logger LOGGER = Logger.getLogger(TeamPluginGlobalConfig.class.getName());
-    private static final TeamPluginGlobalConfig DEFAULT_CONFIG = new TeamPluginGlobalConfig(false);
+    public static final TeamPluginGlobalConfig DEFAULT_CONFIG = new TeamPluginGlobalConfig(false);
 
     private List<TeamCollectionConfiguration> collectionConfigurations = new ArrayList<TeamCollectionConfiguration>();
 

--- a/src/main/java/hudson/plugins/tfs/commands/AbstractCallableCommand.java
+++ b/src/main/java/hudson/plugins/tfs/commands/AbstractCallableCommand.java
@@ -1,6 +1,7 @@
 package hudson.plugins.tfs.commands;
 
 import hudson.model.TaskListener;
+import hudson.plugins.tfs.model.ExtraSettings;
 import hudson.plugins.tfs.model.Server;
 import hudson.plugins.tfs.model.WebProxySettings;
 import hudson.remoting.Callable;
@@ -15,6 +16,7 @@ public abstract class AbstractCallableCommand implements Serializable {
     private final String userPassword;
     private final TaskListener listener;
     private final WebProxySettings webProxySettings;
+    private final ExtraSettings extraSettings;
 
     protected AbstractCallableCommand(final ServerConfigurationProvider serverConfig) {
         url = serverConfig.getUrl();
@@ -22,10 +24,11 @@ public abstract class AbstractCallableCommand implements Serializable {
         userPassword = serverConfig.getUserPassword();
         listener = serverConfig.getListener();
         webProxySettings = serverConfig.getWebProxySettings();
+        extraSettings = serverConfig.getExtraSettings();
     }
 
     public Server createServer() throws IOException {
-        final Server server = new Server(null, listener, url, userName, userPassword, webProxySettings);
+        final Server server = new Server(null, listener, url, userName, userPassword, webProxySettings, extraSettings);
         return server;
     }
 

--- a/src/main/java/hudson/plugins/tfs/commands/ServerConfigurationProvider.java
+++ b/src/main/java/hudson/plugins/tfs/commands/ServerConfigurationProvider.java
@@ -1,6 +1,7 @@
 package hudson.plugins.tfs.commands;
 
 import hudson.model.TaskListener;
+import hudson.plugins.tfs.model.ExtraSettings;
 import hudson.plugins.tfs.model.WebProxySettings;
 
 public interface ServerConfigurationProvider {
@@ -14,4 +15,6 @@ public interface ServerConfigurationProvider {
     public TaskListener getListener();
 
     public WebProxySettings getWebProxySettings();
+
+    public ExtraSettings getExtraSettings();
 }

--- a/src/main/java/hudson/plugins/tfs/model/ClonePersistenceStoreProvider.java
+++ b/src/main/java/hudson/plugins/tfs/model/ClonePersistenceStoreProvider.java
@@ -1,0 +1,64 @@
+package hudson.plugins.tfs.model;
+
+import com.microsoft.tfs.core.config.persistence.PersistenceStoreProvider;
+import com.microsoft.tfs.core.persistence.FilesystemPersistenceStore;
+import org.apache.commons.io.FileUtils;
+
+import java.io.File;
+import java.io.IOException;
+
+public class ClonePersistenceStoreProvider implements PersistenceStoreProvider {
+
+    private final FilesystemPersistenceStore cacheStore;
+    private final FilesystemPersistenceStore configurationStore;
+    private final FilesystemPersistenceStore logStore;
+    private final String nodeName;
+
+    public ClonePersistenceStoreProvider(final PersistenceStoreProvider sourcePersistenceStoreProvider, final String nodeName) {
+
+        this.nodeName = nodeName;
+        final FilesystemPersistenceStore sourceCache = sourcePersistenceStoreProvider.getCachePersistenceStore();
+        final File cacheFolder = createAndCopy(sourceCache, nodeName, "cache");
+        this.cacheStore = new FilesystemPersistenceStore(cacheFolder);
+
+        final FilesystemPersistenceStore sourceConfiguration = sourcePersistenceStoreProvider.getConfigurationPersistenceStore();
+        final File configurationFolder = createAndCopy(sourceConfiguration, nodeName, "configuration");
+        this.configurationStore = new FilesystemPersistenceStore(configurationFolder);
+
+        final FilesystemPersistenceStore sourceLog = sourcePersistenceStoreProvider.getLogPersistenceStore();
+        final File logFolder = createAndCopy(sourceLog, nodeName, "log");
+        this.logStore = new FilesystemPersistenceStore(logFolder);
+    }
+
+    static File createAndCopy(final FilesystemPersistenceStore sourceStore, final String nodeName, final String childName) {
+        final File sourceBase = sourceStore.getStoreFile();
+        final File sourceParent = sourceBase.getParentFile();
+        final File destinationBase = new File(sourceParent, nodeName);
+        final File destination = new File(destinationBase, childName);
+        if (!destination.isDirectory()) {
+            try {
+                FileUtils.copyDirectory(sourceBase, destination);
+            }
+            catch (final IOException e) {
+                throw new Error(e);
+            }
+        }
+        return destination;
+    }
+
+    public FilesystemPersistenceStore getCachePersistenceStore() {
+        return cacheStore;
+    }
+
+    public FilesystemPersistenceStore getConfigurationPersistenceStore() {
+        return configurationStore;
+    }
+
+    public FilesystemPersistenceStore getLogPersistenceStore() {
+        return logStore;
+    }
+
+    public String getNodeName() {
+        return nodeName;
+    }
+}

--- a/src/main/java/hudson/plugins/tfs/model/ClonePersistenceStoreProvider.java
+++ b/src/main/java/hudson/plugins/tfs/model/ClonePersistenceStoreProvider.java
@@ -36,7 +36,7 @@ public class ClonePersistenceStoreProvider implements PersistenceStoreProvider {
         final File sourceParent = sourceBase.getParentFile();
         final File destinationBase = new File(sourceParent, nodeName);
         final File destination = new File(destinationBase, childName);
-        if (!destination.isDirectory()) {
+        if (!destination.isDirectory() && sourceBase.isDirectory()) {
             try {
                 FileUtils.copyDirectory(sourceBase, destination);
             }

--- a/src/main/java/hudson/plugins/tfs/model/ClonePersistenceStoreProvider.java
+++ b/src/main/java/hudson/plugins/tfs/model/ClonePersistenceStoreProvider.java
@@ -12,21 +12,21 @@ public class ClonePersistenceStoreProvider implements PersistenceStoreProvider {
     private final FilesystemPersistenceStore cacheStore;
     private final FilesystemPersistenceStore configurationStore;
     private final FilesystemPersistenceStore logStore;
-    private final String nodeName;
+    private final String hostName;
 
-    public ClonePersistenceStoreProvider(final PersistenceStoreProvider sourcePersistenceStoreProvider, final String nodeName) {
+    public ClonePersistenceStoreProvider(final PersistenceStoreProvider sourcePersistenceStoreProvider, final String hostName) {
 
-        this.nodeName = nodeName;
+        this.hostName = hostName;
         final FilesystemPersistenceStore sourceCache = sourcePersistenceStoreProvider.getCachePersistenceStore();
-        final File cacheFolder = createAndCopy(sourceCache, nodeName);
+        final File cacheFolder = createAndCopy(sourceCache, hostName);
         this.cacheStore = new FilesystemPersistenceStore(cacheFolder);
 
         final FilesystemPersistenceStore sourceConfiguration = sourcePersistenceStoreProvider.getConfigurationPersistenceStore();
-        final File configurationFolder = createAndCopy(sourceConfiguration, nodeName);
+        final File configurationFolder = createAndCopy(sourceConfiguration, hostName);
         this.configurationStore = new FilesystemPersistenceStore(configurationFolder);
 
         final FilesystemPersistenceStore sourceLog = sourcePersistenceStoreProvider.getLogPersistenceStore();
-        final File logFolder = createAndCopy(sourceLog, nodeName);
+        final File logFolder = createAndCopy(sourceLog, hostName);
         this.logStore = new FilesystemPersistenceStore(logFolder);
     }
 
@@ -59,7 +59,7 @@ public class ClonePersistenceStoreProvider implements PersistenceStoreProvider {
         return logStore;
     }
 
-    public String getNodeName() {
-        return nodeName;
+    public String getHostName() {
+        return hostName;
     }
 }

--- a/src/main/java/hudson/plugins/tfs/model/ClonePersistenceStoreProvider.java
+++ b/src/main/java/hudson/plugins/tfs/model/ClonePersistenceStoreProvider.java
@@ -18,20 +18,21 @@ public class ClonePersistenceStoreProvider implements PersistenceStoreProvider {
 
         this.nodeName = nodeName;
         final FilesystemPersistenceStore sourceCache = sourcePersistenceStoreProvider.getCachePersistenceStore();
-        final File cacheFolder = createAndCopy(sourceCache, nodeName, "cache");
+        final File cacheFolder = createAndCopy(sourceCache, nodeName);
         this.cacheStore = new FilesystemPersistenceStore(cacheFolder);
 
         final FilesystemPersistenceStore sourceConfiguration = sourcePersistenceStoreProvider.getConfigurationPersistenceStore();
-        final File configurationFolder = createAndCopy(sourceConfiguration, nodeName, "configuration");
+        final File configurationFolder = createAndCopy(sourceConfiguration, nodeName);
         this.configurationStore = new FilesystemPersistenceStore(configurationFolder);
 
         final FilesystemPersistenceStore sourceLog = sourcePersistenceStoreProvider.getLogPersistenceStore();
-        final File logFolder = createAndCopy(sourceLog, nodeName, "log");
+        final File logFolder = createAndCopy(sourceLog, nodeName);
         this.logStore = new FilesystemPersistenceStore(logFolder);
     }
 
-    static File createAndCopy(final FilesystemPersistenceStore sourceStore, final String nodeName, final String childName) {
+    static File createAndCopy(final FilesystemPersistenceStore sourceStore, final String nodeName) {
         final File sourceBase = sourceStore.getStoreFile();
+        final String childName = sourceBase.getName();
         final File sourceParent = sourceBase.getParentFile();
         final File destinationBase = new File(sourceParent, nodeName);
         final File destination = new File(destinationBase, childName);

--- a/src/main/java/hudson/plugins/tfs/model/ExtraSettings.java
+++ b/src/main/java/hudson/plugins/tfs/model/ExtraSettings.java
@@ -14,19 +14,13 @@ import java.io.Serializable;
 public class ExtraSettings implements Serializable {
     private static final long serialVersionUID = 1L;
 
-    private final boolean configFolderPerNode;
-    private final String computerName;
+    private boolean configFolderPerNode;
+    private String computerName;
 
-    public static final ExtraSettings DEFAULT = new ExtraSettings(false, null);
+    public static final ExtraSettings DEFAULT = new ExtraSettings();
 
     @SuppressWarnings("unused" /* Needed by Serializable interface */)
     private ExtraSettings() {
-        this(false, null);
-    }
-
-    public ExtraSettings(final boolean configFolderPerNode, final String computerName) {
-        this.configFolderPerNode = configFolderPerNode;
-        this.computerName = computerName;
     }
 
     public ExtraSettings(final TeamPluginGlobalConfig teamPluginGlobalConfig) {
@@ -44,7 +38,15 @@ public class ExtraSettings implements Serializable {
         return configFolderPerNode;
     }
 
+    public void setConfigFolderPerNode(final boolean configFolderPerNode) {
+        this.configFolderPerNode = configFolderPerNode;
+    }
+
     public String getComputerName() {
         return computerName;
+    }
+
+    public void setComputerName(final String computerName) {
+        this.computerName = computerName;
     }
 }

--- a/src/main/java/hudson/plugins/tfs/model/ExtraSettings.java
+++ b/src/main/java/hudson/plugins/tfs/model/ExtraSettings.java
@@ -26,7 +26,13 @@ public class ExtraSettings implements Serializable {
     public ExtraSettings(final TeamPluginGlobalConfig teamPluginGlobalConfig) {
         if (teamPluginGlobalConfig != null) {
             this.configFolderPerNode = teamPluginGlobalConfig.isConfigFolderPerNode();
-            this.nodeComputerName = Computer.currentComputer().getName();
+            final Computer currentComputer = Computer.currentComputer();
+            if (currentComputer != null) {
+                this.nodeComputerName = currentComputer.getName();
+            }
+            else {
+                this.nodeComputerName = "";
+            }
         }
         else {
             this.configFolderPerNode = false;

--- a/src/main/java/hudson/plugins/tfs/model/ExtraSettings.java
+++ b/src/main/java/hudson/plugins/tfs/model/ExtraSettings.java
@@ -17,6 +17,8 @@ public class ExtraSettings implements Serializable {
     private final boolean configFolderPerNode;
     private final String computerName;
 
+    public static final ExtraSettings DEFAULT = new ExtraSettings(false, null);
+
     @SuppressWarnings("unused" /* Needed by Serializable interface */)
     private ExtraSettings() {
         this(false, null);

--- a/src/main/java/hudson/plugins/tfs/model/ExtraSettings.java
+++ b/src/main/java/hudson/plugins/tfs/model/ExtraSettings.java
@@ -15,7 +15,7 @@ public class ExtraSettings implements Serializable {
     private static final long serialVersionUID = 1L;
 
     private boolean configFolderPerNode;
-    private String computerName;
+    private String nodeComputerName;
 
     public static final ExtraSettings DEFAULT = new ExtraSettings();
 
@@ -26,11 +26,11 @@ public class ExtraSettings implements Serializable {
     public ExtraSettings(final TeamPluginGlobalConfig teamPluginGlobalConfig) {
         if (teamPluginGlobalConfig != null) {
             this.configFolderPerNode = teamPluginGlobalConfig.isConfigFolderPerNode();
-            this.computerName = Computer.currentComputer().getName();
+            this.nodeComputerName = Computer.currentComputer().getName();
         }
         else {
             this.configFolderPerNode = false;
-            this.computerName = null;
+            this.nodeComputerName = null;
         }
     }
 
@@ -42,11 +42,11 @@ public class ExtraSettings implements Serializable {
         this.configFolderPerNode = configFolderPerNode;
     }
 
-    public String getComputerName() {
-        return computerName;
+    public String getNodeComputerName() {
+        return nodeComputerName;
     }
 
-    public void setComputerName(final String computerName) {
-        this.computerName = computerName;
+    public void setNodeComputerName(final String nodeComputerName) {
+        this.nodeComputerName = nodeComputerName;
     }
 }

--- a/src/main/java/hudson/plugins/tfs/model/ExtraSettings.java
+++ b/src/main/java/hudson/plugins/tfs/model/ExtraSettings.java
@@ -1,0 +1,48 @@
+package hudson.plugins.tfs.model;
+
+import hudson.model.Computer;
+import hudson.plugins.tfs.TeamPluginGlobalConfig;
+
+import java.io.Serializable;
+
+/**
+ * This class exists to shuttle settings between MASTER to remote nodes,
+ * who would otherwise be unable to determine said settings because they
+ * don't have access to the {@link jenkins.model.Jenkins} instance or
+ * anything that could be obtained from it.
+ */
+public class ExtraSettings implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private final boolean configFolderPerNode;
+    private final String computerName;
+
+    @SuppressWarnings("unused" /* Needed by Serializable interface */)
+    private ExtraSettings() {
+        this(false, null);
+    }
+
+    public ExtraSettings(final boolean configFolderPerNode, final String computerName) {
+        this.configFolderPerNode = configFolderPerNode;
+        this.computerName = computerName;
+    }
+
+    public ExtraSettings(final TeamPluginGlobalConfig teamPluginGlobalConfig) {
+        if (teamPluginGlobalConfig != null) {
+            this.configFolderPerNode = teamPluginGlobalConfig.isConfigFolderPerNode();
+            this.computerName = Computer.currentComputer().getName();
+        }
+        else {
+            this.configFolderPerNode = false;
+            this.computerName = null;
+        }
+    }
+
+    public boolean isConfigFolderPerNode() {
+        return configFolderPerNode;
+    }
+
+    public String getComputerName() {
+        return computerName;
+    }
+}

--- a/src/main/java/hudson/plugins/tfs/model/ModernConnectionAdvisor.java
+++ b/src/main/java/hudson/plugins/tfs/model/ModernConnectionAdvisor.java
@@ -6,15 +6,30 @@ import java.util.TimeZone;
 import com.microsoft.tfs.core.config.ConnectionInstanceData;
 import com.microsoft.tfs.core.config.DefaultConnectionAdvisor;
 import com.microsoft.tfs.core.config.httpclient.HTTPClientFactory;
+import com.microsoft.tfs.core.config.persistence.DefaultPersistenceStoreProvider;
+import com.microsoft.tfs.core.config.persistence.PersistenceStoreProvider;
 import com.microsoft.tfs.core.httpclient.ProxyHost;
 
 public class ModernConnectionAdvisor extends DefaultConnectionAdvisor {
 
     private final ProxyHost proxyHost;
+    private final PersistenceStoreProvider persistenceStoreProvider;
 
     public ModernConnectionAdvisor(final ProxyHost proxyHost) {
+        this(proxyHost, null);
+    }
+
+    public ModernConnectionAdvisor(final ProxyHost proxyHost, final PersistenceStoreProvider persistenceStoreProvider) {
         super(Locale.getDefault(), TimeZone.getDefault());
         this.proxyHost = proxyHost;
+        this.persistenceStoreProvider = persistenceStoreProvider;
+    }
+
+    @Override
+    public PersistenceStoreProvider getPersistenceStoreProvider(final ConnectionInstanceData instanceData) {
+        return persistenceStoreProvider != null
+                ? persistenceStoreProvider
+                : DefaultPersistenceStoreProvider.INSTANCE;
     }
 
     @Override

--- a/src/main/java/hudson/plugins/tfs/model/Server.java
+++ b/src/main/java/hudson/plugins/tfs/model/Server.java
@@ -14,6 +14,7 @@ import com.microsoft.tfs.core.httpclient.ProxyHost;
 import com.microsoft.tfs.core.httpclient.UsernamePasswordCredentials;
 import com.microsoft.tfs.core.util.CredentialsUtils;
 import com.microsoft.tfs.core.util.URIUtils;
+import com.microsoft.tfs.jni.helpers.LocalHost;
 import com.microsoft.tfs.util.Closable;
 import hudson.Launcher;
 import hudson.ProxyConfiguration;
@@ -97,9 +98,8 @@ public class Server implements ServerConfigurationProvider, Closable {
             final PersistenceStoreProvider defaultProvider = DefaultPersistenceStoreProvider.INSTANCE;
             final PersistenceStoreProvider provider;
             if (this.extraSettings.isConfigFolderPerNode()) {
-                final String nodeComputerName = this.extraSettings.getNodeComputerName();
-                final String nodeName = Util.fixEmpty(nodeComputerName) == null ? "MASTER" : nodeComputerName;
-                provider = new ClonePersistenceStoreProvider(defaultProvider, nodeName);
+                final String hostName = LocalHost.getShortName();
+                provider = new ClonePersistenceStoreProvider(defaultProvider, hostName);
             }
             else {
                 provider = defaultProvider;

--- a/src/main/java/hudson/plugins/tfs/model/Server.java
+++ b/src/main/java/hudson/plugins/tfs/model/Server.java
@@ -18,7 +18,6 @@ import com.microsoft.tfs.util.Closable;
 import hudson.Launcher;
 import hudson.ProxyConfiguration;
 import hudson.Util;
-import hudson.model.Computer;
 import hudson.model.TaskListener;
 import hudson.plugins.tfs.TeamPluginGlobalConfig;
 import hudson.plugins.tfs.commands.ServerConfigurationProvider;
@@ -31,9 +30,11 @@ import java.lang.reflect.Field;
 import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.logging.Logger;
 
 public class Server implements ServerConfigurationProvider, Closable {
-    
+
+    private static final Logger LOGGER = Logger.getLogger(Server.class.getName());
     private static final String nativeFolderPropertyName = "com.microsoft.tfs.jni.native.base-directory";
     private final String url;
     private final String userName;
@@ -44,13 +45,17 @@ public class Server implements ServerConfigurationProvider, Closable {
     private final TaskListener taskListener;
     private final TFSTeamProjectCollection tpc;
     private final WebProxySettings webProxySettings;
+    private final ExtraSettings extraSettings;
     private MockableVersionControlClient mockableVcc;
 
+    /**
+     * This constructor overload assumes a Jenkins instance is present.
+     */
     public Server(final Launcher launcher, final TaskListener taskListener, final String url, final String username, final String password) throws IOException {
-        this(launcher, taskListener, url, username, password, null);
+        this(launcher, taskListener, url, username, password, null, null);
     }
 
-    public Server(final Launcher launcher, final TaskListener taskListener, final String url, final String username, final String password, final WebProxySettings webProxySettings) throws IOException {
+    public Server(final Launcher launcher, final TaskListener taskListener, final String url, final String username, final String password, final WebProxySettings webProxySettings, final ExtraSettings extraSettings) throws IOException {
         this.launcher = launcher;
         this.taskListener = taskListener;
         this.url = url;
@@ -71,22 +76,28 @@ public class Server implements ServerConfigurationProvider, Closable {
         }
 
         if (credentials != null) {
+            final VirtualChannel channel = launcher != null ? launcher.getChannel() : null;
             if (webProxySettings != null) {
                 this.webProxySettings = webProxySettings;
             }
             else {
-                final VirtualChannel channel = launcher != null ? launcher.getChannel() : null;
                 final ProxyConfiguration proxyConfiguration = determineProxyConfiguration(channel);
                 this.webProxySettings = new WebProxySettings(proxyConfiguration);
             }
             final String host = uri.getHost();
             final ProxyHost proxyHost = this.webProxySettings.toProxyHost(host);
+
+            if (extraSettings != null) {
+                this.extraSettings = extraSettings;
+            }
+            else {
+                final TeamPluginGlobalConfig globalConfig = determineGlobalConfig(channel);
+                this.extraSettings = new ExtraSettings(globalConfig);
+            }
             final PersistenceStoreProvider defaultProvider = DefaultPersistenceStoreProvider.INSTANCE;
-            final TeamPluginGlobalConfig globalConfig = TeamPluginGlobalConfig.get();
             final PersistenceStoreProvider provider;
-            if (globalConfig.isConfigFolderPerNode()) {
-                final Computer computer = Computer.currentComputer();
-                final String computerName = computer.getName();
+            if (this.extraSettings.isConfigFolderPerNode()) {
+                final String computerName = this.extraSettings.getComputerName();
                 final String nodeName = Util.fixEmpty(computerName) == null ? "MASTER" : computerName;
                 provider = new ClonePersistenceStoreProvider(defaultProvider, nodeName);
             }
@@ -98,12 +109,38 @@ public class Server implements ServerConfigurationProvider, Closable {
         }
         else {
             this.webProxySettings = null;
+            this.extraSettings = null;
             this.tpc = null;
         }
     }
 
-    Server(String url) throws IOException {
-        this(null, null, url, null, null);
+    static TeamPluginGlobalConfig determineGlobalConfig(final VirtualChannel channel) {
+        final Jenkins jenkins = Jenkins.getInstance();
+        final TeamPluginGlobalConfig result;
+        if (jenkins == null) {
+            if (channel != null) {
+                try {
+                    result = channel.call(new Callable<TeamPluginGlobalConfig, Throwable>() {
+                        @Override
+                        public TeamPluginGlobalConfig call() throws Throwable {
+                            final Jenkins jenkins = Jenkins.getInstance();
+                            final TeamPluginGlobalConfig result = jenkins != null ? TeamPluginGlobalConfig.get() : null;
+                            return result;
+                        }
+                    });
+                }
+                catch (final Throwable throwable) {
+                    throw new Error(throwable);
+                }
+            }
+            else {
+                result = TeamPluginGlobalConfig.DEFAULT_CONFIG;
+            }
+        }
+        else {
+            result = TeamPluginGlobalConfig.get();
+        }
+        return result;
     }
 
     static ProxyConfiguration determineProxyConfiguration(final VirtualChannel channel) {
@@ -188,6 +225,10 @@ public class Server implements ServerConfigurationProvider, Closable {
 
     public WebProxySettings getWebProxySettings() {
         return webProxySettings;
+    }
+
+    public ExtraSettings getExtraSettings() {
+        return extraSettings;
     }
 
     public TaskListener getListener() {

--- a/src/main/java/hudson/plugins/tfs/model/Server.java
+++ b/src/main/java/hudson/plugins/tfs/model/Server.java
@@ -97,8 +97,8 @@ public class Server implements ServerConfigurationProvider, Closable {
             final PersistenceStoreProvider defaultProvider = DefaultPersistenceStoreProvider.INSTANCE;
             final PersistenceStoreProvider provider;
             if (this.extraSettings.isConfigFolderPerNode()) {
-                final String computerName = this.extraSettings.getComputerName();
-                final String nodeName = Util.fixEmpty(computerName) == null ? "MASTER" : computerName;
+                final String nodeComputerName = this.extraSettings.getNodeComputerName();
+                final String nodeName = Util.fixEmpty(nodeComputerName) == null ? "MASTER" : nodeComputerName;
                 provider = new ClonePersistenceStoreProvider(defaultProvider, nodeName);
             }
             else {

--- a/src/main/resources/hudson/plugins/tfs/TeamPluginGlobalConfig/config.groovy
+++ b/src/main/resources/hudson/plugins/tfs/TeamPluginGlobalConfig/config.groovy
@@ -9,4 +9,11 @@ f.section(title: descriptor.displayName) {
 
         f.repeatableProperty(field: "collectionConfigurations")
     }
+    f.advanced() {
+        f.entry(title: _("Store configuration in node-specific folders"),
+                field: "configFolderPerNode",
+                description: "Warning: don't turn this on unless you know what you are doing!") {
+            f.checkbox (default: false)
+        }
+    }
 }

--- a/src/main/resources/hudson/plugins/tfs/TeamPluginGlobalConfig/config.groovy
+++ b/src/main/resources/hudson/plugins/tfs/TeamPluginGlobalConfig/config.groovy
@@ -10,7 +10,7 @@ f.section(title: descriptor.displayName) {
         f.repeatableProperty(field: "collectionConfigurations")
     }
     f.advanced() {
-        f.entry(title: _("Store configuration in node-specific folders"),
+        f.entry(title: _("Store TFVC configuration in node-specific folders"),
                 field: "configFolderPerNode",
                 description: "Warning: don't turn this on unless you know what you are doing!") {
             f.checkbox (default: false)

--- a/src/main/resources/hudson/plugins/tfs/TeamPluginGlobalConfig/config.groovy
+++ b/src/main/resources/hudson/plugins/tfs/TeamPluginGlobalConfig/config.groovy
@@ -10,7 +10,7 @@ f.section(title: descriptor.displayName) {
         f.repeatableProperty(field: "collectionConfigurations")
     }
     f.advanced() {
-        f.entry(title: _("Store TFVC configuration in node-specific folders"),
+        f.entry(title: _("Store TFVC configuration in computer-specific folders"),
                 field: "configFolderPerNode",
                 description: "Warning: don't turn this on unless you know what you are doing!") {
             f.checkbox (default: false)

--- a/src/main/resources/hudson/plugins/tfs/TeamPluginGlobalConfig/help-configFolderPerNode.html
+++ b/src/main/resources/hudson/plugins/tfs/TeamPluginGlobalConfig/help-configFolderPerNode.html
@@ -1,8 +1,8 @@
 <div>
-    In some environments, the "home" directory is mounted over a network and shared between many build nodes, which eventually leads to corruption of the configuration directory used for TFVC workspaces.  If you have such an environment, check the box to use a sub-directory for each node.<br />
+    In some environments, the "home" directory is mounted over a network and shared between many computers, including Jenkins servers and their associated build nodes, which eventually leads to corruption of the configuration directory used for TFVC workspaces.  If you have such an environment, check the box to use a sub-directory for each computer (using the computers's host name).<br />
     <br />
     In other words, turning on this option means the TFS SDK will use the following base path for its <code>Cache</code>, <code>Configuration</code> and <code>Logs</code> directories:<br />
-    <code>~/.microsoft/Team Foundation/4.0/${NODE_NAME}/</code><br />
+    <code>~/.microsoft/Team Foundation/4.0/${HOSTNAME}/</code><br />
     <br />
     <h3>WARNING:</h3>
     Turning this on is equivalent to setting the <code>TEE_PROFILE_DIRECTORY</code> environment variable and thus any manual operations performed on nodes using the Command-Line Client (CLC) will need to be performed with the <code>TEE_PROFILE_DIRECTORY</code> environment variable set accordingly.

--- a/src/main/resources/hudson/plugins/tfs/TeamPluginGlobalConfig/help-configFolderPerNode.html
+++ b/src/main/resources/hudson/plugins/tfs/TeamPluginGlobalConfig/help-configFolderPerNode.html
@@ -1,0 +1,9 @@
+<div>
+    In some environments, the "home" directory is mounted over a network and shared between many build nodes, which eventually leads to corruption of the configuration directory used for TFVC workspaces.  If you have such an environment, check the box to use a sub-directory for each node.<br />
+    <br />
+    In other words, turning on this option means the TFS SDK will use the following base path for its <code>Cache</code>, <code>Configuration</code> and <code>Logs</code> directories:<br />
+    <code>~/.microsoft/Team Foundation/4.0/${NODE_NAME}/</code><br />
+    <br />
+    <h3>WARNING:</h3>
+    Turning this on is equivalent to setting the <code>TEE_PROFILE_DIRECTORY</code> environment variable and thus any manual operations performed on nodes using the Command-Line Client (CLC) will need to be performed with the <code>TEE_PROFILE_DIRECTORY</code> environment variable set accordingly.
+</div>

--- a/src/test/java/hudson/plugins/tfs/EndToEndTfs.java
+++ b/src/test/java/hudson/plugins/tfs/EndToEndTfs.java
@@ -12,6 +12,7 @@ import com.microsoft.tfs.core.clients.versioncontrol.soapextensions.PendingSet;
 import com.microsoft.tfs.core.clients.versioncontrol.soapextensions.RecursionType;
 import com.microsoft.tfs.core.clients.versioncontrol.soapextensions.WorkingFolder;
 import com.microsoft.tfs.core.clients.versioncontrol.soapextensions.Workspace;
+import hudson.plugins.tfs.model.ExtraSettings;
 import hudson.plugins.tfs.model.MockableVersionControlClient;
 import hudson.plugins.tfs.model.Server;
 import hudson.plugins.tfs.util.XmlHelper;
@@ -147,7 +148,7 @@ public @interface EndToEndTfs {
             final File currentFolder = new File("").getAbsoluteFile();
             final File workspaces = new File(currentFolder, "workspaces");
             // TODO: Consider NOT using the Server class
-            server = new Server(null, null, serverUrl, helper.getUserName(), helper.getUserPassword());
+            server = new Server(null, null, serverUrl, helper.getUserName(), helper.getUserPassword(), null, ExtraSettings.DEFAULT);
 
             final MockableVersionControlClient vcc = server.getVersionControlClient();
 

--- a/src/test/java/hudson/plugins/tfs/commands/AbstractCallableCommandTest.java
+++ b/src/test/java/hudson/plugins/tfs/commands/AbstractCallableCommandTest.java
@@ -2,6 +2,7 @@ package hudson.plugins.tfs.commands;
 
 import com.microsoft.tfs.core.clients.versioncontrol.specs.version.ChangesetVersionSpec;
 import hudson.model.TaskListener;
+import hudson.plugins.tfs.model.ExtraSettings;
 import hudson.plugins.tfs.model.MockableVersionControlClient;
 import hudson.plugins.tfs.model.Server;
 import hudson.plugins.tfs.model.WebProxySettings;
@@ -105,6 +106,11 @@ public abstract class AbstractCallableCommandTest {
                     }
                 }
                 return new WebProxySettings("localhost", 8080, patterns, "user", secret);
+            }
+
+            @Override
+            public ExtraSettings getExtraSettings() {
+                return ExtraSettings.DEFAULT;
             }
         };
         final AbstractCallableCommand command = createCommand(server);

--- a/src/test/java/hudson/plugins/tfs/model/ProjectTest.java
+++ b/src/test/java/hudson/plugins/tfs/model/ProjectTest.java
@@ -243,7 +243,7 @@ public class ProjectTest extends SwedishLocaleTestCase {
         final String serverUrl = helper.getServerUrl();
         final String userName = helper.getUserName();
         final String userPassword = helper.getUserPassword();
-        final Server server = new Server(null, null, serverUrl, userName, userPassword);
+        final Server server = new Server(null, null, serverUrl, userName, userPassword, null, ExtraSettings.DEFAULT);
         try {
             final Project project = new Project(server, "$/FunctionalTests");
             final UserLookup userLookup = mock(UserLookup.class);

--- a/src/test/java/hudson/plugins/tfs/model/ServerTest.java
+++ b/src/test/java/hudson/plugins/tfs/model/ServerTest.java
@@ -14,17 +14,21 @@ public class ServerTest {
     public void setup() {
         MockitoAnnotations.initMocks(this);
     }
-    
+
+    static Server createServer() throws IOException {
+        return new Server(null, null, "url", null, null, null, ExtraSettings.DEFAULT);
+    }
+
     @Test
     public void assertGetWorkspacesReturnSameObject() throws IOException {
-        Server server = new Server("url");
+        Server server = createServer();
         assertNotNull("Workspaces object can not be null", server.getWorkspaces());
         assertSame("getWorkspaces() returned different objects", server.getWorkspaces(), server.getWorkspaces());
     }
-    
+
     @Test
     public void assertGetProjectWithSameProjectPathReturnsSameInstance() throws IOException {
-        Server server = new Server("url");
+        Server server = createServer();
         assertNotNull("Project object can not be null", server.getProject("$/projectPath"));
         assertSame("getProject() returned different objects", 
                 server.getProject("$/projectPath"), server.getProject("$/projectPath"));
@@ -32,7 +36,7 @@ public class ServerTest {
     
     @Test
     public void assertGetProjectWithDifferentProjectPathReturnsNotSameInstance() throws IOException {
-        Server server = new Server("url");
+        Server server = createServer();
         assertNotSame("getProject() did not return different objects", 
                 server.getProject("$/projectPath"), server.getProject("$/otherPath"));
     }


### PR DESCRIPTION
In some environments, the "home" directory is mounted over a network and shared between many computers, including Jenkins servers and their associated build nodes, which eventually leads to corruption of the configuration directory used for TFVC workspaces.  This branch introduces a new, advanced setting that uses a sub-directory for each computer, copying the current configuration directory (if one is found) on the next run.

In other words, turning on the new **Store TFVC configuration in computer-specific folders** option means the TFS SDK will use the following base path for its <code>Cache</code>, <code>Configuration</code> and <code>Logs</code> directories:
`~/.microsoft/Team Foundation/4.0/${HOSTNAME}/`

Manual testing
--------------

1. **Jenkins** > **Manage Jenkins** > **Configure System** and scroll to **TFS/Team Services**
2. Check the new **Store TFVC configuration in computer-specific folders** checkbox and click **Save**:
![image](https://cloud.githubusercontent.com/assets/297515/17760020/5a904806-64ca-11e6-9bcf-829feff881ca.png)
3. Queue a job on MASTER that uses TFVC for its SCM.
    1. Notice that the `4.0` folder now contains a sub-folder named after the server's host name, with copies of the existing folders.
4. Modify the job to execute on a remote node and queue it again.
    1. Notice that the `4.0` folder on the _node_ now contains a sub-folder named after the node's host name.

Mission accomplished!