### PR TITLE
Improve construction of TeamFoundationServerScm

### DIFF
--- a/src/main/java/hudson/plugins/tfs/TeamFoundationServerScm.java
+++ b/src/main/java/hudson/plugins/tfs/TeamFoundationServerScm.java
@@ -88,7 +88,7 @@ public class TeamFoundationServerScm extends SCM {
     private @Deprecated String userPassword;
     private /* almost final */ Secret password;
     private final String userName;
-    private final boolean useUpdate;
+    private boolean useUpdate;
     
     private TeamFoundationServerRepositoryBrowser repositoryBrowser;
 
@@ -97,15 +97,14 @@ public class TeamFoundationServerScm extends SCM {
     
     private static final Logger logger = Logger.getLogger(TeamFoundationServerScm.class.getName());
 
-    TeamFoundationServerScm(String serverUrl, String projectPath, String localPath, boolean useUpdate, String workspaceName) {
-        this(serverUrl, projectPath, localPath, useUpdate, workspaceName, null, (Secret)null);
+    TeamFoundationServerScm(String serverUrl, String projectPath, String localPath, String workspaceName) {
+        this(serverUrl, projectPath, localPath, workspaceName, null, (Secret)null);
     }
 
     @DataBoundConstructor
-    public TeamFoundationServerScm(String serverUrl, String projectPath, String localPath, boolean useUpdate, String workspaceName, String userName, Secret password) {
+    public TeamFoundationServerScm(String serverUrl, String projectPath, String localPath, String workspaceName, String userName, Secret password) {
         this.serverUrl = serverUrl;
         this.projectPath = projectPath;
-        this.useUpdate = useUpdate;
         this.localPath = (Util.fixEmptyAndTrim(localPath) == null ? "." : localPath);
         this.workspaceName = (Util.fixEmptyAndTrim(workspaceName) == null ? "Hudson-${JOB_NAME}-${NODE_NAME}" : workspaceName);
         this.userName = userName;
@@ -140,6 +139,11 @@ public class TeamFoundationServerScm extends SCM {
 
     public boolean isUseUpdate() {
         return useUpdate;
+    }
+
+    @DataBoundSetter
+    public void setUseUpdate(final boolean useUpdate) {
+        this.useUpdate = useUpdate;
     }
 
     public String getUserPassword() {

--- a/src/main/java/hudson/plugins/tfs/TeamFoundationServerScm.java
+++ b/src/main/java/hudson/plugins/tfs/TeamFoundationServerScm.java
@@ -97,10 +97,30 @@ public class TeamFoundationServerScm extends SCM {
     
     private static final Logger logger = Logger.getLogger(TeamFoundationServerScm.class.getName());
 
+    /**
+     * Constructor used for unit tests.
+     *
+     * @param serverUrl the URL to the team project collection
+     * @param projectPath the path in TFVC to download from
+     * @param workspaceName the name (or expression) to use when mapping the workspace
+     */
     TeamFoundationServerScm(String serverUrl, String projectPath, String workspaceName) {
         this(serverUrl, projectPath, workspaceName, null, null);
     }
 
+    /**
+     * Constructor used during serialization (and a few tests).
+     *
+     * WARNING: do NOT add parameters to this constructor when adding fields for new settings.
+     * Instead, add a setter annotated with {@link DataBoundSetter} in the "Bean properties" section.
+     * See {@link #setLocalPath(String)} for an example.
+     *
+     * @param serverUrl the URL to the team project collection
+     * @param projectPath the path in TFVC to download from
+     * @param workspaceName the name (or expression) to use when mapping the workspace
+     * @param userName the name of the user account to use to talk to TFS/Team Services
+     * @param password the password or personal access token to use to talk to TFS/Team Services
+     */
     @DataBoundConstructor
     public TeamFoundationServerScm(String serverUrl, String projectPath, String workspaceName, String userName, Secret password) {
         this.serverUrl = serverUrl;
@@ -110,7 +130,7 @@ public class TeamFoundationServerScm extends SCM {
         this.password = password;
     }
 
-    /* Migrate legacy data */
+    @SuppressWarnings("unused" /* Migrate legacy data */)
     private Object readResolve() {
         if (password == null && userPassword != null) {
             password = Secret.fromString(Scrambler.descramble(userPassword));
@@ -119,7 +139,7 @@ public class TeamFoundationServerScm extends SCM {
         return this;
     }
 
-    // Bean properties need for job configuration
+    // Bean properties needed for job configuration
     public String getServerUrl() {
         return serverUrl;
     }

--- a/src/main/java/hudson/plugins/tfs/TeamFoundationServerScm.java
+++ b/src/main/java/hudson/plugins/tfs/TeamFoundationServerScm.java
@@ -23,6 +23,7 @@ import net.sf.json.JSONObject;
 
 import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.StaplerRequest;
 
 import hudson.Extension;
@@ -81,7 +82,7 @@ public class TeamFoundationServerScm extends SCM {
 
     private final String serverUrl;
     private final String projectPath;
-    private final Collection<String> cloakedPaths;
+    private Collection<String> cloakedPaths;
     private final String localPath;
     private final String workspaceName;
     private @Deprecated String userPassword;
@@ -96,15 +97,14 @@ public class TeamFoundationServerScm extends SCM {
     
     private static final Logger logger = Logger.getLogger(TeamFoundationServerScm.class.getName());
 
-    TeamFoundationServerScm(String serverUrl, String projectPath, String cloakedPaths, String localPath, boolean useUpdate, String workspaceName) {
-        this(serverUrl, projectPath, cloakedPaths, localPath, useUpdate, workspaceName, null, (Secret)null);
+    TeamFoundationServerScm(String serverUrl, String projectPath, String localPath, boolean useUpdate, String workspaceName) {
+        this(serverUrl, projectPath, localPath, useUpdate, workspaceName, null, (Secret)null);
     }
 
     @DataBoundConstructor
-    public TeamFoundationServerScm(String serverUrl, String projectPath, String cloakedPaths, String localPath, boolean useUpdate, String workspaceName, String userName, Secret password) {
+    public TeamFoundationServerScm(String serverUrl, String projectPath, String localPath, boolean useUpdate, String workspaceName, String userName, Secret password) {
         this.serverUrl = serverUrl;
         this.projectPath = projectPath;
-        this.cloakedPaths = splitCloakedPaths(cloakedPaths);
         this.useUpdate = useUpdate;
         this.localPath = (Util.fixEmptyAndTrim(localPath) == null ? "." : localPath);
         this.workspaceName = (Util.fixEmptyAndTrim(workspaceName) == null ? "Hudson-${JOB_NAME}-${NODE_NAME}" : workspaceName);
@@ -157,6 +157,12 @@ public class TeamFoundationServerScm extends SCM {
     public String getCloakedPaths() {
         return serializeCloakedPathCollectionToString(this.cloakedPaths);
     }
+
+    @DataBoundSetter
+    public void setCloakedPaths(final String cloakedPaths) {
+        this.cloakedPaths = splitCloakedPaths(cloakedPaths);
+    }
+
     // Bean properties END
 
     static String serializeCloakedPathCollectionToString(final Collection<String> cloakedPaths) {

--- a/src/main/java/hudson/plugins/tfs/TeamFoundationServerScm.java
+++ b/src/main/java/hudson/plugins/tfs/TeamFoundationServerScm.java
@@ -83,7 +83,7 @@ public class TeamFoundationServerScm extends SCM {
     private final String serverUrl;
     private final String projectPath;
     private Collection<String> cloakedPaths;
-    private final String localPath;
+    private String localPath;
     private final String workspaceName;
     private @Deprecated String userPassword;
     private /* almost final */ Secret password;
@@ -97,15 +97,14 @@ public class TeamFoundationServerScm extends SCM {
     
     private static final Logger logger = Logger.getLogger(TeamFoundationServerScm.class.getName());
 
-    TeamFoundationServerScm(String serverUrl, String projectPath, String localPath, String workspaceName) {
-        this(serverUrl, projectPath, localPath, workspaceName, null, (Secret)null);
+    TeamFoundationServerScm(String serverUrl, String projectPath, String workspaceName) {
+        this(serverUrl, projectPath, workspaceName, null, (Secret)null);
     }
 
     @DataBoundConstructor
-    public TeamFoundationServerScm(String serverUrl, String projectPath, String localPath, String workspaceName, String userName, Secret password) {
+    public TeamFoundationServerScm(String serverUrl, String projectPath, String workspaceName, String userName, Secret password) {
         this.serverUrl = serverUrl;
         this.projectPath = projectPath;
-        this.localPath = (Util.fixEmptyAndTrim(localPath) == null ? "." : localPath);
         this.workspaceName = (Util.fixEmptyAndTrim(workspaceName) == null ? "Hudson-${JOB_NAME}-${NODE_NAME}" : workspaceName);
         this.userName = userName;
         this.password = password;
@@ -134,7 +133,12 @@ public class TeamFoundationServerScm extends SCM {
     }
 
     public String getLocalPath() {
-        return localPath;
+        return (Util.fixEmptyAndTrim(localPath) == null ? "." : localPath);
+    }
+
+    @DataBoundSetter
+    public void setLocalPath(final String localPath) {
+        this.localPath = localPath;
     }
 
     public boolean isUseUpdate() {

--- a/src/main/java/hudson/plugins/tfs/TeamFoundationServerScm.java
+++ b/src/main/java/hudson/plugins/tfs/TeamFoundationServerScm.java
@@ -4,7 +4,6 @@ import static hudson.Util.fixEmpty;
 
 import java.io.File;
 import java.io.IOException;
-import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Collection;
@@ -26,7 +25,6 @@ import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.StaplerRequest;
 
-import hudson.AbortException;
 import hudson.Extension;
 import hudson.FilePath;
 import hudson.Launcher;
@@ -97,11 +95,6 @@ public class TeamFoundationServerScm extends SCM {
     private transient String workspaceChangesetVersion;
     
     private static final Logger logger = Logger.getLogger(TeamFoundationServerScm.class.getName());
-
-    @Deprecated
-    public TeamFoundationServerScm(String serverUrl, String projectPath, String localPath, boolean useUpdate, String workspaceName, String userName, String password) {
-        this(serverUrl, projectPath, null, localPath, useUpdate, workspaceName, userName, Secret.fromString(password));
-    }
 
     TeamFoundationServerScm(String serverUrl, String projectPath, String cloakedPaths, String localPath, boolean useUpdate, String workspaceName) {
         this(serverUrl, projectPath, cloakedPaths, localPath, useUpdate, workspaceName, null, (Secret)null);

--- a/src/main/java/hudson/plugins/tfs/TeamFoundationServerScm.java
+++ b/src/main/java/hudson/plugins/tfs/TeamFoundationServerScm.java
@@ -98,7 +98,7 @@ public class TeamFoundationServerScm extends SCM {
     private static final Logger logger = Logger.getLogger(TeamFoundationServerScm.class.getName());
 
     TeamFoundationServerScm(String serverUrl, String projectPath, String workspaceName) {
-        this(serverUrl, projectPath, workspaceName, null, (Secret)null);
+        this(serverUrl, projectPath, workspaceName, null, null);
     }
 
     @DataBoundConstructor

--- a/src/test/java/hudson/plugins/tfs/TeamFoundationServerScmIntegrationTest.java
+++ b/src/test/java/hudson/plugins/tfs/TeamFoundationServerScmIntegrationTest.java
@@ -21,7 +21,7 @@ public class TeamFoundationServerScmIntegrationTest {
     public void connectToTfs() throws URISyntaxException {
         final IntegrationTestHelper helper = new IntegrationTestHelper();
         final String serverUrl = helper.getServerUrl();
-        scm = new TeamFoundationServerScm(serverUrl, "projectPath", "localPath", false, "workspaceName", null, (Secret) null);
+        scm = new TeamFoundationServerScm(serverUrl, "projectPath", "localPath", "workspaceName", null, (Secret) null);
     }
 
     @Test

--- a/src/test/java/hudson/plugins/tfs/TeamFoundationServerScmIntegrationTest.java
+++ b/src/test/java/hudson/plugins/tfs/TeamFoundationServerScmIntegrationTest.java
@@ -21,7 +21,8 @@ public class TeamFoundationServerScmIntegrationTest {
     public void connectToTfs() throws URISyntaxException {
         final IntegrationTestHelper helper = new IntegrationTestHelper();
         final String serverUrl = helper.getServerUrl();
-        scm = new TeamFoundationServerScm(serverUrl, "projectPath", "localPath", "workspaceName", null, (Secret) null);
+        scm = new TeamFoundationServerScm(serverUrl, "projectPath", "workspaceName", null, (Secret) null);
+        scm.setLocalPath("localPath");
     }
 
     @Test

--- a/src/test/java/hudson/plugins/tfs/TeamFoundationServerScmIntegrationTest.java
+++ b/src/test/java/hudson/plugins/tfs/TeamFoundationServerScmIntegrationTest.java
@@ -21,7 +21,7 @@ public class TeamFoundationServerScmIntegrationTest {
     public void connectToTfs() throws URISyntaxException {
         final IntegrationTestHelper helper = new IntegrationTestHelper();
         final String serverUrl = helper.getServerUrl();
-        scm = new TeamFoundationServerScm(serverUrl, "projectPath", null, "localPath", false, "workspaceName", null, (Secret) null);
+        scm = new TeamFoundationServerScm(serverUrl, "projectPath", "localPath", false, "workspaceName", null, (Secret) null);
     }
 
     @Test

--- a/src/test/java/hudson/plugins/tfs/TeamFoundationServerScmIntegrationTest.java
+++ b/src/test/java/hudson/plugins/tfs/TeamFoundationServerScmIntegrationTest.java
@@ -21,7 +21,7 @@ public class TeamFoundationServerScmIntegrationTest {
     public void connectToTfs() throws URISyntaxException {
         final IntegrationTestHelper helper = new IntegrationTestHelper();
         final String serverUrl = helper.getServerUrl();
-        scm = new TeamFoundationServerScm(serverUrl, "projectPath", "workspaceName", null, (Secret) null);
+        scm = new TeamFoundationServerScm(serverUrl, "projectPath", "workspaceName", null, null);
         scm.setLocalPath("localPath");
     }
 

--- a/src/test/java/hudson/plugins/tfs/TeamFoundationServerScmTest.java
+++ b/src/test/java/hudson/plugins/tfs/TeamFoundationServerScmTest.java
@@ -116,7 +116,7 @@ public class TeamFoundationServerScmTest {
         when(build.getProject()).thenReturn(project);
         when(project.getName()).thenReturn("ThisIsAJob");
 
-        TeamFoundationServerScm scm = new TeamFoundationServerScm(null, null, ".", "erik_${JOB_NAME}");
+        TeamFoundationServerScm scm = new TeamFoundationServerScm(null, null, "erik_${JOB_NAME}");
         assertEquals("Workspace name was incorrect", "erik_ThisIsAJob", scm.getWorkspaceName(build, mock(Computer.class)));
     }
     
@@ -266,23 +266,31 @@ public class TeamFoundationServerScmTest {
             }
         }
     }
+    @Test
+    public void assertDefaultValueIsUsedForNullLocalPath() {
+        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", "workspace");
+        assertEquals("Default value for work folder was incorrect", ".", scm.getLocalPath());
+    }
 
     @Test
     public void assertDefaultValueIsUsedForEmptyLocalPath() {
-        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", "", "workspace");
+        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", "workspace");
+        scm.setLocalPath("");
         assertEquals("Default value for work folder was incorrect", ".", scm.getLocalPath());
     }
+
     
     @Test
     public void assertDefaultValueIsUsedForEmptyWorkspaceName() {
-        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", ".", "");
+        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", "");
         assertEquals("Default value for workspace was incorrect", "Hudson-${JOB_NAME}-${NODE_NAME}", scm.getWorkspaceName());
     }
     
     @Test
     public void assertGetModuleRootReturnsWorkFolder() throws Exception {
         workspace = Util.createTempFilePath();
-        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", "workfolder", "");
+        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", "");
+        scm.setLocalPath("workfolder");
         FilePath moduleRoot = scm.getModuleRoot(workspace);
         assertEquals("Name for module root was incorrect", "workfolder", moduleRoot.getName());
         assertEquals("The parent for module root was incorrect", workspace.getName(), moduleRoot.getParent().getName());
@@ -291,7 +299,7 @@ public class TeamFoundationServerScmTest {
     @Test
     public void assertGetModuleRootWorksForDotWorkFolder() throws Exception {
         workspace = Util.createTempFilePath();
-        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", ".", "");
+        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", "");
         FilePath moduleRoot = scm.getModuleRoot(workspace);
         assertTrue("The module root was reported as not existing even if its virtually the same as workspace",
                 moduleRoot.exists());
@@ -300,20 +308,26 @@ public class TeamFoundationServerScmTest {
     
     @Test
     public void assertWorkspaceNameIsAddedToEnvVars() throws Exception {
-        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", ".", "WORKSPACE_SAMPLE");
+        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", "WORKSPACE_SAMPLE");
         AbstractBuild build = mock(AbstractBuild.class);
         AbstractProject project = mock(AbstractProject.class);
         when(build.getProject()).thenReturn(project);
         scm.getWorkspaceName(build, mock(Computer.class));
         
         Map<String, String> env = new HashMap<String, String>();
-        scm.buildEnvVars(build, env );        
+        scm.buildEnvVars(build, env);
         assertEquals("The workspace name was incorrect", "WORKSPACE_SAMPLE", env.get(TeamFoundationServerScm.WORKSPACE_ENV_STR));
     }
     
+    private TeamFoundationServerScm createForEnvVars() {
+        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", "WORKSPACE_SAMPLE", "user", null);
+        scm.setLocalPath("PATH");
+        return scm;
+    }
+
     @Test
     public void assertWorksfolderPathIsAddedToEnvVars() throws Exception {
-        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", "PATH", "WORKSPACE_SAMPLE");
+        final TeamFoundationServerScm scm = createForEnvVars();
         
         Map<String, String> env = new HashMap<String, String>();
         env.put("WORKSPACE", "/this/is/a");
@@ -323,7 +337,7 @@ public class TeamFoundationServerScmTest {
     
     @Test
     public void assertProjectPathIsAddedToEnvVars() throws Exception {
-        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", "PATH", "WORKSPACE_SAMPLE");
+        final TeamFoundationServerScm scm = createForEnvVars();
         Map<String, String> env = new HashMap<String, String>();
         scm.buildEnvVars(mock(AbstractBuild.class), env );        
         assertEquals("The project path was incorrect", "projectpath", env.get(TeamFoundationServerScm.PROJECTPATH_ENV_STR));
@@ -331,7 +345,7 @@ public class TeamFoundationServerScmTest {
     
     @Test
     public void assertServerUrlIsAddedToEnvVars() throws Exception {
-        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", "PATH", "WORKSPACE_SAMPLE");
+        final TeamFoundationServerScm scm = createForEnvVars();
         Map<String, String> env = new HashMap<String, String>();
         scm.buildEnvVars(mock(AbstractBuild.class), env );        
         assertEquals("The server URL was incorrect", "serverurl", env.get(TeamFoundationServerScm.SERVERURL_ENV_STR));
@@ -339,7 +353,7 @@ public class TeamFoundationServerScmTest {
     
     @Test
     public void assertTfsUserNameIsAddedToEnvVars() throws Exception {
-        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", "PATH", "WORKSPACE_SAMPLE", "user", (Secret) null);
+        final TeamFoundationServerScm scm = createForEnvVars();
         Map<String, String> env = new HashMap<String, String>();
         scm.buildEnvVars(mock(AbstractBuild.class), env );        
         assertEquals("The TFS user name was incorrect", "user", env.get(TeamFoundationServerScm.USERNAME_ENV_STR));
@@ -347,7 +361,7 @@ public class TeamFoundationServerScmTest {
     
     @Test
     public void assertTfsWorkspaceChangesetIsAddedToEnvVars() throws Exception {
-        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", "PATH", "WORKSPACE_SAMPLE");
+        final TeamFoundationServerScm scm = createForEnvVars();
         scm.setWorkspaceChangesetVersion("12345");
         Map<String, String> env = new HashMap<String, String>();
         scm.buildEnvVars(mock(AbstractBuild.class), env );        
@@ -356,7 +370,7 @@ public class TeamFoundationServerScmTest {
   
     @Test
     public void assertTfsWorkspaceChangesetIsNotAddedToEnvVarsIfEmpty() throws Exception {
-        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", "PATH", "WORKSPACE_SAMPLE");
+        final TeamFoundationServerScm scm = createForEnvVars();
         scm.setWorkspaceChangesetVersion("");
         Map<String, String> env = new HashMap<String, String>();
         scm.buildEnvVars(mock(AbstractBuild.class), env );        
@@ -365,7 +379,7 @@ public class TeamFoundationServerScmTest {
 
     @Test
     public void assertTfsWorkspaceChangesetIsNotAddedToEnvVarsIfNull() throws Exception {
-        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", "PATH", "WORKSPACE_SAMPLE");
+        final TeamFoundationServerScm scm = createForEnvVars();
         scm.setWorkspaceChangesetVersion(null);
         Map<String, String> env = new HashMap<String, String>();
         scm.buildEnvVars(mock(AbstractBuild.class), env );        
@@ -373,7 +387,8 @@ public class TeamFoundationServerScmTest {
     }
 
     @Test public void recordWorkspaceChangesetVersion() throws Exception {
-        final TeamFoundationServerScm scm = new TeamFoundationServerScm("serverUrl", "projectPath", "localPath", "workspace");
+        final TeamFoundationServerScm scm = new TeamFoundationServerScm("serverUrl", "projectPath", "workspace");
+        scm.setLocalPath("localPath");
         final AbstractBuild build = mock(AbstractBuild.class);
         when(build.getTimestamp()).thenReturn(new GregorianCalendar(2015, 03, 28, 22, 04));
         final BuildListener listener = null;
@@ -391,7 +406,8 @@ public class TeamFoundationServerScmTest {
     }
 
     @Test public void recordWorkspaceChangesetVersionWithSingleVersionSpec() throws Exception {
-        final TeamFoundationServerScm scm = new TeamFoundationServerScm("serverUrl", "projectPath", "localPath", "workspace");
+        final TeamFoundationServerScm scm = new TeamFoundationServerScm("serverUrl", "projectPath", "workspace");
+        scm.setLocalPath("localPath");
         final AbstractBuild build = mock(AbstractBuild.class);
         final BuildListener listener = null;
         final Project project = mock(Project.class);
@@ -412,7 +428,7 @@ public class TeamFoundationServerScmTest {
      */
     @Test
     public void assertWorkspaceNameReplacesInvalidChars() {
-        TeamFoundationServerScm scm = new TeamFoundationServerScm(null, null, ".", "A\"B/C:D<E>F|G*H?I");
+        TeamFoundationServerScm scm = new TeamFoundationServerScm(null, null, "A\"B/C:D<E>F|G*H?I");
         assertEquals("Workspace name contained invalid chars", "A_B_C_D_E_F_G_H_I", scm.getWorkspaceName(null, null));
     }
     
@@ -421,7 +437,7 @@ public class TeamFoundationServerScmTest {
      */
     @Test
     public void assertWorkspaceNameReplacesEndingPeriod() {
-        TeamFoundationServerScm scm = new TeamFoundationServerScm(null, null, ".", "Workspace.Name.");
+        TeamFoundationServerScm scm = new TeamFoundationServerScm(null, null, "Workspace.Name.");
         assertEquals("Workspace name ends with period", "Workspace.Name_", scm.getWorkspaceName(null, null));
     }
     
@@ -430,7 +446,7 @@ public class TeamFoundationServerScmTest {
      */
     @Test
     public void assertWorkspaceNameReplacesEndingSpace() {
-        TeamFoundationServerScm scm = new TeamFoundationServerScm(null, null, ".", "Workspace Name ");
+        TeamFoundationServerScm scm = new TeamFoundationServerScm(null, null, "Workspace Name ");
         assertEquals("Workspace name ends with space", "Workspace Name_", scm.getWorkspaceName(null, null));
     }    
     
@@ -440,7 +456,7 @@ public class TeamFoundationServerScmTest {
         AbstractBuild build = mock(AbstractBuild.class);
         when(build.getAction(ParametersAction.class)).thenReturn(action);
 
-        TeamFoundationServerScm scm = new TeamFoundationServerScm("https://${PARAM}.com", null, ".", "");
+        TeamFoundationServerScm scm = new TeamFoundationServerScm("https://${PARAM}.com", null, "");
         assertEquals("The server url wasnt resolved", "https://RESOLVED.com", scm.getServerUrl(build));
     }    
     
@@ -450,7 +466,7 @@ public class TeamFoundationServerScmTest {
         AbstractBuild build = mock(AbstractBuild.class);
         when(build.getAction(ParametersAction.class)).thenReturn(action);
 
-        TeamFoundationServerScm scm = new TeamFoundationServerScm(null, "$/$PARAM/path", ".", "");
+        TeamFoundationServerScm scm = new TeamFoundationServerScm(null, "$/$PARAM/path", "");
         assertEquals("The project path wasnt resolved", "$/RESOLVED/path", scm.getProjectPath(build));
     }    
     
@@ -460,14 +476,14 @@ public class TeamFoundationServerScmTest {
         AbstractBuild build = mock(AbstractBuild.class);
         when(build.getAction(ParametersAction.class)).thenReturn(action);
 
-        TeamFoundationServerScm scm = new TeamFoundationServerScm(null, null, ".", "WS-${PARAM}");
+        TeamFoundationServerScm scm = new TeamFoundationServerScm(null, null, "WS-${PARAM}");
         assertEquals("The workspace name wasnt resolved", "WS-RESOLVED", scm.getWorkspaceName(build, mock(Computer.class)));
     }
     
     @Test public void assertTfsWorkspaceIsntRemovedIfThereIsNoBuildWhenProcessWorkspaceBeforeDeletion() throws Exception {
         AbstractProject project = mock(AbstractProject.class);
         Node node = mock(Node.class);
-        TeamFoundationServerScm scm = new TeamFoundationServerScm("server", "projectpath", ".", "workspace");
+        TeamFoundationServerScm scm = new TeamFoundationServerScm("server", "projectpath", "workspace");
         assertThat(scm.processWorkspaceBeforeDeletion(project, workspace, node), is(true));
         verify(project).getLastBuild();
         verifyNoMoreInteractions(project);
@@ -483,7 +499,7 @@ public class TeamFoundationServerScmTest {
         when(build.getBuiltOn()).thenReturn(node).thenReturn(node);
         when(node.getNodeName()).thenReturn("node1").thenReturn("node2");
         when(inNode.getNodeName()).thenReturn("needleNode").thenReturn("needleNode");
-        TeamFoundationServerScm scm = new TeamFoundationServerScm("server", "projectpath", ".", "workspace");
+        TeamFoundationServerScm scm = new TeamFoundationServerScm("server", "projectpath", "workspace");
         assertThat( scm.processWorkspaceBeforeDeletion(project, workspace, inNode), is(true));
         verify(project).getLastBuild();
         verify(node, times(2)).getNodeName();

--- a/src/test/java/hudson/plugins/tfs/TeamFoundationServerScmTest.java
+++ b/src/test/java/hudson/plugins/tfs/TeamFoundationServerScmTest.java
@@ -116,7 +116,7 @@ public class TeamFoundationServerScmTest {
         when(build.getProject()).thenReturn(project);
         when(project.getName()).thenReturn("ThisIsAJob");
 
-        TeamFoundationServerScm scm = new TeamFoundationServerScm(null, null, null, ".", false, "erik_${JOB_NAME}");
+        TeamFoundationServerScm scm = new TeamFoundationServerScm(null, null, ".", false, "erik_${JOB_NAME}");
         assertEquals("Workspace name was incorrect", "erik_ThisIsAJob", scm.getWorkspaceName(build, mock(Computer.class)));
     }
     
@@ -269,20 +269,20 @@ public class TeamFoundationServerScmTest {
 
     @Test
     public void assertDefaultValueIsUsedForEmptyLocalPath() {
-        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", null, "", false, "workspace");
+        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", "", false, "workspace");
         assertEquals("Default value for work folder was incorrect", ".", scm.getLocalPath());
     }
     
     @Test
     public void assertDefaultValueIsUsedForEmptyWorkspaceName() {
-        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", null, ".", false, "");
+        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", ".", false, "");
         assertEquals("Default value for workspace was incorrect", "Hudson-${JOB_NAME}-${NODE_NAME}", scm.getWorkspaceName());
     }
     
     @Test
     public void assertGetModuleRootReturnsWorkFolder() throws Exception {
         workspace = Util.createTempFilePath();
-        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", null, "workfolder", false, "");
+        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", "workfolder", false, "");
         FilePath moduleRoot = scm.getModuleRoot(workspace);
         assertEquals("Name for module root was incorrect", "workfolder", moduleRoot.getName());
         assertEquals("The parent for module root was incorrect", workspace.getName(), moduleRoot.getParent().getName());
@@ -291,7 +291,7 @@ public class TeamFoundationServerScmTest {
     @Test
     public void assertGetModuleRootWorksForDotWorkFolder() throws Exception {
         workspace = Util.createTempFilePath();
-        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", null, ".", false, "");
+        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", ".", false, "");
         FilePath moduleRoot = scm.getModuleRoot(workspace);
         assertTrue("The module root was reported as not existing even if its virtually the same as workspace",
                 moduleRoot.exists());
@@ -300,7 +300,7 @@ public class TeamFoundationServerScmTest {
     
     @Test
     public void assertWorkspaceNameIsAddedToEnvVars() throws Exception {
-        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", null, ".", false, "WORKSPACE_SAMPLE");
+        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", ".", false, "WORKSPACE_SAMPLE");
         AbstractBuild build = mock(AbstractBuild.class);
         AbstractProject project = mock(AbstractProject.class);
         when(build.getProject()).thenReturn(project);
@@ -313,7 +313,7 @@ public class TeamFoundationServerScmTest {
     
     @Test
     public void assertWorksfolderPathIsAddedToEnvVars() throws Exception {
-        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", null, "PATH", false, "WORKSPACE_SAMPLE");
+        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", "PATH", false, "WORKSPACE_SAMPLE");
         
         Map<String, String> env = new HashMap<String, String>();
         env.put("WORKSPACE", "/this/is/a");
@@ -323,7 +323,7 @@ public class TeamFoundationServerScmTest {
     
     @Test
     public void assertProjectPathIsAddedToEnvVars() throws Exception {
-        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", null, "PATH", false, "WORKSPACE_SAMPLE");
+        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", "PATH", false, "WORKSPACE_SAMPLE");
         Map<String, String> env = new HashMap<String, String>();
         scm.buildEnvVars(mock(AbstractBuild.class), env );        
         assertEquals("The project path was incorrect", "projectpath", env.get(TeamFoundationServerScm.PROJECTPATH_ENV_STR));
@@ -331,7 +331,7 @@ public class TeamFoundationServerScmTest {
     
     @Test
     public void assertServerUrlIsAddedToEnvVars() throws Exception {
-        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", null, "PATH", false, "WORKSPACE_SAMPLE");
+        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", "PATH", false, "WORKSPACE_SAMPLE");
         Map<String, String> env = new HashMap<String, String>();
         scm.buildEnvVars(mock(AbstractBuild.class), env );        
         assertEquals("The server URL was incorrect", "serverurl", env.get(TeamFoundationServerScm.SERVERURL_ENV_STR));
@@ -339,7 +339,7 @@ public class TeamFoundationServerScmTest {
     
     @Test
     public void assertTfsUserNameIsAddedToEnvVars() throws Exception {
-        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", null, "PATH", false, "WORKSPACE_SAMPLE", "user", (Secret) null);
+        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", "PATH", false, "WORKSPACE_SAMPLE", "user", (Secret) null);
         Map<String, String> env = new HashMap<String, String>();
         scm.buildEnvVars(mock(AbstractBuild.class), env );        
         assertEquals("The TFS user name was incorrect", "user", env.get(TeamFoundationServerScm.USERNAME_ENV_STR));
@@ -347,7 +347,7 @@ public class TeamFoundationServerScmTest {
     
     @Test
     public void assertTfsWorkspaceChangesetIsAddedToEnvVars() throws Exception {
-        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", null, "PATH", false, "WORKSPACE_SAMPLE");
+        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", "PATH", false, "WORKSPACE_SAMPLE");
         scm.setWorkspaceChangesetVersion("12345");
         Map<String, String> env = new HashMap<String, String>();
         scm.buildEnvVars(mock(AbstractBuild.class), env );        
@@ -356,7 +356,7 @@ public class TeamFoundationServerScmTest {
   
     @Test
     public void assertTfsWorkspaceChangesetIsNotAddedToEnvVarsIfEmpty() throws Exception {
-        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", null, "PATH", false, "WORKSPACE_SAMPLE");
+        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", "PATH", false, "WORKSPACE_SAMPLE");
         scm.setWorkspaceChangesetVersion("");
         Map<String, String> env = new HashMap<String, String>();
         scm.buildEnvVars(mock(AbstractBuild.class), env );        
@@ -365,7 +365,7 @@ public class TeamFoundationServerScmTest {
 
     @Test
     public void assertTfsWorkspaceChangesetIsNotAddedToEnvVarsIfNull() throws Exception {
-        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", null, "PATH", false, "WORKSPACE_SAMPLE");
+        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", "PATH", false, "WORKSPACE_SAMPLE");
         scm.setWorkspaceChangesetVersion(null);
         Map<String, String> env = new HashMap<String, String>();
         scm.buildEnvVars(mock(AbstractBuild.class), env );        
@@ -373,7 +373,7 @@ public class TeamFoundationServerScmTest {
     }
 
     @Test public void recordWorkspaceChangesetVersion() throws Exception {
-        final TeamFoundationServerScm scm = new TeamFoundationServerScm("serverUrl", "projectPath", null, "localPath", false, "workspace");
+        final TeamFoundationServerScm scm = new TeamFoundationServerScm("serverUrl", "projectPath", "localPath", false, "workspace");
         final AbstractBuild build = mock(AbstractBuild.class);
         when(build.getTimestamp()).thenReturn(new GregorianCalendar(2015, 03, 28, 22, 04));
         final BuildListener listener = null;
@@ -391,7 +391,7 @@ public class TeamFoundationServerScmTest {
     }
 
     @Test public void recordWorkspaceChangesetVersionWithSingleVersionSpec() throws Exception {
-        final TeamFoundationServerScm scm = new TeamFoundationServerScm("serverUrl", "projectPath", null, "localPath", false, "workspace");
+        final TeamFoundationServerScm scm = new TeamFoundationServerScm("serverUrl", "projectPath", "localPath", false, "workspace");
         final AbstractBuild build = mock(AbstractBuild.class);
         final BuildListener listener = null;
         final Project project = mock(Project.class);
@@ -412,7 +412,7 @@ public class TeamFoundationServerScmTest {
      */
     @Test
     public void assertWorkspaceNameReplacesInvalidChars() {
-        TeamFoundationServerScm scm = new TeamFoundationServerScm(null, null, null, ".", false, "A\"B/C:D<E>F|G*H?I");
+        TeamFoundationServerScm scm = new TeamFoundationServerScm(null, null, ".", false, "A\"B/C:D<E>F|G*H?I");
         assertEquals("Workspace name contained invalid chars", "A_B_C_D_E_F_G_H_I", scm.getWorkspaceName(null, null));
     }
     
@@ -421,7 +421,7 @@ public class TeamFoundationServerScmTest {
      */
     @Test
     public void assertWorkspaceNameReplacesEndingPeriod() {
-        TeamFoundationServerScm scm = new TeamFoundationServerScm(null, null, null, ".", false, "Workspace.Name.");
+        TeamFoundationServerScm scm = new TeamFoundationServerScm(null, null, ".", false, "Workspace.Name.");
         assertEquals("Workspace name ends with period", "Workspace.Name_", scm.getWorkspaceName(null, null));
     }
     
@@ -430,7 +430,7 @@ public class TeamFoundationServerScmTest {
      */
     @Test
     public void assertWorkspaceNameReplacesEndingSpace() {
-        TeamFoundationServerScm scm = new TeamFoundationServerScm(null, null, null, ".", false, "Workspace Name ");
+        TeamFoundationServerScm scm = new TeamFoundationServerScm(null, null, ".", false, "Workspace Name ");
         assertEquals("Workspace name ends with space", "Workspace Name_", scm.getWorkspaceName(null, null));
     }    
     
@@ -440,7 +440,7 @@ public class TeamFoundationServerScmTest {
         AbstractBuild build = mock(AbstractBuild.class);
         when(build.getAction(ParametersAction.class)).thenReturn(action);
 
-        TeamFoundationServerScm scm = new TeamFoundationServerScm("https://${PARAM}.com", null, null, ".", false, "");
+        TeamFoundationServerScm scm = new TeamFoundationServerScm("https://${PARAM}.com", null, ".", false, "");
         assertEquals("The server url wasnt resolved", "https://RESOLVED.com", scm.getServerUrl(build));
     }    
     
@@ -450,7 +450,7 @@ public class TeamFoundationServerScmTest {
         AbstractBuild build = mock(AbstractBuild.class);
         when(build.getAction(ParametersAction.class)).thenReturn(action);
 
-        TeamFoundationServerScm scm = new TeamFoundationServerScm(null, "$/$PARAM/path", null, ".", false, "");
+        TeamFoundationServerScm scm = new TeamFoundationServerScm(null, "$/$PARAM/path", ".", false, "");
         assertEquals("The project path wasnt resolved", "$/RESOLVED/path", scm.getProjectPath(build));
     }    
     
@@ -460,14 +460,14 @@ public class TeamFoundationServerScmTest {
         AbstractBuild build = mock(AbstractBuild.class);
         when(build.getAction(ParametersAction.class)).thenReturn(action);
 
-        TeamFoundationServerScm scm = new TeamFoundationServerScm(null, null, null, ".", false, "WS-${PARAM}");
+        TeamFoundationServerScm scm = new TeamFoundationServerScm(null, null, ".", false, "WS-${PARAM}");
         assertEquals("The workspace name wasnt resolved", "WS-RESOLVED", scm.getWorkspaceName(build, mock(Computer.class)));
     }
     
     @Test public void assertTfsWorkspaceIsntRemovedIfThereIsNoBuildWhenProcessWorkspaceBeforeDeletion() throws Exception {
         AbstractProject project = mock(AbstractProject.class);
         Node node = mock(Node.class);
-        TeamFoundationServerScm scm = new TeamFoundationServerScm("server", "projectpath", null, ".", false, "workspace");
+        TeamFoundationServerScm scm = new TeamFoundationServerScm("server", "projectpath", ".", false, "workspace");
         assertThat(scm.processWorkspaceBeforeDeletion(project, workspace, node), is(true));
         verify(project).getLastBuild();
         verifyNoMoreInteractions(project);
@@ -483,7 +483,7 @@ public class TeamFoundationServerScmTest {
         when(build.getBuiltOn()).thenReturn(node).thenReturn(node);
         when(node.getNodeName()).thenReturn("node1").thenReturn("node2");
         when(inNode.getNodeName()).thenReturn("needleNode").thenReturn("needleNode");
-        TeamFoundationServerScm scm = new TeamFoundationServerScm("server", "projectpath", null, ".", false, "workspace");
+        TeamFoundationServerScm scm = new TeamFoundationServerScm("server", "projectpath", ".", false, "workspace");
         assertThat( scm.processWorkspaceBeforeDeletion(project, workspace, inNode), is(true));
         verify(project).getLastBuild();
         verify(node, times(2)).getNodeName();

--- a/src/test/java/hudson/plugins/tfs/TeamFoundationServerScmTest.java
+++ b/src/test/java/hudson/plugins/tfs/TeamFoundationServerScmTest.java
@@ -116,7 +116,7 @@ public class TeamFoundationServerScmTest {
         when(build.getProject()).thenReturn(project);
         when(project.getName()).thenReturn("ThisIsAJob");
 
-        TeamFoundationServerScm scm = new TeamFoundationServerScm(null, null, ".", false, "erik_${JOB_NAME}");
+        TeamFoundationServerScm scm = new TeamFoundationServerScm(null, null, ".", "erik_${JOB_NAME}");
         assertEquals("Workspace name was incorrect", "erik_ThisIsAJob", scm.getWorkspaceName(build, mock(Computer.class)));
     }
     
@@ -269,20 +269,20 @@ public class TeamFoundationServerScmTest {
 
     @Test
     public void assertDefaultValueIsUsedForEmptyLocalPath() {
-        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", "", false, "workspace");
+        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", "", "workspace");
         assertEquals("Default value for work folder was incorrect", ".", scm.getLocalPath());
     }
     
     @Test
     public void assertDefaultValueIsUsedForEmptyWorkspaceName() {
-        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", ".", false, "");
+        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", ".", "");
         assertEquals("Default value for workspace was incorrect", "Hudson-${JOB_NAME}-${NODE_NAME}", scm.getWorkspaceName());
     }
     
     @Test
     public void assertGetModuleRootReturnsWorkFolder() throws Exception {
         workspace = Util.createTempFilePath();
-        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", "workfolder", false, "");
+        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", "workfolder", "");
         FilePath moduleRoot = scm.getModuleRoot(workspace);
         assertEquals("Name for module root was incorrect", "workfolder", moduleRoot.getName());
         assertEquals("The parent for module root was incorrect", workspace.getName(), moduleRoot.getParent().getName());
@@ -291,7 +291,7 @@ public class TeamFoundationServerScmTest {
     @Test
     public void assertGetModuleRootWorksForDotWorkFolder() throws Exception {
         workspace = Util.createTempFilePath();
-        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", ".", false, "");
+        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", ".", "");
         FilePath moduleRoot = scm.getModuleRoot(workspace);
         assertTrue("The module root was reported as not existing even if its virtually the same as workspace",
                 moduleRoot.exists());
@@ -300,7 +300,7 @@ public class TeamFoundationServerScmTest {
     
     @Test
     public void assertWorkspaceNameIsAddedToEnvVars() throws Exception {
-        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", ".", false, "WORKSPACE_SAMPLE");
+        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", ".", "WORKSPACE_SAMPLE");
         AbstractBuild build = mock(AbstractBuild.class);
         AbstractProject project = mock(AbstractProject.class);
         when(build.getProject()).thenReturn(project);
@@ -313,7 +313,7 @@ public class TeamFoundationServerScmTest {
     
     @Test
     public void assertWorksfolderPathIsAddedToEnvVars() throws Exception {
-        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", "PATH", false, "WORKSPACE_SAMPLE");
+        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", "PATH", "WORKSPACE_SAMPLE");
         
         Map<String, String> env = new HashMap<String, String>();
         env.put("WORKSPACE", "/this/is/a");
@@ -323,7 +323,7 @@ public class TeamFoundationServerScmTest {
     
     @Test
     public void assertProjectPathIsAddedToEnvVars() throws Exception {
-        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", "PATH", false, "WORKSPACE_SAMPLE");
+        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", "PATH", "WORKSPACE_SAMPLE");
         Map<String, String> env = new HashMap<String, String>();
         scm.buildEnvVars(mock(AbstractBuild.class), env );        
         assertEquals("The project path was incorrect", "projectpath", env.get(TeamFoundationServerScm.PROJECTPATH_ENV_STR));
@@ -331,7 +331,7 @@ public class TeamFoundationServerScmTest {
     
     @Test
     public void assertServerUrlIsAddedToEnvVars() throws Exception {
-        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", "PATH", false, "WORKSPACE_SAMPLE");
+        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", "PATH", "WORKSPACE_SAMPLE");
         Map<String, String> env = new HashMap<String, String>();
         scm.buildEnvVars(mock(AbstractBuild.class), env );        
         assertEquals("The server URL was incorrect", "serverurl", env.get(TeamFoundationServerScm.SERVERURL_ENV_STR));
@@ -339,7 +339,7 @@ public class TeamFoundationServerScmTest {
     
     @Test
     public void assertTfsUserNameIsAddedToEnvVars() throws Exception {
-        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", "PATH", false, "WORKSPACE_SAMPLE", "user", (Secret) null);
+        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", "PATH", "WORKSPACE_SAMPLE", "user", (Secret) null);
         Map<String, String> env = new HashMap<String, String>();
         scm.buildEnvVars(mock(AbstractBuild.class), env );        
         assertEquals("The TFS user name was incorrect", "user", env.get(TeamFoundationServerScm.USERNAME_ENV_STR));
@@ -347,7 +347,7 @@ public class TeamFoundationServerScmTest {
     
     @Test
     public void assertTfsWorkspaceChangesetIsAddedToEnvVars() throws Exception {
-        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", "PATH", false, "WORKSPACE_SAMPLE");
+        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", "PATH", "WORKSPACE_SAMPLE");
         scm.setWorkspaceChangesetVersion("12345");
         Map<String, String> env = new HashMap<String, String>();
         scm.buildEnvVars(mock(AbstractBuild.class), env );        
@@ -356,7 +356,7 @@ public class TeamFoundationServerScmTest {
   
     @Test
     public void assertTfsWorkspaceChangesetIsNotAddedToEnvVarsIfEmpty() throws Exception {
-        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", "PATH", false, "WORKSPACE_SAMPLE");
+        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", "PATH", "WORKSPACE_SAMPLE");
         scm.setWorkspaceChangesetVersion("");
         Map<String, String> env = new HashMap<String, String>();
         scm.buildEnvVars(mock(AbstractBuild.class), env );        
@@ -365,7 +365,7 @@ public class TeamFoundationServerScmTest {
 
     @Test
     public void assertTfsWorkspaceChangesetIsNotAddedToEnvVarsIfNull() throws Exception {
-        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", "PATH", false, "WORKSPACE_SAMPLE");
+        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", "PATH", "WORKSPACE_SAMPLE");
         scm.setWorkspaceChangesetVersion(null);
         Map<String, String> env = new HashMap<String, String>();
         scm.buildEnvVars(mock(AbstractBuild.class), env );        
@@ -373,7 +373,7 @@ public class TeamFoundationServerScmTest {
     }
 
     @Test public void recordWorkspaceChangesetVersion() throws Exception {
-        final TeamFoundationServerScm scm = new TeamFoundationServerScm("serverUrl", "projectPath", "localPath", false, "workspace");
+        final TeamFoundationServerScm scm = new TeamFoundationServerScm("serverUrl", "projectPath", "localPath", "workspace");
         final AbstractBuild build = mock(AbstractBuild.class);
         when(build.getTimestamp()).thenReturn(new GregorianCalendar(2015, 03, 28, 22, 04));
         final BuildListener listener = null;
@@ -391,7 +391,7 @@ public class TeamFoundationServerScmTest {
     }
 
     @Test public void recordWorkspaceChangesetVersionWithSingleVersionSpec() throws Exception {
-        final TeamFoundationServerScm scm = new TeamFoundationServerScm("serverUrl", "projectPath", "localPath", false, "workspace");
+        final TeamFoundationServerScm scm = new TeamFoundationServerScm("serverUrl", "projectPath", "localPath", "workspace");
         final AbstractBuild build = mock(AbstractBuild.class);
         final BuildListener listener = null;
         final Project project = mock(Project.class);
@@ -412,7 +412,7 @@ public class TeamFoundationServerScmTest {
      */
     @Test
     public void assertWorkspaceNameReplacesInvalidChars() {
-        TeamFoundationServerScm scm = new TeamFoundationServerScm(null, null, ".", false, "A\"B/C:D<E>F|G*H?I");
+        TeamFoundationServerScm scm = new TeamFoundationServerScm(null, null, ".", "A\"B/C:D<E>F|G*H?I");
         assertEquals("Workspace name contained invalid chars", "A_B_C_D_E_F_G_H_I", scm.getWorkspaceName(null, null));
     }
     
@@ -421,7 +421,7 @@ public class TeamFoundationServerScmTest {
      */
     @Test
     public void assertWorkspaceNameReplacesEndingPeriod() {
-        TeamFoundationServerScm scm = new TeamFoundationServerScm(null, null, ".", false, "Workspace.Name.");
+        TeamFoundationServerScm scm = new TeamFoundationServerScm(null, null, ".", "Workspace.Name.");
         assertEquals("Workspace name ends with period", "Workspace.Name_", scm.getWorkspaceName(null, null));
     }
     
@@ -430,7 +430,7 @@ public class TeamFoundationServerScmTest {
      */
     @Test
     public void assertWorkspaceNameReplacesEndingSpace() {
-        TeamFoundationServerScm scm = new TeamFoundationServerScm(null, null, ".", false, "Workspace Name ");
+        TeamFoundationServerScm scm = new TeamFoundationServerScm(null, null, ".", "Workspace Name ");
         assertEquals("Workspace name ends with space", "Workspace Name_", scm.getWorkspaceName(null, null));
     }    
     
@@ -440,7 +440,7 @@ public class TeamFoundationServerScmTest {
         AbstractBuild build = mock(AbstractBuild.class);
         when(build.getAction(ParametersAction.class)).thenReturn(action);
 
-        TeamFoundationServerScm scm = new TeamFoundationServerScm("https://${PARAM}.com", null, ".", false, "");
+        TeamFoundationServerScm scm = new TeamFoundationServerScm("https://${PARAM}.com", null, ".", "");
         assertEquals("The server url wasnt resolved", "https://RESOLVED.com", scm.getServerUrl(build));
     }    
     
@@ -450,7 +450,7 @@ public class TeamFoundationServerScmTest {
         AbstractBuild build = mock(AbstractBuild.class);
         when(build.getAction(ParametersAction.class)).thenReturn(action);
 
-        TeamFoundationServerScm scm = new TeamFoundationServerScm(null, "$/$PARAM/path", ".", false, "");
+        TeamFoundationServerScm scm = new TeamFoundationServerScm(null, "$/$PARAM/path", ".", "");
         assertEquals("The project path wasnt resolved", "$/RESOLVED/path", scm.getProjectPath(build));
     }    
     
@@ -460,14 +460,14 @@ public class TeamFoundationServerScmTest {
         AbstractBuild build = mock(AbstractBuild.class);
         when(build.getAction(ParametersAction.class)).thenReturn(action);
 
-        TeamFoundationServerScm scm = new TeamFoundationServerScm(null, null, ".", false, "WS-${PARAM}");
+        TeamFoundationServerScm scm = new TeamFoundationServerScm(null, null, ".", "WS-${PARAM}");
         assertEquals("The workspace name wasnt resolved", "WS-RESOLVED", scm.getWorkspaceName(build, mock(Computer.class)));
     }
     
     @Test public void assertTfsWorkspaceIsntRemovedIfThereIsNoBuildWhenProcessWorkspaceBeforeDeletion() throws Exception {
         AbstractProject project = mock(AbstractProject.class);
         Node node = mock(Node.class);
-        TeamFoundationServerScm scm = new TeamFoundationServerScm("server", "projectpath", ".", false, "workspace");
+        TeamFoundationServerScm scm = new TeamFoundationServerScm("server", "projectpath", ".", "workspace");
         assertThat(scm.processWorkspaceBeforeDeletion(project, workspace, node), is(true));
         verify(project).getLastBuild();
         verifyNoMoreInteractions(project);
@@ -483,7 +483,7 @@ public class TeamFoundationServerScmTest {
         when(build.getBuiltOn()).thenReturn(node).thenReturn(node);
         when(node.getNodeName()).thenReturn("node1").thenReturn("node2");
         when(inNode.getNodeName()).thenReturn("needleNode").thenReturn("needleNode");
-        TeamFoundationServerScm scm = new TeamFoundationServerScm("server", "projectpath", ".", false, "workspace");
+        TeamFoundationServerScm scm = new TeamFoundationServerScm("server", "projectpath", ".", "workspace");
         assertThat( scm.processWorkspaceBeforeDeletion(project, workspace, inNode), is(true));
         verify(project).getLastBuild();
         verify(node, times(2)).getNodeName();

--- a/src/test/java/hudson/plugins/tfs/browsers/TeamSystemWebAccessBrowserTest.java
+++ b/src/test/java/hudson/plugins/tfs/browsers/TeamSystemWebAccessBrowserTest.java
@@ -63,7 +63,7 @@ public class TeamSystemWebAccessBrowserTest {
         final String projectPath = "$/project/folder/folder/branch";
         final Secret password = null;
         final String userName = null;
-        final TeamFoundationServerScm result = new TeamFoundationServerScm(serverUrl, projectPath, null, false, null, userName, password);
+        final TeamFoundationServerScm result = new TeamFoundationServerScm(serverUrl, projectPath, null, null, userName, password);
 
         final TeamFoundationServerRepositoryBrowser repositoryBrowser = mock(TeamFoundationServerRepositoryBrowser.class);
         result.setRepositoryBrowser(repositoryBrowser);

--- a/src/test/java/hudson/plugins/tfs/browsers/TeamSystemWebAccessBrowserTest.java
+++ b/src/test/java/hudson/plugins/tfs/browsers/TeamSystemWebAccessBrowserTest.java
@@ -63,7 +63,7 @@ public class TeamSystemWebAccessBrowserTest {
         final String projectPath = "$/project/folder/folder/branch";
         final Secret password = null;
         final String userName = null;
-        final TeamFoundationServerScm result = new TeamFoundationServerScm(serverUrl, projectPath, null, null, false, null, userName, password);
+        final TeamFoundationServerScm result = new TeamFoundationServerScm(serverUrl, projectPath, null, false, null, userName, password);
 
         final TeamFoundationServerRepositoryBrowser repositoryBrowser = mock(TeamFoundationServerRepositoryBrowser.class);
         result.setRepositoryBrowser(repositoryBrowser);

--- a/src/test/java/hudson/plugins/tfs/browsers/TeamSystemWebAccessBrowserTest.java
+++ b/src/test/java/hudson/plugins/tfs/browsers/TeamSystemWebAccessBrowserTest.java
@@ -63,7 +63,7 @@ public class TeamSystemWebAccessBrowserTest {
         final String projectPath = "$/project/folder/folder/branch";
         final Secret password = null;
         final String userName = null;
-        final TeamFoundationServerScm result = new TeamFoundationServerScm(serverUrl, projectPath, null, null, userName, password);
+        final TeamFoundationServerScm result = new TeamFoundationServerScm(serverUrl, projectPath, null, userName, password);
 
         final TeamFoundationServerRepositoryBrowser repositoryBrowser = mock(TeamFoundationServerRepositoryBrowser.class);
         result.setRepositoryBrowser(repositoryBrowser);


### PR DESCRIPTION
This branch consists only of refactors and conversions designed to simplify the addition of fields representing new settings to the `TeamFoundationServerScm` class.

Instead of adding parameters to the constructor(s) and propagating to all the tests, adding a setter annotated with `@DataBoundSetter` works just as well and is much less disruptive.  The approach is also clearly documented.

Manual testing
--------------

1. I edited a job that used the TFVC SCM and confirmed that the settings were still being saved in the job's `config.xml` file and that nothing broke as a result of these changes.
    1. I tested adding and removing values to the `cloakedPaths` field and queuing the job.
    2. I experimented with turning on and off `userUpdate` and then queuing the job.
    3. The lack of catastrophy with the two tests above (plus its unit tests) gave me confidence that `localPath` wasn't also broken.
2. I created a new job that used the TFVC SCM to make sure the "new" scenario still worked.  I was able to queue that job as well and see it fetch items from the TFVC repository.

Mission accomplished!