### PR TITLE
Use collection URI in payloads, if possible

### DIFF
--- a/src/main/java/hudson/plugins/tfs/TeamBuildEndpoint.java
+++ b/src/main/java/hudson/plugins/tfs/TeamBuildEndpoint.java
@@ -9,7 +9,6 @@ import hudson.model.Job;
 import hudson.model.UnprotectedRootAction;
 import hudson.plugins.tfs.model.AbstractCommand;
 import hudson.plugins.tfs.model.BuildCommand;
-import hudson.plugins.tfs.model.BuildParameter;
 import hudson.plugins.tfs.model.BuildWithParametersCommand;
 import hudson.plugins.tfs.model.PingCommand;
 import hudson.plugins.tfs.model.TeamBuildPayload;
@@ -55,8 +54,6 @@ public class TeamBuildEndpoint implements UnprotectedRootAction {
     private static final Map<String, AbstractCommand.Factory> COMMAND_FACTORIES_BY_NAME;
     private static final ObjectMapper MAPPER;
     public static final String URL_NAME = "team-build";
-    public static final String TEAM_EVENT = "team-event";
-    public static final String TEAM_BUILD = "team-build";
     public static final String PARAMETER = "parameter";
     static final String URL_PREFIX = "/" + URL_NAME + "/";
 

--- a/src/main/java/hudson/plugins/tfs/TeamBuildEndpoint.java
+++ b/src/main/java/hudson/plugins/tfs/TeamBuildEndpoint.java
@@ -1,5 +1,7 @@
 package hudson.plugins.tfs;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import hudson.Extension;
 import hudson.model.AbstractProject;
 import hudson.model.BuildAuthorizationToken;
@@ -7,8 +9,10 @@ import hudson.model.Job;
 import hudson.model.UnprotectedRootAction;
 import hudson.plugins.tfs.model.AbstractCommand;
 import hudson.plugins.tfs.model.BuildCommand;
+import hudson.plugins.tfs.model.BuildParameter;
 import hudson.plugins.tfs.model.BuildWithParametersCommand;
 import hudson.plugins.tfs.model.PingCommand;
+import hudson.plugins.tfs.model.TeamBuildPayload;
 import hudson.plugins.tfs.util.EndpointHelper;
 import hudson.plugins.tfs.util.MediaType;
 import jenkins.model.Jenkins;
@@ -49,6 +53,7 @@ public class TeamBuildEndpoint implements UnprotectedRootAction {
 
     private static final Logger LOGGER = Logger.getLogger(TeamBuildEndpoint.class.getName());
     private static final Map<String, AbstractCommand.Factory> COMMAND_FACTORIES_BY_NAME;
+    private static final ObjectMapper MAPPER;
     public static final String URL_NAME = "team-build";
     public static final String TEAM_EVENT = "team-event";
     public static final String TEAM_BUILD = "team-build";
@@ -61,6 +66,10 @@ public class TeamBuildEndpoint implements UnprotectedRootAction {
         map.put("build", new BuildCommand.Factory());
         map.put("buildWithParameters", new BuildWithParametersCommand.Factory());
         COMMAND_FACTORIES_BY_NAME = Collections.unmodifiableMap(map);
+
+        MAPPER = new ObjectMapper();
+        MAPPER.enable(DeserializationFeature.READ_ENUMS_USING_TO_STRING);
+        MAPPER.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
     }
 
     private String commandName;
@@ -215,7 +224,8 @@ public class TeamBuildEndpoint implements UnprotectedRootAction {
         final AbstractCommand command = factory.create();
         final JSONObject response;
         final JSONObject formData = req.getSubmittedForm();
-        response = command.perform(project, req, formData, actualDelay);
+        final TeamBuildPayload teamBuildPayload = MAPPER.convertValue(formData, TeamBuildPayload.class);
+        response = command.perform(project, req, formData, MAPPER, teamBuildPayload, actualDelay);
         return response;
     }
 

--- a/src/main/java/hudson/plugins/tfs/TeamEventsEndpoint.java
+++ b/src/main/java/hudson/plugins/tfs/TeamEventsEndpoint.java
@@ -62,6 +62,7 @@ public class TeamEventsEndpoint implements UnprotectedRootAction {
         HOOK_EVENT_FACTORIES_BY_NAME = Collections.unmodifiableMap(eventMap);
 
         MAPPER = new ObjectMapper();
+        MAPPER.enable(DeserializationFeature.READ_ENUMS_USING_TO_STRING);
         MAPPER.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
     }
 

--- a/src/main/java/hudson/plugins/tfs/TeamEventsEndpoint.java
+++ b/src/main/java/hudson/plugins/tfs/TeamEventsEndpoint.java
@@ -136,7 +136,7 @@ public class TeamEventsEndpoint implements UnprotectedRootAction {
         final String pathInfo = request.getPathInfo();
         final String eventName = pathInfoToEventName(pathInfo);
         try {
-            final JSONObject response = innerDispatch(body, eventName);
+            final JSONObject response = innerDispatch(body, eventName, HOOK_EVENT_FACTORIES_BY_NAME);
 
             rsp.setStatus(SC_OK);
             rsp.setContentType(MediaType.APPLICATION_JSON_UTF_8);
@@ -157,11 +157,11 @@ public class TeamEventsEndpoint implements UnprotectedRootAction {
         }
     }
 
-    private JSONObject innerDispatch(final String body, final String eventName) throws IOException {
-        if (StringUtils.isBlank(eventName) || !HOOK_EVENT_FACTORIES_BY_NAME.containsKey(eventName)) {
+    static JSONObject innerDispatch(final String body, final String eventName, final Map<String, AbstractHookEvent.Factory> factoriesByName) throws IOException {
+        if (StringUtils.isBlank(eventName) || !factoriesByName.containsKey(eventName)) {
             throw new IllegalArgumentException("Invalid event");
         }
-        final AbstractHookEvent.Factory factory = HOOK_EVENT_FACTORIES_BY_NAME.get(eventName);
+        final AbstractHookEvent.Factory factory = factoriesByName.get(eventName);
         final Event serviceHookEvent = deserializeEvent(body);
         final AbstractHookEvent hookEvent = factory.create();
         return hookEvent.perform(MAPPER, serviceHookEvent);

--- a/src/main/java/hudson/plugins/tfs/model/AbstractCommand.java
+++ b/src/main/java/hudson/plugins/tfs/model/AbstractCommand.java
@@ -1,6 +1,8 @@
 package hudson.plugins.tfs.model;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import hudson.model.AbstractProject;
+import hudson.plugins.tfs.model.servicehooks.Event;
 import jenkins.util.TimeDuration;
 import net.sf.json.JSONObject;
 import org.kohsuke.stapler.StaplerRequest;
@@ -16,16 +18,18 @@ public abstract class AbstractCommand {
     }
 
     /**
-     * Actually do the work of the command, using the supplied
-     * {@code requestPayload} and returning the output as a {@link JSONObject}.
+     * Actually do the work of the command, using the supplied {@code requestPayload} and
+     * {@code teamBuildPayload}, then returning the output as a {@link JSONObject}.
      *
      * @param project an {@link AbstractProject to operate on}
      * @param request a {@link StaplerRequest} to help build parameter values
      * @param requestPayload a {@link JSONObject} representing the command's input
+     * @param mapper an {@link ObjectMapper} instance to use to convert the {@link Event#resource}
+     * @param teamBuildPayload a {@link TeamBuildPayload} representing the command's input
      * @param delay how long to wait before the project starts executing
      *
      * @return a {@link JSONObject} representing the hook event's output
      */
-    public abstract JSONObject perform(final AbstractProject project, final StaplerRequest request, final JSONObject requestPayload, final TimeDuration delay);
+    public abstract JSONObject perform(final AbstractProject project, final StaplerRequest request, final JSONObject requestPayload, final ObjectMapper mapper, final TeamBuildPayload teamBuildPayload, final TimeDuration delay);
 
 }

--- a/src/main/java/hudson/plugins/tfs/model/AbstractHookEvent.java
+++ b/src/main/java/hudson/plugins/tfs/model/AbstractHookEvent.java
@@ -48,19 +48,6 @@ public abstract class AbstractHookEvent {
 
     /**
      * Actually do the work of the hook event, using the supplied
-     * {@code mapper} to decode the event's data from the supplied {@code resourceParser}
-     * and returning the output as a {@link JSONObject}.
-     *
-     * @param mapper an {@link ObjectMapper} instance to use to read from {@code resourceParser}
-     * @param resourceParser a {@link JsonParser} initialized to the {@code resource} node
-     *                       in the request payload
-     *
-     * @return a {@link JSONObject} representing the hook event's output
-     */
-    public abstract JSONObject perform(final ObjectMapper mapper, final JsonParser resourceParser);
-
-    /**
-     * Actually do the work of the hook event, using the supplied
      * {@code mapper} to convert the event's data from the supplied {@code serviceHookEvent}
      * and returning the output as a {@link JSONObject}.
      *

--- a/src/main/java/hudson/plugins/tfs/model/AbstractHookEvent.java
+++ b/src/main/java/hudson/plugins/tfs/model/AbstractHookEvent.java
@@ -45,19 +45,6 @@ public abstract class AbstractHookEvent {
         String getSampleRequestPayload();
     }
 
-    static String fetchResourceAsString(final Class<? extends Factory> referenceClass, final String fileName) {
-        final InputStream stream = referenceClass.getResourceAsStream(fileName);
-        try {
-            return IOUtils.toString(stream, MediaType.UTF_8);
-        }
-        catch (final IOException e) {
-            throw new Error(e);
-        }
-        finally {
-            IOUtils.closeQuietly(stream);
-        }
-    }
-
     /**
      * Actually do the work of the hook event, using the supplied
      * {@code mapper} to decode the event's data from the supplied {@code resourceParser}

--- a/src/main/java/hudson/plugins/tfs/model/AbstractHookEvent.java
+++ b/src/main/java/hudson/plugins/tfs/model/AbstractHookEvent.java
@@ -1,6 +1,5 @@
 package hudson.plugins.tfs.model;
 
-import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import hudson.model.AbstractProject;
 import hudson.model.Cause;
@@ -15,7 +14,6 @@ import hudson.plugins.tfs.TeamEventsEndpoint;
 import hudson.plugins.tfs.TeamHookCause;
 import hudson.plugins.tfs.TeamPushTrigger;
 import hudson.plugins.tfs.model.servicehooks.Event;
-import hudson.plugins.tfs.util.MediaType;
 import hudson.scm.SCM;
 import hudson.security.ACL;
 import hudson.triggers.SCMTrigger;
@@ -29,8 +27,6 @@ import org.apache.commons.io.IOUtils;
 import org.eclipse.jgit.transport.RemoteConfig;
 import org.eclipse.jgit.transport.URIish;
 
-import java.io.IOException;
-import java.io.InputStream;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.ArrayList;

--- a/src/main/java/hudson/plugins/tfs/model/AbstractHookEvent.java
+++ b/src/main/java/hudson/plugins/tfs/model/AbstractHookEvent.java
@@ -14,6 +14,7 @@ import hudson.plugins.tfs.CommitParameterAction;
 import hudson.plugins.tfs.TeamEventsEndpoint;
 import hudson.plugins.tfs.TeamHookCause;
 import hudson.plugins.tfs.TeamPushTrigger;
+import hudson.plugins.tfs.model.servicehooks.Event;
 import hudson.plugins.tfs.util.MediaType;
 import hudson.scm.SCM;
 import hudson.security.ACL;
@@ -57,6 +58,19 @@ public abstract class AbstractHookEvent {
      * @return a {@link JSONObject} representing the hook event's output
      */
     public abstract JSONObject perform(final ObjectMapper mapper, final JsonParser resourceParser);
+
+    /**
+     * Actually do the work of the hook event, using the supplied
+     * {@code mapper} to convert the event's data from the supplied {@code serviceHookEvent}
+     * and returning the output as a {@link JSONObject}.
+     *
+     * @param mapper an {@link ObjectMapper} instance to use to convert the {@link Event#resource}
+     * @param serviceHookEvent an {@link Event} that represents the request payload
+     *                         and from which the {@link Event#resource} can be obtained
+     *
+     * @return a {@link JSONObject} representing the hook event's output
+     */
+    public abstract JSONObject perform(final ObjectMapper mapper, final Event serviceHookEvent);
 
     static JSONObject fromResponseContributors(final List<GitStatus.ResponseContributor> contributors) {
         final JSONObject result = new JSONObject();

--- a/src/main/java/hudson/plugins/tfs/model/BuildCommand.java
+++ b/src/main/java/hudson/plugins/tfs/model/BuildCommand.java
@@ -188,7 +188,7 @@ public class BuildCommand extends AbstractCommand {
         return innerPerform(project, delay, actions);
     }
 
-    static boolean isTeamGit(final HashMap<String, String> teamBuildParameters) {
+    static boolean isTeamGit(final Map<String, String> teamBuildParameters) {
         if (teamBuildParameters.containsKey(BUILD_REPOSITORY_PROVIDER)) {
             final String provider = teamBuildParameters.get(BUILD_REPOSITORY_PROVIDER);
             return "TfGit".equalsIgnoreCase(provider)
@@ -197,7 +197,7 @@ public class BuildCommand extends AbstractCommand {
         return false;
     }
 
-    static void contributeTeamBuildParameterActions(final HashMap<String, String> teamBuildParameters, final List<Action> actions) {
+    static void contributeTeamBuildParameterActions(final Map<String, String> teamBuildParameters, final List<Action> actions) {
         if (isTeamGit(teamBuildParameters)) {
             final String collectionUriString = teamBuildParameters.get(SYSTEM_TEAM_FOUNDATION_COLLECTION_URI);
             final URI collectionUri = URI.create(collectionUriString);

--- a/src/main/java/hudson/plugins/tfs/model/BuildCommand.java
+++ b/src/main/java/hudson/plugins/tfs/model/BuildCommand.java
@@ -1,5 +1,8 @@
 package hudson.plugins.tfs.model;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.microsoft.teamfoundation.sourcecontrol.webapi.model.GitPullRequest;
+import com.microsoft.teamfoundation.sourcecontrol.webapi.model.GitPush;
 import hudson.model.AbstractProject;
 import hudson.model.Action;
 import hudson.model.Cause;
@@ -15,6 +18,7 @@ import hudson.model.queue.ScheduleResult;
 import hudson.plugins.tfs.CommitParameterAction;
 import hudson.plugins.tfs.PullRequestParameterAction;
 import hudson.plugins.tfs.TeamBuildEndpoint;
+import hudson.plugins.tfs.model.servicehooks.Event;
 import hudson.plugins.tfs.util.MediaType;
 import jenkins.model.Jenkins;
 import jenkins.util.TimeDuration;
@@ -27,7 +31,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -88,7 +91,7 @@ public class BuildCommand extends AbstractCommand {
     }
 
     @Override
-    public JSONObject perform(final AbstractProject project, final StaplerRequest req, final JSONObject requestPayload, final TimeDuration delay) {
+    public JSONObject perform(final AbstractProject project, final StaplerRequest req, final JSONObject requestPayload, final ObjectMapper mapper, final TeamBuildPayload teamBuildPayload, final TimeDuration delay) {
 
         // These values are for optional parameters of the same name, for the git.pullrequest.merged event
         String commitId = null;
@@ -96,25 +99,22 @@ public class BuildCommand extends AbstractCommand {
 
         final List<Action> actions = new ArrayList<Action>();
 
-        if (requestPayload.containsKey(TeamBuildEndpoint.TEAM_BUILD)) {
-            final HashMap<String, String> teamBuildParameters = new HashMap<String, String>();
-            final JSONObject variables = requestPayload.getJSONObject(TeamBuildEndpoint.TEAM_BUILD);
-            for (final String key : ((Map<String, Object>)variables).keySet()) {
-                final String value = variables.getString(key);
-                teamBuildParameters.put(key, value);
-            }
-            contributeTeamBuildParameterActions(teamBuildParameters, actions);
+        if (teamBuildPayload.BuildVariables != null) {
+            contributeTeamBuildParameterActions(teamBuildPayload.BuildVariables, actions);
         }
-        else if (requestPayload.containsKey(TeamBuildEndpoint.TEAM_EVENT)) {
-            final JSONObject teamEventJson = requestPayload.getJSONObject(TeamBuildEndpoint.TEAM_EVENT);
-            final String eventType = teamEventJson.getString("eventType");
+        else if (teamBuildPayload.ServiceHookEvent != null) {
+            final Event event = teamBuildPayload.ServiceHookEvent;
+            final String eventType = event.getEventType();
+            final Object resource = event.getResource();
             if ("git.push".equals(eventType)) {
-                final GitCodePushedEventArgs args = GitPushEvent.decodeGitPush(teamEventJson);
+                final GitPush gitPush = mapper.convertValue(resource, GitPush.class);
+                final GitCodePushedEventArgs args = GitPushEvent.decodeGitPush(gitPush, event);
                 final Action action = new CommitParameterAction(args);
                 actions.add(action);
             }
             else if ("git.pullrequest.merged".equals(eventType)) {
-                final PullRequestMergeCommitCreatedEventArgs args = GitPullRequestMergedEvent.decodeGitPullRequestMerged(teamEventJson);
+                final GitPullRequest gitPullRequest = mapper.convertValue(resource, GitPullRequest.class);
+                final PullRequestMergeCommitCreatedEventArgs args = GitPullRequestMergedEvent.decodeGitPullRequest(gitPullRequest, event);
                 // record the values for the special optional parameters
                 commitId = args.commit;
                 pullRequestId = Integer.toString(args.pullRequestId, 10);

--- a/src/main/java/hudson/plugins/tfs/model/BuildParameter.java
+++ b/src/main/java/hudson/plugins/tfs/model/BuildParameter.java
@@ -1,0 +1,6 @@
+package hudson.plugins.tfs.model;
+
+public class BuildParameter {
+    public String name;
+    public String value;
+}

--- a/src/main/java/hudson/plugins/tfs/model/GitPullRequestMergedEvent.java
+++ b/src/main/java/hudson/plugins/tfs/model/GitPullRequestMergedEvent.java
@@ -1,6 +1,5 @@
 package hudson.plugins.tfs.model;
 
-import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.microsoft.teamfoundation.sourcecontrol.webapi.model.GitCommitRef;
 import com.microsoft.teamfoundation.sourcecontrol.webapi.model.GitPullRequest;
@@ -12,7 +11,6 @@ import hudson.plugins.tfs.model.servicehooks.Event;
 import hudson.plugins.tfs.util.ResourceHelper;
 import net.sf.json.JSONObject;
 
-import java.io.IOException;
 import java.net.URI;
 import java.util.List;
 
@@ -81,23 +79,6 @@ public class GitPullRequestMergedEvent extends GitPushEvent {
         final GitCommitRef lastMergeCommit = gitPullRequest.getLastMergeCommit();
         final String result = lastMergeCommit.getCommitId();
         return result;
-    }
-
-    @Override
-    public JSONObject perform(final ObjectMapper mapper, final JsonParser resourceParser) {
-        final GitPullRequest gitPullRequest;
-        try {
-            gitPullRequest = mapper.readValue(resourceParser, GitPullRequest.class);
-        }
-        catch (final IOException e) {
-            throw new Error(e);
-        }
-
-        final PullRequestMergeCommitCreatedEventArgs args = decodeGitPullRequest(gitPullRequest);
-        final PullRequestParameterAction parameterAction = new PullRequestParameterAction(args);
-        final List<GitStatus.ResponseContributor> contributors = pollOrQueueFromEvent(args, parameterAction, true);
-        final JSONObject response = fromResponseContributors(contributors);
-        return response;
     }
 
     @Override

--- a/src/main/java/hudson/plugins/tfs/model/GitPullRequestMergedEvent.java
+++ b/src/main/java/hudson/plugins/tfs/model/GitPullRequestMergedEvent.java
@@ -86,7 +86,7 @@ public class GitPullRequestMergedEvent extends GitPushEvent {
         final Object resource = serviceHookEvent.getResource();
         final GitPullRequest gitPullRequest = mapper.convertValue(resource, GitPullRequest.class);
 
-        final PullRequestMergeCommitCreatedEventArgs args = decodeGitPullRequest(gitPullRequest);
+        final PullRequestMergeCommitCreatedEventArgs args = decodeGitPullRequest(gitPullRequest, serviceHookEvent);
         final PullRequestParameterAction parameterAction = new PullRequestParameterAction(args);
         final List<GitStatus.ResponseContributor> contributors = pollOrQueueFromEvent(args, parameterAction, true);
         final JSONObject response = fromResponseContributors(contributors);
@@ -117,9 +117,9 @@ public class GitPullRequestMergedEvent extends GitPushEvent {
         return args;
     }
 
-    static PullRequestMergeCommitCreatedEventArgs decodeGitPullRequest(final GitPullRequest gitPullRequest) {
+    static PullRequestMergeCommitCreatedEventArgs decodeGitPullRequest(final GitPullRequest gitPullRequest, final Event serviceHookEvent) {
         final GitRepository repository = gitPullRequest.getRepository();
-        final URI collectionUri = determineCollectionUri(repository);
+        final URI collectionUri = determineCollectionUri(repository, serviceHookEvent);
         final String repoUriString = repository.getRemoteUrl();
         final URI repoUri = URI.create(repoUriString);
         final String projectId = determineProjectId(repository);

--- a/src/main/java/hudson/plugins/tfs/model/GitPullRequestMergedEvent.java
+++ b/src/main/java/hudson/plugins/tfs/model/GitPullRequestMergedEvent.java
@@ -8,6 +8,7 @@ import com.microsoft.teamfoundation.sourcecontrol.webapi.model.GitRepository;
 import com.microsoft.visualstudio.services.webapi.model.IdentityRef;
 import hudson.plugins.git.GitStatus;
 import hudson.plugins.tfs.PullRequestParameterAction;
+import hudson.plugins.tfs.util.ResourceHelper;
 import net.sf.json.JSONObject;
 
 import java.io.IOException;
@@ -27,7 +28,7 @@ public class GitPullRequestMergedEvent extends GitPushEvent {
 
         @Override
         public String getSampleRequestPayload() {
-            return fetchResourceAsString(this.getClass(), "GitPullRequestMergedEvent.json");
+            return ResourceHelper.fetchAsString(this.getClass(), "GitPullRequestMergedEvent.json");
         }
     }
 

--- a/src/main/java/hudson/plugins/tfs/model/GitPullRequestMergedEvent.java
+++ b/src/main/java/hudson/plugins/tfs/model/GitPullRequestMergedEvent.java
@@ -102,7 +102,14 @@ public class GitPullRequestMergedEvent extends GitPushEvent {
 
     @Override
     public JSONObject perform(final ObjectMapper mapper, final Event serviceHookEvent) {
-        return null;
+        final Object resource = serviceHookEvent.getResource();
+        final GitPullRequest gitPullRequest = mapper.convertValue(resource, GitPullRequest.class);
+
+        final PullRequestMergeCommitCreatedEventArgs args = decodeGitPullRequest(gitPullRequest);
+        final PullRequestParameterAction parameterAction = new PullRequestParameterAction(args);
+        final List<GitStatus.ResponseContributor> contributors = pollOrQueueFromEvent(args, parameterAction, true);
+        final JSONObject response = fromResponseContributors(contributors);
+        return response;
     }
 
     static PullRequestMergeCommitCreatedEventArgs decodeGitPullRequestMerged(final JSONObject gitPullRequestMergedJson) {

--- a/src/main/java/hudson/plugins/tfs/model/GitPullRequestMergedEvent.java
+++ b/src/main/java/hudson/plugins/tfs/model/GitPullRequestMergedEvent.java
@@ -16,8 +16,6 @@ import java.util.List;
 
 public class GitPullRequestMergedEvent extends GitPushEvent {
 
-    private static final String GIT_PULLREQUEST_MERGED = "git.pullrequest.merged";
-
     public static class Factory implements AbstractHookEvent.Factory {
 
         @Override
@@ -29,12 +27,6 @@ public class GitPullRequestMergedEvent extends GitPushEvent {
         public String getSampleRequestPayload() {
             return ResourceHelper.fetchAsString(this.getClass(), "GitPullRequestMergedEvent.json");
         }
-    }
-
-    static String determineCreatedBy(final JSONObject resource) {
-        final JSONObject createdBy = resource.getJSONObject("createdBy");
-        final String result = createdBy.getString("displayName");
-        return result;
     }
 
     static String determineCreatedBy(final GitPullRequest gitPullRequest) {
@@ -69,12 +61,6 @@ public class GitPullRequestMergedEvent extends GitPushEvent {
     to merge it with `a511f5` (the tip of whatever the branch the PR is targeting, lastMergeTargetCommit),
     yielding `eef717f`.
      */
-    static String determineMergeCommit(final JSONObject resource) {
-        final JSONObject lastMergeCommit = resource.getJSONObject("lastMergeCommit");
-        final String result = lastMergeCommit.getString("commitId");
-        return result;
-    }
-
     static String determineMergeCommit(final GitPullRequest gitPullRequest) {
         final GitCommitRef lastMergeCommit = gitPullRequest.getLastMergeCommit();
         final String result = lastMergeCommit.getCommitId();
@@ -91,30 +77,6 @@ public class GitPullRequestMergedEvent extends GitPushEvent {
         final List<GitStatus.ResponseContributor> contributors = pollOrQueueFromEvent(args, parameterAction, true);
         final JSONObject response = fromResponseContributors(contributors);
         return response;
-    }
-
-    static PullRequestMergeCommitCreatedEventArgs decodeGitPullRequestMerged(final JSONObject gitPullRequestMergedJson) {
-        assertEquals(gitPullRequestMergedJson, EVENT_TYPE, GIT_PULLREQUEST_MERGED);
-        final JSONObject resource = gitPullRequestMergedJson.getJSONObject(RESOURCE);
-        final JSONObject repository = resource.getJSONObject(REPOSITORY);
-        final URI collectionUri = determineCollectionUri(repository);
-        final String repoUriString = repository.getString(REMOTE_URL);
-        final URI repoUri = URI.create(repoUriString);
-        final String projectId = determineProjectId(repository);
-        final String repoId = repository.getString(NAME);
-        final String commit = determineMergeCommit(resource);
-        final String pushedBy = determineCreatedBy(resource);
-        final int pullRequestId = resource.getInt("pullRequestId");
-
-        final PullRequestMergeCommitCreatedEventArgs args = new PullRequestMergeCommitCreatedEventArgs();
-        args.collectionUri = collectionUri;
-        args.repoUri = repoUri;
-        args.projectId = projectId;
-        args.repoId = repoId;
-        args.commit = commit;
-        args.pushedBy = pushedBy;
-        args.pullRequestId = pullRequestId;
-        return args;
     }
 
     static PullRequestMergeCommitCreatedEventArgs decodeGitPullRequest(final GitPullRequest gitPullRequest, final Event serviceHookEvent) {

--- a/src/main/java/hudson/plugins/tfs/model/GitPullRequestMergedEvent.java
+++ b/src/main/java/hudson/plugins/tfs/model/GitPullRequestMergedEvent.java
@@ -8,6 +8,7 @@ import com.microsoft.teamfoundation.sourcecontrol.webapi.model.GitRepository;
 import com.microsoft.visualstudio.services.webapi.model.IdentityRef;
 import hudson.plugins.git.GitStatus;
 import hudson.plugins.tfs.PullRequestParameterAction;
+import hudson.plugins.tfs.model.servicehooks.Event;
 import hudson.plugins.tfs.util.ResourceHelper;
 import net.sf.json.JSONObject;
 
@@ -97,6 +98,11 @@ public class GitPullRequestMergedEvent extends GitPushEvent {
         final List<GitStatus.ResponseContributor> contributors = pollOrQueueFromEvent(args, parameterAction, true);
         final JSONObject response = fromResponseContributors(contributors);
         return response;
+    }
+
+    @Override
+    public JSONObject perform(final ObjectMapper mapper, final Event serviceHookEvent) {
+        return null;
     }
 
     static PullRequestMergeCommitCreatedEventArgs decodeGitPullRequestMerged(final JSONObject gitPullRequestMergedJson) {

--- a/src/main/java/hudson/plugins/tfs/model/GitPushEvent.java
+++ b/src/main/java/hudson/plugins/tfs/model/GitPushEvent.java
@@ -61,7 +61,14 @@ public class GitPushEvent extends AbstractHookEvent {
 
     @Override
     public JSONObject perform(final ObjectMapper mapper, final Event serviceHookEvent) {
-        return null;
+        final Object resource = serviceHookEvent.getResource();
+        final GitPush gitPush = mapper.convertValue(resource, GitPush.class);
+
+        final GitCodePushedEventArgs args = decodeGitPush(gitPush);
+        final CommitParameterAction parameterAction = new CommitParameterAction(args);
+        final List<GitStatus.ResponseContributor> contributors = pollOrQueueFromEvent(args, parameterAction, false);
+        final JSONObject response = fromResponseContributors(contributors);
+        return response;
     }
 
     static void assertEquals(final JSONObject jsonObject, final String key, final String expectedValue) {

--- a/src/main/java/hudson/plugins/tfs/model/GitPushEvent.java
+++ b/src/main/java/hudson/plugins/tfs/model/GitPushEvent.java
@@ -1,6 +1,5 @@
 package hudson.plugins.tfs.model;
 
-import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.microsoft.teamfoundation.core.webapi.model.TeamProjectReference;
 import com.microsoft.teamfoundation.sourcecontrol.webapi.model.GitCommitRef;
@@ -14,7 +13,6 @@ import hudson.plugins.tfs.util.ResourceHelper;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
 
-import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.List;
@@ -40,23 +38,6 @@ public class GitPushEvent extends AbstractHookEvent {
         public String getSampleRequestPayload() {
             return ResourceHelper.fetchAsString(this.getClass(), "GitPushEvent.json");
         }
-    }
-
-    @Override
-    public JSONObject perform(final ObjectMapper mapper, final JsonParser resourceParser) {
-        final GitPush gitPush;
-        try {
-            gitPush = mapper.readValue(resourceParser, GitPush.class);
-        }
-        catch (final IOException e) {
-            throw new Error(e);
-        }
-
-        final GitCodePushedEventArgs args = decodeGitPush(gitPush);
-        final CommitParameterAction parameterAction = new CommitParameterAction(args);
-        final List<GitStatus.ResponseContributor> contributors = pollOrQueueFromEvent(args, parameterAction, false);
-        final JSONObject response = fromResponseContributors(contributors);
-        return response;
     }
 
     @Override

--- a/src/main/java/hudson/plugins/tfs/model/GitPushEvent.java
+++ b/src/main/java/hudson/plugins/tfs/model/GitPushEvent.java
@@ -100,12 +100,14 @@ public class GitPushEvent extends AbstractHookEvent {
     static URI determineCollectionUri(final GitRepository repository, final Event serviceHookEvent) {
         URI result = null;
         final Map<String, ResourceContainer> containers = serviceHookEvent.getResourceContainers();
-        final String collection = "collection";
-        if (containers.containsKey(collection)) {
-            final ResourceContainer collectionContainer = containers.get(collection);
-            final String baseUrl = collectionContainer.getBaseUrl();
-            if (StringUtils.isNotEmpty(baseUrl)) {
-                result = URI.create(baseUrl);
+        if (containers != null) {
+            final String collection = "collection";
+            if (containers.containsKey(collection)) {
+                final ResourceContainer collectionContainer = containers.get(collection);
+                final String baseUrl = collectionContainer.getBaseUrl();
+                if (StringUtils.isNotEmpty(baseUrl)) {
+                    result = URI.create(baseUrl);
+                }
             }
         }
         if (result == null) {

--- a/src/main/java/hudson/plugins/tfs/model/GitPushEvent.java
+++ b/src/main/java/hudson/plugins/tfs/model/GitPushEvent.java
@@ -9,6 +9,7 @@ import com.microsoft.teamfoundation.sourcecontrol.webapi.model.GitRepository;
 import com.microsoft.visualstudio.services.webapi.model.IdentityRef;
 import hudson.plugins.git.GitStatus;
 import hudson.plugins.tfs.CommitParameterAction;
+import hudson.plugins.tfs.model.servicehooks.Event;
 import hudson.plugins.tfs.util.ResourceHelper;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
@@ -56,6 +57,11 @@ public class GitPushEvent extends AbstractHookEvent {
         final List<GitStatus.ResponseContributor> contributors = pollOrQueueFromEvent(args, parameterAction, false);
         final JSONObject response = fromResponseContributors(contributors);
         return response;
+    }
+
+    @Override
+    public JSONObject perform(final ObjectMapper mapper, final Event serviceHookEvent) {
+        return null;
     }
 
     static void assertEquals(final JSONObject jsonObject, final String key, final String expectedValue) {

--- a/src/main/java/hudson/plugins/tfs/model/GitPushEvent.java
+++ b/src/main/java/hudson/plugins/tfs/model/GitPushEvent.java
@@ -9,6 +9,7 @@ import com.microsoft.teamfoundation.sourcecontrol.webapi.model.GitRepository;
 import com.microsoft.visualstudio.services.webapi.model.IdentityRef;
 import hudson.plugins.git.GitStatus;
 import hudson.plugins.tfs.CommitParameterAction;
+import hudson.plugins.tfs.util.ResourceHelper;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
 
@@ -36,7 +37,7 @@ public class GitPushEvent extends AbstractHookEvent {
 
         @Override
         public String getSampleRequestPayload() {
-            return fetchResourceAsString(this.getClass(), "GitPushEvent.json");
+            return ResourceHelper.fetchAsString(this.getClass(), "GitPushEvent.json");
         }
     }
 

--- a/src/main/java/hudson/plugins/tfs/model/PingCommand.java
+++ b/src/main/java/hudson/plugins/tfs/model/PingCommand.java
@@ -1,5 +1,6 @@
 package hudson.plugins.tfs.model;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import hudson.model.AbstractProject;
 import jenkins.util.TimeDuration;
 import net.sf.json.JSONObject;
@@ -26,7 +27,7 @@ public class PingCommand extends AbstractCommand {
     }
 
     @Override
-    public JSONObject perform(final AbstractProject project, final StaplerRequest request, final JSONObject requestPayload, final TimeDuration delay) {
+    public JSONObject perform(final AbstractProject project, final StaplerRequest request, final JSONObject requestPayload, final ObjectMapper mapper, final TeamBuildPayload teamBuildPayload, final TimeDuration delay) {
         return requestPayload;
     }
 

--- a/src/main/java/hudson/plugins/tfs/model/PingHookEvent.java
+++ b/src/main/java/hudson/plugins/tfs/model/PingHookEvent.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.TreeNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import hudson.plugins.tfs.model.servicehooks.Event;
 import net.sf.json.JSONObject;
 
 import java.io.IOException;
@@ -45,5 +46,10 @@ public class PingHookEvent extends AbstractHookEvent {
         catch (final IOException e) {
             throw new Error(e);
         }
+    }
+
+    @Override
+    public JSONObject perform(final ObjectMapper mapper, final Event serviceHookEvent) {
+        return null;
     }
 }

--- a/src/main/java/hudson/plugins/tfs/model/PingHookEvent.java
+++ b/src/main/java/hudson/plugins/tfs/model/PingHookEvent.java
@@ -50,6 +50,6 @@ public class PingHookEvent extends AbstractHookEvent {
 
     @Override
     public JSONObject perform(final ObjectMapper mapper, final Event serviceHookEvent) {
-        return null;
+        return JSONObject.fromObject(serviceHookEvent);
     }
 }

--- a/src/main/java/hudson/plugins/tfs/model/PingHookEvent.java
+++ b/src/main/java/hudson/plugins/tfs/model/PingHookEvent.java
@@ -1,15 +1,8 @@
 package hudson.plugins.tfs.model;
 
-import com.fasterxml.jackson.core.JsonFactory;
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.TreeNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import hudson.plugins.tfs.model.servicehooks.Event;
 import net.sf.json.JSONObject;
-
-import java.io.IOException;
-import java.io.StringWriter;
 
 public class PingHookEvent extends AbstractHookEvent {
 
@@ -28,23 +21,6 @@ public class PingHookEvent extends AbstractHookEvent {
                     "        \"message\": \"Hello, world!\"\n" +
                     "    }\n" +
                     "}";
-        }
-    }
-
-    @Override
-    public JSONObject perform(final ObjectMapper mapper, final JsonParser resourceParser) {
-        final TreeNode treeNode;
-        try {
-            treeNode = mapper.readTree(resourceParser);
-            final JsonFactory factory = mapper.getFactory();
-            final StringWriter sw = new StringWriter();
-            final JsonGenerator generator = factory.createGenerator(sw);
-            mapper.writeTree(generator, treeNode);
-            final String jsonString = sw.toString();
-            return JSONObject.fromObject(jsonString);
-        }
-        catch (final IOException e) {
-            throw new Error(e);
         }
     }
 

--- a/src/main/java/hudson/plugins/tfs/model/TeamBuildPayload.java
+++ b/src/main/java/hudson/plugins/tfs/model/TeamBuildPayload.java
@@ -1,0 +1,19 @@
+package hudson.plugins.tfs.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import hudson.plugins.tfs.model.servicehooks.Event;
+
+import java.util.List;
+import java.util.Map;
+
+public class TeamBuildPayload {
+
+    @JsonProperty("parameter")
+    public List<BuildParameter> BuildParameters;
+
+    @JsonProperty("team-build")
+    public Map<String, String> BuildVariables;
+
+    @JsonProperty("team-event")
+    public Event ServiceHookEvent;
+}

--- a/src/main/java/hudson/plugins/tfs/model/servicehooks/Event.java
+++ b/src/main/java/hudson/plugins/tfs/model/servicehooks/Event.java
@@ -1,0 +1,95 @@
+package hudson.plugins.tfs.model.servicehooks;
+
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Encapsulates the properties of an event.
+ */
+public class Event {
+    private UUID id;
+    private String eventType;
+    private String publisherId;
+    private EventScope scope;
+    private FormattedEventMessage message;
+    private FormattedEventMessage detailedMessage;
+    private Object resource;
+    private String resourceVersion;
+    private Map<String, ResourceContainer> resourceContainers;
+
+    public Event() {
+
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(final UUID id) {
+        this.id = id;
+    }
+
+    public String getEventType() {
+        return eventType;
+    }
+
+    public void setEventType(final String eventType) {
+        this.eventType = eventType;
+    }
+
+    public String getPublisherId() {
+        return publisherId;
+    }
+
+    public void setPublisherId(final String publisherId) {
+        this.publisherId = publisherId;
+    }
+
+    public EventScope getScope() {
+        return scope;
+    }
+
+    public void setScope(final EventScope scope) {
+        this.scope = scope;
+    }
+
+    public FormattedEventMessage getMessage() {
+        return message;
+    }
+
+    public void setMessage(final FormattedEventMessage message) {
+        this.message = message;
+    }
+
+    public FormattedEventMessage getDetailedMessage() {
+        return detailedMessage;
+    }
+
+    public void setDetailedMessage(final FormattedEventMessage detailedMessage) {
+        this.detailedMessage = detailedMessage;
+    }
+
+    public Object getResource() {
+        return resource;
+    }
+
+    public void setResource(final Object resource) {
+        this.resource = resource;
+    }
+
+    public String getResourceVersion() {
+        return resourceVersion;
+    }
+
+    public void setResourceVersion(final String resourceVersion) {
+        this.resourceVersion = resourceVersion;
+    }
+
+    public Map<String, ResourceContainer> getResourceContainers() {
+        return resourceContainers;
+    }
+
+    public void setResourceContainers(final Map<String, ResourceContainer> resourceContainers) {
+        this.resourceContainers = resourceContainers;
+    }
+}

--- a/src/main/java/hudson/plugins/tfs/model/servicehooks/EventScope.java
+++ b/src/main/java/hudson/plugins/tfs/model/servicehooks/EventScope.java
@@ -1,0 +1,33 @@
+package hudson.plugins.tfs.model.servicehooks;
+
+public enum EventScope {
+    /**
+     * No input scope specified.
+     */
+    All,
+
+    /**
+     * Team Project scope.
+     */
+    Project,
+
+    /**
+     * Team scope.
+     */
+    Team,
+
+    /**
+     * Collection scope.
+     */
+    Collection,
+
+    /**
+     * Account scope.
+     */
+    Account,
+
+    /**
+     * Deployment scope.
+     */
+    Deployment,
+}

--- a/src/main/java/hudson/plugins/tfs/model/servicehooks/FormattedEventMessage.java
+++ b/src/main/java/hudson/plugins/tfs/model/servicehooks/FormattedEventMessage.java
@@ -1,0 +1,34 @@
+package hudson.plugins.tfs.model.servicehooks;
+
+/**
+ * Provides different formats of an event message
+ */
+public class FormattedEventMessage {
+    private String text;
+    private String html;
+    private String markdown;
+
+    public String getText() {
+        return text;
+    }
+
+    public void setText(final String text) {
+        this.text = text;
+    }
+
+    public String getHtml() {
+        return html;
+    }
+
+    public void setHtml(final String html) {
+        this.html = html;
+    }
+
+    public String getMarkdown() {
+        return markdown;
+    }
+
+    public void setMarkdown(final String markdown) {
+        this.markdown = markdown;
+    }
+}

--- a/src/main/java/hudson/plugins/tfs/model/servicehooks/ResourceContainer.java
+++ b/src/main/java/hudson/plugins/tfs/model/servicehooks/ResourceContainer.java
@@ -1,0 +1,49 @@
+package hudson.plugins.tfs.model.servicehooks;
+
+import java.util.UUID;
+
+/**
+ * The base class for all resource containers, i.e. Account, Collection, Project
+ */
+public class ResourceContainer {
+    private UUID id;
+    private String baseUrl;
+    private String url;
+    private String name;
+
+    public ResourceContainer() {
+
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(final UUID id) {
+        this.id = id;
+    }
+
+    public String getBaseUrl() {
+        return baseUrl;
+    }
+
+    public void setBaseUrl(final String baseUrl) {
+        this.baseUrl = baseUrl;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public void setUrl(final String url) {
+        this.url = url;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(final String name) {
+        this.name = name;
+    }
+}

--- a/src/main/java/hudson/plugins/tfs/util/ResourceHelper.java
+++ b/src/main/java/hudson/plugins/tfs/util/ResourceHelper.java
@@ -1,0 +1,23 @@
+package hudson.plugins.tfs.util;
+
+import org.apache.commons.io.IOUtils;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+public class ResourceHelper {
+
+    public static String fetchAsString(final Class<?> referenceClass, final String fileName) {
+        final InputStream stream = referenceClass.getResourceAsStream(fileName);
+        try {
+            return IOUtils.toString(stream, MediaType.UTF_8);
+        }
+        catch (final IOException e) {
+            throw new Error(e);
+        }
+        finally {
+            IOUtils.closeQuietly(stream);
+        }
+    }
+
+}

--- a/src/test/java/hudson/plugins/tfs/TeamEventsEndpointTest.java
+++ b/src/test/java/hudson/plugins/tfs/TeamEventsEndpointTest.java
@@ -13,11 +13,12 @@ import java.util.Map;
  */
 public class TeamEventsEndpointTest {
 
+    private static final String GIT_PUSH_SAMPLE_JSON =
+            ResourceHelper.fetchAsString(TeamEventsEndpointTest.class, "git.push-sample.json");
+
     @Test
     public void deserializeEvent_sample() throws Exception {
-        final String input = ResourceHelper.fetchAsString(TeamEventsEndpointTest.class, "git.push-sample.json");
-
-        final Event actual = TeamEventsEndpoint.deserializeEvent(input);
+        final Event actual = TeamEventsEndpoint.deserializeEvent(GIT_PUSH_SAMPLE_JSON);
 
         Assert.assertEquals("git.push", actual.getEventType());
         final Map<String, ResourceContainer> containers = actual.getResourceContainers();

--- a/src/test/java/hudson/plugins/tfs/TeamEventsEndpointTest.java
+++ b/src/test/java/hudson/plugins/tfs/TeamEventsEndpointTest.java
@@ -1,0 +1,28 @@
+package hudson.plugins.tfs;
+
+import hudson.plugins.tfs.model.servicehooks.Event;
+import hudson.plugins.tfs.model.servicehooks.ResourceContainer;
+import hudson.plugins.tfs.util.ResourceHelper;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Map;
+
+/**
+ * A class to test {@link TeamEventsEndpoint}.
+ */
+public class TeamEventsEndpointTest {
+
+    @Test
+    public void deserializeEvent_sample() throws Exception {
+        final String input = ResourceHelper.fetchAsString(TeamEventsEndpointTest.class, "git.push-sample.json");
+
+        final Event actual = TeamEventsEndpoint.deserializeEvent(input);
+
+        Assert.assertEquals("git.push", actual.getEventType());
+        final Map<String, ResourceContainer> containers = actual.getResourceContainers();
+        final ResourceContainer collection = containers.get("collection");
+        Assert.assertEquals("https://fabrikam-fiber-inc.visualstudio.com/", collection.getBaseUrl());
+    }
+
+}

--- a/src/test/java/hudson/plugins/tfs/TeamEventsEndpointTest.java
+++ b/src/test/java/hudson/plugins/tfs/TeamEventsEndpointTest.java
@@ -1,11 +1,17 @@
 package hudson.plugins.tfs;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.microsoft.teamfoundation.common.model.ProjectState;
+import com.microsoft.teamfoundation.sourcecontrol.webapi.model.GitPush;
+import hudson.plugins.tfs.model.AbstractHookEvent;
 import hudson.plugins.tfs.model.servicehooks.Event;
 import hudson.plugins.tfs.model.servicehooks.ResourceContainer;
 import hudson.plugins.tfs.util.ResourceHelper;
+import net.sf.json.JSONObject;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -26,4 +32,35 @@ public class TeamEventsEndpointTest {
         Assert.assertEquals("https://fabrikam-fiber-inc.visualstudio.com/", collection.getBaseUrl());
     }
 
+    @Test
+    public void innerDispatch_fakedGitPushEventHandling() throws Exception {
+        final Map<String, AbstractHookEvent.Factory> factories = new HashMap<String, AbstractHookEvent.Factory>();
+        final String eventName = "fakedGitPush";
+        factories.put(eventName, FakedGitPush.FACTORY);
+
+        TeamEventsEndpoint.innerDispatch(GIT_PUSH_SAMPLE_JSON, eventName, factories);
+    }
+
+    private static class FakedGitPush extends AbstractHookEvent {
+
+        public static final AbstractHookEvent.Factory FACTORY = new Factory() {
+            @Override
+            public AbstractHookEvent create() {
+                return new FakedGitPush();
+            }
+
+            @Override
+            public String getSampleRequestPayload() {
+                return null;
+            }
+        };
+
+        @Override
+        public JSONObject perform(final ObjectMapper mapper, final Event serviceHookEvent) {
+            final Object resource = serviceHookEvent.getResource();
+            final GitPush actual = mapper.convertValue(resource, GitPush.class);
+            Assert.assertEquals(ProjectState.WELL_FORMED, actual.getRepository().getProject().getState());
+            return null;
+        }
+    }
 }

--- a/src/test/java/hudson/plugins/tfs/model/GitPullRequestMergedEventTest.java
+++ b/src/test/java/hudson/plugins/tfs/model/GitPullRequestMergedEventTest.java
@@ -11,21 +11,4 @@ import java.net.URI;
  */
 public class GitPullRequestMergedEventTest {
 
-    @Test
-    public void decodeGitPullRequestMerged() throws Exception {
-        final GitPullRequestMergedEvent.Factory factory = new GitPullRequestMergedEvent.Factory();
-        final String inputString = factory.getSampleRequestPayload();
-        final JSONObject input = JSONObject.fromObject(inputString);
-
-        final PullRequestMergeCommitCreatedEventArgs actual = GitPullRequestMergedEvent.decodeGitPullRequestMerged(input);
-
-        Assert.assertEquals(URI.create("https://fabrikam.visualstudio.com/"), actual.collectionUri);
-        Assert.assertEquals(URI.create("https://fabrikam.visualstudio.com/_git/Fabrikam"), actual.repoUri);
-        Assert.assertEquals("Fabrikam", actual.projectId);
-        Assert.assertEquals("Fabrikam", actual.repoId);
-        Assert.assertEquals("eef717f69257a6333f221566c1c987dc94cc0d72", actual.commit);
-        Assert.assertEquals("Jamal Hartnett", actual.pushedBy);
-        Assert.assertEquals(1, actual.pullRequestId);
-        Assert.assertEquals(-1, actual.iterationId);
-    }
 }

--- a/src/test/java/hudson/plugins/tfs/model/GitPushEventTest.java
+++ b/src/test/java/hudson/plugins/tfs/model/GitPushEventTest.java
@@ -1,6 +1,5 @@
 package hudson.plugins.tfs.model;
 
-import net.sf.json.JSONObject;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -19,22 +18,6 @@ public class GitPushEventTest {
 
         final URI expected = URI.create("https://fabrikam-fiber-inc.visualstudio.com/");
         Assert.assertEquals(expected, actual);
-    }
-
-    @Test
-    public void decodeGitPush() throws Exception {
-        final GitPushEvent.Factory factory = new GitPushEvent.Factory();
-        final String inputString = factory.getSampleRequestPayload();
-        final JSONObject input = JSONObject.fromObject(inputString);
-
-        final GitCodePushedEventArgs actual = GitPushEvent.decodeGitPush(input);
-
-        Assert.assertEquals(URI.create("https://fabrikam-fiber-inc.visualstudio.com/"), actual.collectionUri);
-        Assert.assertEquals(URI.create("https://fabrikam-fiber-inc.visualstudio.com/_git/Fabrikam-Fiber-Git"), actual.repoUri);
-        Assert.assertEquals("Fabrikam-Fiber-Git", actual.projectId);
-        Assert.assertEquals("Fabrikam-Fiber-Git", actual.repoId);
-        Assert.assertEquals("33b55f7cb7e7e245323987634f960cf4a6e6bc74", actual.commit);
-        Assert.assertEquals("Jamal Hartnett", actual.pushedBy);
     }
 
 }

--- a/src/test/resources/hudson/plugins/tfs/git.push-sample.json
+++ b/src/test/resources/hudson/plugins/tfs/git.push-sample.json
@@ -1,0 +1,78 @@
+{
+  "id": "03c164c2-8912-4d5e-8009-3707d5f83734",
+  "eventType": "git.push",
+  "publisherId": "tfs",
+  "message": {
+    "text": "Jamal Hartnett pushed updates to branch master of repository Fabrikam-Fiber-Git.",
+    "html": "Jamal Hartnett pushed updates to branch master of repository Fabrikam-Fiber-Git.",
+    "markdown": "Jamal Hartnett pushed updates to branch `master` of repository `Fabrikam-Fiber-Git`."
+  },
+  "detailedMessage": {
+    "text": "Jamal Hartnett pushed 1 commit to branch master of repository Fabrikam-Fiber-Git.\n - Fixed bug in web.config file 33b55f7c",
+    "html": "Jamal Hartnett pushed 1 commit to branch <a href=\"https://fabrikam-fiber-inc.visualstudio.com/_git/Fabrikam-Fiber-Git/#version=GBmaster\">master</a> of repository <a href=\"https://fabrikam-fiber-inc.visualstudio.com/_git/Fabrikam-Fiber-Git/\">Fabrikam-Fiber-Git</a>.\n<ul>\n<li>Fixed bug in web.config file <a href=\"https://fabrikam-fiber-inc.visualstudio.com/_git/Fabrikam-Fiber-Git/commit/33b55f7cb7e7e245323987634f960cf4a6e6bc74\">33b55f7c</a>\n</ul>",
+    "markdown": "Jamal Hartnett pushed 1 commit to branch [master](https://fabrikam-fiber-inc.visualstudio.com/_git/Fabrikam-Fiber-Git/#version=GBmaster) of repository [Fabrikam-Fiber-Git](https://fabrikam-fiber-inc.visualstudio.com/_git/Fabrikam-Fiber-Git/).\n* Fixed bug in web.config file [33b55f7c](https://fabrikam-fiber-inc.visualstudio.com/_git/Fabrikam-Fiber-Git/commit/33b55f7cb7e7e245323987634f960cf4a6e6bc74)"
+  },
+  "resource": {
+    "commits": [
+      {
+        "commitId": "33b55f7cb7e7e245323987634f960cf4a6e6bc74",
+        "author": {
+          "name": "Jamal Hartnett",
+          "email": "fabrikamfiber4@hotmail.com",
+          "date": "2015-02-25T19:01:00Z"
+        },
+        "committer": {
+          "name": "Jamal Hartnett",
+          "email": "fabrikamfiber4@hotmail.com",
+          "date": "2015-02-25T19:01:00Z"
+        },
+        "comment": "Fixed bug in web.config file",
+        "url": "https://fabrikam-fiber-inc.visualstudio.com/_git/Fabrikam-Fiber-Git/commit/33b55f7cb7e7e245323987634f960cf4a6e6bc74"
+      }
+    ],
+    "refUpdates": [
+      {
+        "name": "refs/heads/master",
+        "oldObjectId": "aad331d8d3b131fa9ae03cf5e53965b51942618a",
+        "newObjectId": "33b55f7cb7e7e245323987634f960cf4a6e6bc74"
+      }
+    ],
+    "repository": {
+      "id": "278d5cd2-584d-4b63-824a-2ba458937249",
+      "name": "Fabrikam-Fiber-Git",
+      "url": "https://fabrikam-fiber-inc.visualstudio.com/_apis/git/repositories/278d5cd2-584d-4b63-824a-2ba458937249",
+      "project": {
+        "id": "6ce954b1-ce1f-45d1-b94d-e6bf2464ba2c",
+        "name": "Fabrikam-Fiber-Git",
+        "url": "https://fabrikam-fiber-inc.visualstudio.com/_apis/projects/6ce954b1-ce1f-45d1-b94d-e6bf2464ba2c",
+        "state": "wellFormed"
+      },
+      "defaultBranch": "refs/heads/master",
+      "remoteUrl": "https://fabrikam-fiber-inc.visualstudio.com/_git/Fabrikam-Fiber-Git"
+    },
+    "pushedBy": {
+      "id": "00067FFED5C7AF52@Live.com",
+      "displayName": "Jamal Hartnett",
+      "uniqueName": "Windows Live ID\\fabrikamfiber4@hotmail.com"
+    },
+    "pushId": 14,
+    "date": "2014-05-02T19:17:13.3309587Z",
+    "url": "https://fabrikam-fiber-inc.visualstudio.com/_apis/git/repositories/278d5cd2-584d-4b63-824a-2ba458937249/pushes/14"
+  },
+  "resourceVersion": "3.0-preview.1",
+  "resourceContainers": {
+    "collection": {
+      "id": "c12d0eb8-e382-443b-9f9c-c52cba5014c2",
+      "baseUrl": "https://fabrikam-fiber-inc.visualstudio.com/"
+    },
+    "account": {
+      "id": "f844ec47-a9db-4511-8281-8b63f4eaf94e",
+      "baseUrl": "https://fabrikam-fiber-inc.visualstudio.com/"
+    },
+    "project": {
+      "id": "be9b3917-87e6-42a4-a549-2bc06a7a878f",
+      "baseUrl": "https://fabrikam-fiber-inc.visualstudio.com/"
+    }
+  },
+  "createdDate": "2016-06-10T16:32:21.0569909Z"
+}


### PR DESCRIPTION
This branch is mostly about eliminating technical debt around the determination of collection URI and improving the robustness of the endpoints.  A lot of the decoding is now done more automatically by Jackson deserialization, leading to stronger typing and less chance of error.  This also made it possible to remove some duplicated code that ended up no longer being used.

Manual testing
--------------

1. Crafted an event payload with an **eventType** of `git.pullrequest.merged` such that it contained a value for the upcoming `resourceContainers/collection/baseUrl`, then used `curl` to POST it to the `/team-events/gitPullRequestMerged` endpoint.
    1. A breakpoint I had in the `GitPushEvent#determineCollectionUri()` method allowed me to verify that the `baseUrl` value would be used if it was found.
    2. The triggered build had all the usual behaviour, such as building the exact commit specified, posting the Jenkins build's status to the pull request and commit in TFS/Team Services, etc.
2. Included the event payload from test 1 above as the content of a `team-event` section in a payload that was then POSTed to the `/team-build/build/` endpoint using `curl`.
    1. A breakpoint I had in the `GitPushEvent#determineCollectionUri()` method allowed me to verify that the `baseUrl` value would be used if it was found.
    2. The triggered build also had all the usual behaviour.
3. I also tested without the upcoming `baseUrl` value and confirmed the collection URI could still be "guessed".

Mission accomplished!