### PR TITLE
Withstand all sorts of workspace-related mishaps

### DIFF
--- a/src/main/java/hudson/plugins/tfs/actions/CheckoutAction.java
+++ b/src/main/java/hudson/plugins/tfs/actions/CheckoutAction.java
@@ -90,11 +90,11 @@ public class CheckoutAction {
         final PrintStream logger = listener.getLogger();
 
         final HashSet<String> workspaceNamesToDelete = new HashSet<String>();
-        if (!useUpdate) {
-            workspaceNamesToDelete.add(workspaceName);
-        }
         final String existingWorkspaceName = workspaces.getWorkspaceMapping(localPath);
         if (workspaces.exists(workspaceName)) {
+            if (!useUpdate) {
+                workspaceNamesToDelete.add(workspaceName);
+            }
             if (existingWorkspaceName == null) {
                 logger.println("Warning: Although the server thinks the workspace exists, no mapping was found.");
                 workspaceNamesToDelete.add(workspaceName);

--- a/src/main/java/hudson/plugins/tfs/actions/CheckoutAction.java
+++ b/src/main/java/hudson/plugins/tfs/actions/CheckoutAction.java
@@ -3,14 +3,17 @@ package hudson.plugins.tfs.actions;
 import com.microsoft.tfs.core.clients.versioncontrol.specs.version.DateVersionSpec;
 import com.microsoft.tfs.core.clients.versioncontrol.specs.version.VersionSpec;
 import hudson.FilePath;
+import hudson.model.TaskListener;
 import hudson.plugins.tfs.commands.RemoteChangesetVersionCommand;
 import hudson.plugins.tfs.model.ChangeSet;
+import hudson.plugins.tfs.model.MockableVersionControlClient;
 import hudson.plugins.tfs.model.Project;
 import hudson.plugins.tfs.model.Server;
 import hudson.plugins.tfs.model.Workspace;
 import hudson.plugins.tfs.model.Workspaces;
 
 import java.io.IOException;
+import java.io.PrintStream;
 import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Calendar;
@@ -83,15 +86,33 @@ public class CheckoutAction {
         final Project project = server.getProject(projectPath);
         final FilePath localFolderPath = workspacePath.child(localFolder);
         final String localPath = localFolderPath.getRemote();
+        final TaskListener listener = server.getListener();
+        final PrintStream logger = listener.getLogger();
 
-        if (workspaces.exists(workspaceName) && !useUpdate) {
-            Workspace workspace = workspaces.getWorkspace(workspaceName);
-            workspaces.deleteWorkspace(workspace);
+        boolean shouldDelete = false;
+        if (workspaces.exists(workspaceName)) {
+            boolean localFolderExists = true;
+            final boolean isMapped = workspaces.isMapped(localPath);
+            if (!isMapped) {
+                logger.println("Warning: Although the server thinks the workspace exists, no mapping was found.");
+            }
+            else {
+                localFolderExists = localFolderPath.exists();
+                if (!localFolderExists) {
+                    logger.println("Warning: The local folder is missing.");
+                }
+
+            }
+            if (!localFolderExists || !isMapped || !useUpdate) {
+                shouldDelete = true;
+                Workspace workspace = workspaces.getWorkspace(workspaceName);
+                workspaces.deleteWorkspace(workspace);
+            }
         }
 
         Workspace workspace;
         if (! workspaces.exists(workspaceName)) {
-            if (!useUpdate && localFolderPath.exists()) {
+            if (shouldDelete && localFolderPath.exists()) {
                 localFolderPath.deleteContents();
             }
             final String serverPath = project.getProjectPath();

--- a/src/main/java/hudson/plugins/tfs/actions/CheckoutAction.java
+++ b/src/main/java/hudson/plugins/tfs/actions/CheckoutAction.java
@@ -134,7 +134,7 @@ public class CheckoutAction {
 
         Workspace workspace;
         if (! workspaces.exists(workspaceName)) {
-            if (workspaceNamesToDelete.size() > 0 && localFolderPath.exists()) {
+            if ((!useUpdate || workspaceNamesToDelete.size() > 0) && localFolderPath.exists()) {
                 localFolderPath.deleteContents();
             }
             final String serverPath = project.getProjectPath();

--- a/src/main/java/hudson/plugins/tfs/actions/CheckoutAction.java
+++ b/src/main/java/hudson/plugins/tfs/actions/CheckoutAction.java
@@ -81,6 +81,8 @@ public class CheckoutAction {
             throws IOException, InterruptedException {
         final Workspaces workspaces = server.getWorkspaces();
         final Project project = server.getProject(projectPath);
+        final FilePath localFolderPath = workspacePath.child(localFolder);
+        final String localPath = localFolderPath.getRemote();
 
         if (workspaces.exists(workspaceName) && !useUpdate) {
             Workspace workspace = workspaces.getWorkspace(workspaceName);
@@ -89,12 +91,10 @@ public class CheckoutAction {
 
         Workspace workspace;
         if (! workspaces.exists(workspaceName)) {
-            final FilePath localFolderPath = workspacePath.child(localFolder);
             if (!useUpdate && localFolderPath.exists()) {
                 localFolderPath.deleteContents();
             }
             final String serverPath = project.getProjectPath();
-            final String localPath = localFolderPath.getRemote();
             workspace = workspaces.newWorkspace(workspaceName, serverPath, cloakedPaths, localPath);
         } else {
             workspace = workspaces.getWorkspace(workspaceName);

--- a/src/main/java/hudson/plugins/tfs/actions/CheckoutAction.java
+++ b/src/main/java/hudson/plugins/tfs/actions/CheckoutAction.java
@@ -1,12 +1,5 @@
 package hudson.plugins.tfs.actions;
 
-import java.io.IOException;
-import java.text.ParseException;
-import java.util.ArrayList;
-import java.util.Calendar;
-import java.util.Collection;
-import java.util.List;
-
 import com.microsoft.tfs.core.clients.versioncontrol.specs.version.DateVersionSpec;
 import com.microsoft.tfs.core.clients.versioncontrol.specs.version.VersionSpec;
 import hudson.FilePath;
@@ -16,6 +9,13 @@ import hudson.plugins.tfs.model.Project;
 import hudson.plugins.tfs.model.Server;
 import hudson.plugins.tfs.model.Workspace;
 import hudson.plugins.tfs.model.Workspaces;
+
+import java.io.IOException;
+import java.text.ParseException;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Collection;
+import java.util.List;
 
 public class CheckoutAction {
 
@@ -77,19 +77,19 @@ public class CheckoutAction {
         return result;
     }
 
-    private Project getProject(Server server, FilePath workspacePath)
-			throws IOException, InterruptedException {
-		Workspaces workspaces = server.getWorkspaces();
-        Project project = server.getProject(projectPath);
-        
+    private Project getProject(final Server server, final FilePath workspacePath)
+            throws IOException, InterruptedException {
+        final Workspaces workspaces = server.getWorkspaces();
+        final Project project = server.getProject(projectPath);
+
         if (workspaces.exists(workspaceName) && !useUpdate) {
             Workspace workspace = workspaces.getWorkspace(workspaceName);
             workspaces.deleteWorkspace(workspace);
         }
-        
+
         Workspace workspace;
         if (! workspaces.exists(workspaceName)) {
-            FilePath localFolderPath = workspacePath.child(localFolder);
+            final FilePath localFolderPath = workspacePath.child(localFolder);
             if (!useUpdate && localFolderPath.exists()) {
                 localFolderPath.deleteContents();
             }
@@ -99,7 +99,7 @@ public class CheckoutAction {
         } else {
             workspace = workspaces.getWorkspace(workspaceName);
         }
-		return project;
+        return project;
 	}
 
 }

--- a/src/main/java/hudson/plugins/tfs/commands/AbstractCallableCommand.java
+++ b/src/main/java/hudson/plugins/tfs/commands/AbstractCallableCommand.java
@@ -32,7 +32,7 @@ public abstract class AbstractCallableCommand implements Serializable {
         extraSettings = serverConfig.getExtraSettings();
     }
 
-    static void updateCache(final TFSTeamProjectCollection connection) {
+    protected void updateCache(final TFSTeamProjectCollection connection) {
         final PersistenceStoreProvider persistenceStoreProvider = connection.getPersistenceStoreProvider();
         final Workstation workstation = Workstation.getCurrent(persistenceStoreProvider);
         final VersionControlClient vcc = connection.getVersionControlClient();

--- a/src/main/java/hudson/plugins/tfs/commands/AbstractCallableCommand.java
+++ b/src/main/java/hudson/plugins/tfs/commands/AbstractCallableCommand.java
@@ -1,5 +1,10 @@
 package hudson.plugins.tfs.commands;
 
+import com.microsoft.tfs.core.TFSTeamProjectCollection;
+import com.microsoft.tfs.core.clients.versioncontrol.VersionControlClient;
+import com.microsoft.tfs.core.clients.versioncontrol.VersionControlConstants;
+import com.microsoft.tfs.core.clients.versioncontrol.Workstation;
+import com.microsoft.tfs.core.config.persistence.PersistenceStoreProvider;
 import hudson.model.TaskListener;
 import hudson.plugins.tfs.model.ExtraSettings;
 import hudson.plugins.tfs.model.Server;
@@ -25,6 +30,13 @@ public abstract class AbstractCallableCommand implements Serializable {
         listener = serverConfig.getListener();
         webProxySettings = serverConfig.getWebProxySettings();
         extraSettings = serverConfig.getExtraSettings();
+    }
+
+    static void updateCache(final TFSTeamProjectCollection connection) {
+        final PersistenceStoreProvider persistenceStoreProvider = connection.getPersistenceStoreProvider();
+        final Workstation workstation = Workstation.getCurrent(persistenceStoreProvider);
+        final VersionControlClient vcc = connection.getVersionControlClient();
+        workstation.updateWorkspaceInfoCache(vcc, VersionControlConstants.AUTHENTICATED_USER);
     }
 
     public Server createServer() throws IOException {

--- a/src/main/java/hudson/plugins/tfs/commands/GetWorkspaceMappingCommand.java
+++ b/src/main/java/hudson/plugins/tfs/commands/GetWorkspaceMappingCommand.java
@@ -9,39 +9,43 @@ import hudson.remoting.Callable;
 
 import java.io.PrintStream;
 
-public class IsWorkspaceMappedCommand extends AbstractCallableCommand implements Callable<Boolean, Exception> {
+public class GetWorkspaceMappingCommand extends AbstractCallableCommand implements Callable<String, Exception> {
 
     private static final String CheckingMappingTemplate = "Checking if there exists a mapping for %s...";
+    private static final String FoundResultTemplate = "yes, in workspace '%s'.";
 
     private final String localPath;
 
-    public IsWorkspaceMappedCommand(final ServerConfigurationProvider serverConfig, final String localPath) {
+    public GetWorkspaceMappingCommand(final ServerConfigurationProvider serverConfig, final String localPath) {
         super(serverConfig);
         this.localPath = localPath;
     }
 
     @Override
-    public Callable<Boolean, Exception> getCallable() {
+    public Callable<String, Exception> getCallable() {
         return this;
     }
 
     @Override
-    public Boolean call() throws Exception {
+    public String call() throws Exception {
         final Server server = createServer();
         final MockableVersionControlClient vcc = server.getVersionControlClient();
         final TFSTeamProjectCollection connection = vcc.getConnection();
         updateCache(connection);
         final TaskListener listener = server.getListener();
         final PrintStream logger = listener.getLogger();
-        final String listWorkspacesMessage = String.format(CheckingMappingTemplate, localPath);
-        logger.print(listWorkspacesMessage);
+
+        final String checkingMessage = String.format(CheckingMappingTemplate, localPath);
+        logger.print(checkingMessage);
 
         final Workspace workspace = vcc.tryGetWorkspace(localPath);
         final boolean existsMapping = workspace != null;
+        final String result = existsMapping ? workspace.getName() : null;
 
-        logger.println(existsMapping ? "yes" : "no");
+        final String resultMessage = existsMapping ? String.format(FoundResultTemplate, result) : "no.";
+        logger.println(resultMessage);
 
-        return existsMapping;
+        return result;
     }
 
 }

--- a/src/main/java/hudson/plugins/tfs/commands/IsWorkspaceMappedCommand.java
+++ b/src/main/java/hudson/plugins/tfs/commands/IsWorkspaceMappedCommand.java
@@ -1,11 +1,7 @@
 package hudson.plugins.tfs.commands;
 
 import com.microsoft.tfs.core.TFSTeamProjectCollection;
-import com.microsoft.tfs.core.clients.versioncontrol.VersionControlClient;
-import com.microsoft.tfs.core.clients.versioncontrol.VersionControlConstants;
-import com.microsoft.tfs.core.clients.versioncontrol.Workstation;
 import com.microsoft.tfs.core.clients.versioncontrol.soapextensions.Workspace;
-import com.microsoft.tfs.core.config.persistence.PersistenceStoreProvider;
 import hudson.model.TaskListener;
 import hudson.plugins.tfs.model.MockableVersionControlClient;
 import hudson.plugins.tfs.model.Server;
@@ -48,10 +44,4 @@ public class IsWorkspaceMappedCommand extends AbstractCallableCommand implements
         return existsMapping;
     }
 
-    static void updateCache(final TFSTeamProjectCollection connection) {
-        final PersistenceStoreProvider persistenceStoreProvider = connection.getPersistenceStoreProvider();
-        final Workstation workstation = Workstation.getCurrent(persistenceStoreProvider);
-        final VersionControlClient vcc = connection.getVersionControlClient();
-        workstation.updateWorkspaceInfoCache(vcc, VersionControlConstants.AUTHENTICATED_USER);
-    }
 }

--- a/src/main/java/hudson/plugins/tfs/commands/IsWorkspaceMappedCommand.java
+++ b/src/main/java/hudson/plugins/tfs/commands/IsWorkspaceMappedCommand.java
@@ -1,0 +1,43 @@
+package hudson.plugins.tfs.commands;
+
+import com.microsoft.tfs.core.clients.versioncontrol.soapextensions.Workspace;
+import hudson.model.TaskListener;
+import hudson.plugins.tfs.model.MockableVersionControlClient;
+import hudson.plugins.tfs.model.Server;
+import hudson.remoting.Callable;
+
+import java.io.PrintStream;
+
+public class IsWorkspaceMappedCommand extends AbstractCallableCommand implements Callable<Boolean, Exception> {
+
+    private static final String CheckingMappingTemplate = "Checking if there exists a mapping for %s...";
+
+    private final String localPath;
+
+    public IsWorkspaceMappedCommand(final ServerConfigurationProvider serverConfig, final String localPath) {
+        super(serverConfig);
+        this.localPath = localPath;
+    }
+
+    @Override
+    public Callable<Boolean, Exception> getCallable() {
+        return this;
+    }
+
+    @Override
+    public Boolean call() throws Exception {
+        final Server server = createServer();
+        final MockableVersionControlClient vcc = server.getVersionControlClient();
+        final TaskListener listener = server.getListener();
+        final PrintStream logger = listener.getLogger();
+        final String listWorkspacesMessage = String.format(CheckingMappingTemplate, localPath);
+        logger.print(listWorkspacesMessage);
+
+        final Workspace workspace = vcc.tryGetWorkspace(localPath);
+        final boolean existsMapping = workspace != null;
+
+        logger.println(existsMapping ? "yes" : "no");
+
+        return existsMapping;
+    }
+}

--- a/src/main/java/hudson/plugins/tfs/commands/NewWorkspaceCommand.java
+++ b/src/main/java/hudson/plugins/tfs/commands/NewWorkspaceCommand.java
@@ -1,5 +1,6 @@
 package hudson.plugins.tfs.commands;
 
+import com.microsoft.tfs.core.TFSTeamProjectCollection;
 import com.microsoft.tfs.core.clients.versioncontrol.VersionControlConstants;
 import com.microsoft.tfs.core.clients.versioncontrol.WorkspaceLocation;
 import com.microsoft.tfs.core.clients.versioncontrol.WorkspaceOptions;
@@ -47,6 +48,7 @@ public class NewWorkspaceCommand extends AbstractCallableCommand implements Call
     public Void call() throws IOException {
         final Server server = createServer();
         final MockableVersionControlClient vcc = server.getVersionControlClient();
+        final TFSTeamProjectCollection connection = vcc.getConnection();
         final TaskListener listener = server.getListener();
         final PrintStream logger = listener.getLogger();
         final String userName = server.getUserName();
@@ -73,6 +75,8 @@ public class NewWorkspaceCommand extends AbstractCallableCommand implements Call
             foldersToMap = folderList.toArray(EMPTY_WORKING_FOLDER_ARRAY);
         }
 
+        updateCache(connection);
+        // TODO: we might need to delete a previous workspace that had another name
         vcc.createWorkspace(
                 foldersToMap,
                 workspaceName,

--- a/src/main/java/hudson/plugins/tfs/model/MockableVersionControlClient.java
+++ b/src/main/java/hudson/plugins/tfs/model/MockableVersionControlClient.java
@@ -369,4 +369,21 @@ public class MockableVersionControlClient implements Closable {
         makeSureNotClosed();
         return vcc.removeCachedWorkspace(workspaceName, workspaceOwner);
     }
+
+    /**
+     * This is the same as GetWorkspace() except that it returns null rather
+     * than throwing ItemNotMappedException if the path is not in any known
+     * local workspace.
+     *
+     * @param localPath
+     *        A local path for which a workspace is desired (must not be
+     *        <code>null</code>)
+     * @return A reference to the workspace object that has mapped the specified
+     *         local path or null if the local path is not in a local workspace
+     */
+    public Workspace tryGetWorkspace(final String localPath) {
+        makeSureNotClosed();
+        return vcc.tryGetWorkspace(localPath);
+    }
+
 }

--- a/src/main/java/hudson/plugins/tfs/model/MockableVersionControlClient.java
+++ b/src/main/java/hudson/plugins/tfs/model/MockableVersionControlClient.java
@@ -222,7 +222,7 @@ public class MockableVersionControlClient implements Closable {
      *        end at the most recent version).
      * @param maxCount
      *        the maximum number of changes to return (pass Integer.MAX_VALUE
-     *        for all available values). Must be > 0.
+     *        for all available values). Must be &gt; 0.
      * @param includeFileDetails
      *        true to include individual file change details with the returned
      *        results, false to return only general changeset information.

--- a/src/main/java/hudson/plugins/tfs/model/MockableVersionControlClient.java
+++ b/src/main/java/hudson/plugins/tfs/model/MockableVersionControlClient.java
@@ -2,10 +2,12 @@ package hudson.plugins.tfs.model;
 
 import com.microsoft.tfs.core.TFSTeamProjectCollection;
 import com.microsoft.tfs.core.clients.versioncontrol.VersionControlClient;
+import com.microsoft.tfs.core.clients.versioncontrol.VersionControlConstants;
 import com.microsoft.tfs.core.clients.versioncontrol.WorkspaceLocation;
 import com.microsoft.tfs.core.clients.versioncontrol.WorkspaceOptions;
 import com.microsoft.tfs.core.clients.versioncontrol.WorkspacePermissions;
 import com.microsoft.tfs.core.clients.versioncontrol.Workstation;
+import com.microsoft.tfs.core.clients.versioncontrol.events.EventSource;
 import com.microsoft.tfs.core.clients.versioncontrol.events.VersionControlEventEngine;
 import com.microsoft.tfs.core.clients.versioncontrol.exceptions.ItemNotMappedException;
 import com.microsoft.tfs.core.clients.versioncontrol.exceptions.ServerPathFormatException;
@@ -43,6 +45,20 @@ public class MockableVersionControlClient implements Closable {
         }
     }
 
+    /**
+     * Create or update a label for items in this workspace.
+     *
+     * @param label
+     *        the label to create or update (must not be <code>null</code>)
+     * @param items
+     *        the items to be included in the label creation or update (not
+     *        null).
+     * @param options
+     *        options that affect the processing of the label creation or update
+     *        (must not be <code>null</code> or empty).
+     * @return the label results, null if none were returned. May be empty but
+     *         never null.
+     */
     public LabelResult[] createLabel(
             final VersionControlLabel label,
             final LabelItemSpec[] items,
@@ -51,6 +67,40 @@ public class MockableVersionControlClient implements Closable {
         return vcc.createLabel(label, items, options);
     }
 
+    /**
+     * Create a workspace on the server.
+     * <p>
+     * <!-- Event Origination Info -->
+     * <p>
+     * This method is an <b>core event origination point</b>. The
+     * {@link EventSource} object that accompanies each event fired by this
+     * method describes the execution context (current thread, etc.) when and
+     * where this method was invoked.
+     *
+     * @param workingFolders
+     *        the initial working folder mappings for this workspace. May be
+     *        null, which means no working folders mapped.
+     * @param workspaceName
+     *        the name of the new workspace (must not be <code>null</code>)
+     * @param owner
+     *        the name of the workspace owner (if <code>null</code>, empty, or
+     *        {@link VersionControlConstants#AUTHENTICATED_USER} the currently
+     *        authorized user's name is used)
+     * @param ownerDisplayName
+     *        the display name of the workspace owner (if <code>null</code>,
+     *        empty, or {@link VersionControlConstants#AUTHENTICATED_USER} the
+     *        currently authorized user's display name is used)
+     * @param comment
+     *        an optional comment to be stored with this workspace (may be
+     *        null).
+     * @param location
+     *        where the workspace data is stored (if <code>null</code>, the
+     *        server's default is used)
+     * @param options
+     *        options to use on the newly created workspace (if
+     *        <code>null</code>, the default options are used)
+     * @return the workspace object created by the server.
+     */
     public Workspace createWorkspace(
             final WorkingFolder[] workingFolders,
             final String workspaceName,
@@ -71,6 +121,19 @@ public class MockableVersionControlClient implements Closable {
         );
     }
 
+    /**
+     * Delete a workspace on the server.
+     * <p>
+     * <!-- Event Origination Info -->
+     * <p>
+     * This method is an <b>core event origination point</b>. The
+     * {@link EventSource} object that accompanies each event fired by this
+     * method describes the execution context (current thread, etc.) when and
+     * where this method was invoked.
+     *
+     * @param workspace
+     *        the workspace to delete.
+     */
     public void deleteWorkspace(final Workspace workspace) {
         makeSureNotClosed();
         vcc.deleteWorkspace(workspace);
@@ -81,26 +144,99 @@ public class MockableVersionControlClient implements Closable {
         return vcc.getConnection();
     }
 
+    /**
+     * @return a reference to the EventEngine used by this client. Add (and
+     *         remove) listeners to this event engine instance in order to be
+     *         notified of events. All client events are dispatched through this
+     *         event engine.
+     */
     public VersionControlEventEngine getEventEngine() {
         makeSureNotClosed();
         return vcc.getEventEngine();
     }
 
+    /**
+     * Look up the local workspace for the specified repository, workspaceName
+     * and workspaceOwner combo. This will only ever return anything if the
+     * workspaceOwner matches the current user. This returns the actual
+     * instance, not a copy!
+     */
     public Workspace getLocalWorkspace(final String workspaceName, final String workspaceOwner) {
         makeSureNotClosed();
         return vcc.getLocalWorkspace(workspaceName, workspaceOwner);
     }
 
+    /**
+     * Gets the latest changeset ID from the server.
+     *
+     * @return the changeset ID number of the latest changeset.
+     */
     public int getLatestChangesetID() {
         makeSureNotClosed();
         return vcc.getLatestChangesetID();
     }
 
+    /**
+     * Retrieve the workspace that is mapped to the provided local path. This
+     * method searches all known workspaces on the current computer to identify
+     * a workspace that has explicitly or implicitly mapped the provided local
+     * path. If no workspace is found, this method throws a
+     * ItemNotMappedException.
+     *
+     * @param localPath
+     *        A local path for which a workspace is desired (must not be
+     *        <code>null</code>)
+     * @return A reference to the workspace object that has mapped the specified
+     *         local path
+     * @throws ItemNotMappedException
+     *         if the path is not mapped to any local workspace
+     */
     public Workspace getWorkspace(final String localPath) throws ItemNotMappedException {
         makeSureNotClosed();
         return vcc.getWorkspace(localPath);
     }
 
+    /**
+     * Queries the server for history about an item. History items are returned
+     * as an array of changesets.
+     *
+     * @param serverOrLocalPath
+     *        the server or local path to the server item being queried for its
+     *        history (must not be <code>null</code> or empty).
+     * @param version
+     *        the version of the item to query history for (history older than
+     *        this version will be returned) (must not be <code>null</code>)
+     * @param deletionID
+     *        the deletion ID for the item, if it is a deleted item (pass 0 if
+     *        the item is not deleted).
+     * @param recursion
+     *        whether to query recursively (must not be <code>null</code>)
+     * @param user
+     *        only include historical changes made by this user (pass null to
+     *        retrieve changes made by all users).
+     * @param versionFrom
+     *        the beginning version to query historical changes from (pass null
+     *        to start at the first version).
+     * @param versionTo
+     *        the ending version to query historical changes to (pass null to
+     *        end at the most recent version).
+     * @param maxCount
+     *        the maximum number of changes to return (pass Integer.MAX_VALUE
+     *        for all available values). Must be > 0.
+     * @param includeFileDetails
+     *        true to include individual file change details with the returned
+     *        results, false to return only general changeset information.
+     * @param slotMode
+     *        if true, all items that have occupied the given serverPath (during
+     *        different times) will have their changes returned. If false, only
+     *        the item that matches that path at the given version will have its
+     *        changes returned.
+     * @param sortAscending
+     *        when <code>true</code> gets the top maxCount changes in ascending
+     *        order, when <code>false</code> gets them in descending order
+     * @return the changesets that matched the history query, null if the server
+     *         did not return a changeset array.
+     */
     public Changeset[] queryHistory(
             final String serverOrLocalPath,
             final VersionSpec version,
@@ -131,6 +267,27 @@ public class MockableVersionControlClient implements Closable {
         );
     }
 
+    /**
+     * Query the collection of labels that match the given specifications.
+     *
+     * @param label
+     *        the label name to match (may be null?).
+     * @param scope
+     *        the scope of the label to match (may be null?).
+     * @param owner
+     *        the owner of the label to match (may be null?).
+     * @param includeItemDetails
+     *        if true, details about the labeled items are included in the
+     *        results, otherwise only general label information is included.
+     * @param filterItem
+     *        if not <code>null</code>, only labels containing this item are
+     *        returned.
+     * @param filterItemVersion
+     *        if filterItem was supplied, only labels that include this version
+     *        of the filterItem are returned, otherwise may be null.
+     * @return the label items that matched the query. May be empty but never
+     *         null.
+     */
     public VersionControlLabel[] queryLabels(
             final String label,
             final String scope,
@@ -149,11 +306,51 @@ public class MockableVersionControlClient implements Closable {
         );
     }
 
+    /**
+     * Returns the workspace on the server that matches the given parameters.
+     * Always queries the server immediately; does not check the local workspace
+     * cache.
+     * <p>
+     * Unlike {@link VersionControlClient#queryWorkspaces(String, String, String)}, this method does
+     * not update the local workspace cache when workspaces are queried, because
+     * the workspace's computer is unknown (and the computer must be know to
+     * update the cache).
+     *
+     * @param name
+     *        the workspace name to match, null to match all.
+     * @param owner
+     *        the owner name to match, null to match all. Use
+     *        {@link VersionControlConstants#AUTHENTICATED_USER} to retrieve
+     *        workspaces owned by the currently logged in user.
+     * @return the matching workspace or null if no matching workspace was
+     *         found.
+     */
     public Workspace queryWorkspace(final String name, final String owner) {
         makeSureNotClosed();
         return vcc.queryWorkspace(name, owner);
     }
 
+    /**
+     * Returns all workspaces on the server that match the given parameters.
+     * Always queries the server immediately; does not check the local workspace
+     * cache.
+     *
+     * @param workspaceName
+     *        the workspace name to match, null to match all.
+     * @param workspaceOwner
+     *        the owner name to match, null to match all. Use
+     *        {@link VersionControlConstants#AUTHENTICATED_USER} to retrieve
+     *        workspaces owned by the currently logged in user.
+     * @param computer
+     *        the computer name to match, null to match all. Use
+     *        LocalHost.getShortName() to match workspaces for this computer.
+     * @param permissionsFilter
+     *        find only workspaces matching the given permissions (must not be
+     *        <code>null</code>) Use
+     *        {@link WorkspacePermissions#NONE_OR_NOT_SUPPORTED} to find all
+     *        workspaces.
+     * @return an array of matching workspaces. May be empty but never null.
+     */
     public Workspace[] queryWorkspaces(
             final String workspaceName,
             final String workspaceOwner,

--- a/src/main/java/hudson/plugins/tfs/model/Workspaces.java
+++ b/src/main/java/hudson/plugins/tfs/model/Workspaces.java
@@ -1,6 +1,7 @@
 package hudson.plugins.tfs.model;
 
 import hudson.plugins.tfs.commands.DeleteWorkspaceCommand;
+import hudson.plugins.tfs.commands.IsWorkspaceMappedCommand;
 import hudson.plugins.tfs.commands.ListWorkspacesCommand;
 import hudson.plugins.tfs.commands.NewWorkspaceCommand;
 
@@ -78,6 +79,17 @@ public class Workspaces implements ListWorkspacesCommand.WorkspaceFactory {
      */
     public boolean exists(Workspace workspace) {
         return exists(workspace.getName());
+    }
+
+    /**
+     * Returns whether there exists a workspace mapping for the given localPath.
+     * @param localPath the path where TFVC files would be downloaded
+     * @return {@code true} if there exists a mapping; {@code false} otherwise.
+     */
+    public boolean isMapped(final String localPath) {
+        final IsWorkspaceMappedCommand command = new IsWorkspaceMappedCommand(server, localPath);
+        final Boolean result = server.execute(command.getCallable());
+        return result;
     }
 
     /**

--- a/src/main/java/hudson/plugins/tfs/model/Workspaces.java
+++ b/src/main/java/hudson/plugins/tfs/model/Workspaces.java
@@ -1,7 +1,7 @@
 package hudson.plugins.tfs.model;
 
 import hudson.plugins.tfs.commands.DeleteWorkspaceCommand;
-import hudson.plugins.tfs.commands.IsWorkspaceMappedCommand;
+import hudson.plugins.tfs.commands.GetWorkspaceMappingCommand;
 import hudson.plugins.tfs.commands.ListWorkspacesCommand;
 import hudson.plugins.tfs.commands.NewWorkspaceCommand;
 
@@ -82,13 +82,16 @@ public class Workspaces implements ListWorkspacesCommand.WorkspaceFactory {
     }
 
     /**
-     * Returns whether there exists a workspace mapping for the given localPath.
+     * Returns the name of the workspace that mapped at the given localPath,
+     * if applicable.
+     *
      * @param localPath the path where TFVC files would be downloaded
-     * @return {@code true} if there exists a mapping; {@code false} otherwise.
+     * @return the workspace name if there exists a mapping;
+     *          {@code null} otherwise.
      */
-    public boolean isMapped(final String localPath) {
-        final IsWorkspaceMappedCommand command = new IsWorkspaceMappedCommand(server, localPath);
-        final Boolean result = server.execute(command.getCallable());
+    public String getWorkspaceMapping(final String localPath) {
+        final GetWorkspaceMappingCommand command = new GetWorkspaceMappingCommand(server, localPath);
+        final String result = server.execute(command.getCallable());
         return result;
     }
 

--- a/src/test/java/hudson/plugins/tfs/actions/CheckoutActionTest.java
+++ b/src/test/java/hudson/plugins/tfs/actions/CheckoutActionTest.java
@@ -305,6 +305,7 @@ public class CheckoutActionTest {
         verify(workspaces).getWorkspace("workspace");
         verify(workspaces).deleteWorkspace(workspace);
         verify(workspaces).newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class));
+        verify(workspaces).getWorkspaceMapping(anyString());
         verifyNoMoreInteractions(workspaces);
     }
     
@@ -324,6 +325,7 @@ public class CheckoutActionTest {
         verify(workspaces).getWorkspace("workspace");
         verify(workspaces).deleteWorkspace(workspace);
         verify(workspaces).newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class));
+        verify(workspaces).getWorkspaceMapping(anyString());
         verifyNoMoreInteractions(workspaces);
     }
     
@@ -339,6 +341,7 @@ public class CheckoutActionTest {
         verify(server).getWorkspaces();
         verify(workspaces, times(2)).exists("workspace");
         verify(workspaces).getWorkspace("workspace");
+        verify(workspaces).getWorkspaceMapping(anyString());
         verifyNoMoreInteractions(workspaces);
     }
     
@@ -354,6 +357,7 @@ public class CheckoutActionTest {
         verify(server).getWorkspaces();
         verify(workspaces, times(2)).exists("workspace");
         verify(workspaces).getWorkspace("workspace");
+        verify(workspaces).getWorkspaceMapping(anyString());
         verifyNoMoreInteractions(workspaces);
     }
     
@@ -370,6 +374,7 @@ public class CheckoutActionTest {
         verify(server).getWorkspaces();
         verify(workspaces, times(2)).exists("workspace");
         verify(workspaces).newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class));
+        verify(workspaces).getWorkspaceMapping(anyString());
         verifyNoMoreInteractions(workspaces);
     }
     
@@ -386,6 +391,7 @@ public class CheckoutActionTest {
         verify(server).getWorkspaces();
         verify(workspaces, times(2)).exists("workspace");
         verify(workspaces).newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class));
+        verify(workspaces).getWorkspaceMapping(anyString());
         verifyNoMoreInteractions(workspaces);
     }
     

--- a/src/test/java/hudson/plugins/tfs/actions/CheckoutActionTest.java
+++ b/src/test/java/hudson/plugins/tfs/actions/CheckoutActionTest.java
@@ -12,6 +12,7 @@ import java.util.List;
 import com.microsoft.tfs.core.clients.versioncontrol.specs.version.DateVersionSpec;
 import com.microsoft.tfs.core.clients.versioncontrol.specs.version.VersionSpec;
 import hudson.FilePath;
+import hudson.model.TaskListener;
 import hudson.plugins.tfs.Util;
 import hudson.plugins.tfs.model.ChangeSet;
 import hudson.plugins.tfs.model.Project;
@@ -38,6 +39,7 @@ public class CheckoutActionTest {
     private @Mock Workspaces workspaces;
     private @Mock Workspace workspace;
     private @Mock Project project;
+    private @Mock TaskListener taskListener;
 
     @Before public void setup() throws Exception {
         MockitoAnnotations.initMocks(this);
@@ -49,11 +51,19 @@ public class CheckoutActionTest {
             hudsonWs.deleteRecursive();
         }
     }
+
+    private void prepareCommonMocks() {
+        when(server.getWorkspaces()).thenReturn(workspaces);
+        when(server.getProject("project")).thenReturn(project);
+
+        when(server.getListener()).thenReturn(taskListener);
+        when(taskListener.getLogger()).thenReturn(System.out);
+        when(workspaces.getWorkspaceMapping(anyString())).thenReturn("workspace");
+    }
     
     @Test
     public void assertFirstCheckoutBySingleVersionSpecNotUsingUpdate() throws Exception {
-    	when(server.getWorkspaces()).thenReturn(workspaces);
-    	when(server.getProject("project")).thenReturn(project);
+        prepareCommonMocks();
         when(project.getProjectPath()).thenReturn("project");
     	when(workspaces.exists("workspace")).thenReturn(true).thenReturn(false);
         when(workspaces.newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class))).thenReturn(workspace);
@@ -68,8 +78,7 @@ public class CheckoutActionTest {
     
     @Test
     public void assertFirstCheckoutNotUsingUpdate() throws Exception {
-        when(server.getWorkspaces()).thenReturn(workspaces);
-        when(server.getProject("project")).thenReturn(project);
+        prepareCommonMocks();
         when(project.getProjectPath()).thenReturn("project");
         when(workspaces.exists("workspace")).thenReturn(true).thenReturn(false);
         when(workspaces.newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class))).thenReturn(workspace);
@@ -84,8 +93,7 @@ public class CheckoutActionTest {
 
     @Test
     public void assertFirstCheckoutBySingleVersionSpecUsingUpdate() throws Exception {
-        when(server.getWorkspaces()).thenReturn(workspaces);
-        when(server.getProject("project")).thenReturn(project);
+        prepareCommonMocks();
         when(project.getProjectPath()).thenReturn("project");
         when(workspaces.exists(new Workspace("workspace"))).thenReturn(false);
         when(workspaces.newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class))).thenReturn(workspace);
@@ -99,8 +107,7 @@ public class CheckoutActionTest {
 
     @Test
     public void assertFirstCheckoutUsingUpdate() throws Exception {
-    	when(server.getWorkspaces()).thenReturn(workspaces);
-    	when(server.getProject("project")).thenReturn(project);
+        prepareCommonMocks();
         when(project.getProjectPath()).thenReturn("project");
     	when(workspaces.exists(new Workspace("workspace"))).thenReturn(false);
         when(workspaces.newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class))).thenReturn(workspace);
@@ -114,8 +121,7 @@ public class CheckoutActionTest {
     
     @Test
     public void assertSecondCheckoutBySingleVersionSpecUsingUpdate() throws Exception {
-        when(server.getWorkspaces()).thenReturn(workspaces);
-        when(server.getProject("project")).thenReturn(project);
+        prepareCommonMocks();
         when(workspaces.exists("workspace")).thenReturn(true);
         when(workspaces.getWorkspace("workspace")).thenReturn(workspace);
         when(workspace.getComputer()).thenReturn("LocalComputer");
@@ -129,8 +135,7 @@ public class CheckoutActionTest {
     
     @Test
     public void assertSecondCheckoutUsingUpdate() throws Exception {
-        when(server.getWorkspaces()).thenReturn(workspaces);
-        when(server.getProject("project")).thenReturn(project);
+        prepareCommonMocks();
         when(workspaces.exists("workspace")).thenReturn(true);
         when(workspaces.getWorkspace("workspace")).thenReturn(workspace);
         when(workspace.getComputer()).thenReturn("LocalComputer");
@@ -144,8 +149,7 @@ public class CheckoutActionTest {
 
     @Test
     public void assertSecondCheckoutBySingleVersionSpecNotUsingUpdate() throws Exception {
-        when(server.getWorkspaces()).thenReturn(workspaces);
-        when(server.getProject("project")).thenReturn(project);
+        prepareCommonMocks();
         when(project.getProjectPath()).thenReturn("project");
         when(workspaces.exists("workspace")).thenReturn(true).thenReturn(false);
         when(workspaces.newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class))).thenReturn(workspace);
@@ -160,8 +164,7 @@ public class CheckoutActionTest {
 
     @Test
     public void assertSecondCheckoutNotUsingUpdate() throws Exception {
-        when(server.getWorkspaces()).thenReturn(workspaces);
-        when(server.getProject("project")).thenReturn(project);
+        prepareCommonMocks();
         when(project.getProjectPath()).thenReturn("project");
         when(workspaces.exists("workspace")).thenReturn(true).thenReturn(false);
         when(workspaces.newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class))).thenReturn(workspace);
@@ -176,8 +179,7 @@ public class CheckoutActionTest {
    
     @Test
     public void assertDetailedHistoryIsNotRetrievedInFirstBuildCheckingOutByLabel() throws Exception {
-        when(server.getWorkspaces()).thenReturn(workspaces);
-        when(server.getProject("project")).thenReturn(project);
+        prepareCommonMocks();
         when(workspaces.exists("workspace")).thenReturn(true);
         when(workspaces.getWorkspace("workspace")).thenReturn(workspace);
         when(workspace.getComputer()).thenReturn("LocalComputer");
@@ -189,8 +191,7 @@ public class CheckoutActionTest {
    
     @Test
     public void assertDetailedHistoryIsNotRetrievedInFirstBuild() throws Exception {
-        when(server.getWorkspaces()).thenReturn(workspaces);
-        when(server.getProject("project")).thenReturn(project);
+        prepareCommonMocks();
         when(workspaces.exists("workspace")).thenReturn(true);
         when(workspaces.getWorkspace("workspace")).thenReturn(workspace);
         when(workspace.getComputer()).thenReturn("LocalComputer");
@@ -203,8 +204,7 @@ public class CheckoutActionTest {
     @Test
     public void assertDetailedHistoryIsRetrievedInSecondBuildCheckingOutByLabel() throws Exception {
         List<ChangeSet> list = new ArrayList<ChangeSet>();
-        when(server.getWorkspaces()).thenReturn(workspaces);
-        when(server.getProject("project")).thenReturn(project);
+        prepareCommonMocks();
         when(workspaces.exists("workspace")).thenReturn(true);
         when(workspaces.getWorkspace("workspace")).thenReturn(workspace);
         when(workspace.getComputer()).thenReturn("LocalComputer");
@@ -220,8 +220,7 @@ public class CheckoutActionTest {
     @Test
     public void assertDetailedHistoryIsRetrievedInSecondBuild() throws Exception {
         List<ChangeSet> list = new ArrayList<ChangeSet>();
-        when(server.getWorkspaces()).thenReturn(workspaces);
-        when(server.getProject("project")).thenReturn(project);
+        prepareCommonMocks();
         when(workspaces.exists("workspace")).thenReturn(true);
         when(workspaces.getWorkspace("workspace")).thenReturn(workspace);
         when(workspace.getComputer()).thenReturn("LocalComputer");
@@ -244,8 +243,7 @@ public class CheckoutActionTest {
         tfsWs.mkdirs();
         tfsWs.createTempFile("temp", "txt");
         
-        when(server.getWorkspaces()).thenReturn(workspaces);
-        when(server.getProject("project")).thenReturn(project);
+        prepareCommonMocks();
         when(workspaces.exists(new Workspace("workspace"))).thenReturn(false);
         when(workspaces.newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class))).thenReturn(workspace);
         
@@ -263,8 +261,7 @@ public class CheckoutActionTest {
         tfsWs.mkdirs();
         tfsWs.createTempFile("temp", "txt");
         
-        when(server.getWorkspaces()).thenReturn(workspaces);
-        when(server.getProject("project")).thenReturn(project);
+        prepareCommonMocks();
         when(workspaces.exists(new Workspace("workspace"))).thenReturn(false);
         when(workspaces.newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class))).thenReturn(workspace);
         
@@ -281,8 +278,7 @@ public class CheckoutActionTest {
         tfsWs.mkdirs();
         tfsWs.createTempFile("temp", "txt");
         
-        when(server.getWorkspaces()).thenReturn(workspaces);
-        when(server.getProject("project")).thenReturn(project);
+        prepareCommonMocks();
         when(workspaces.exists("workspace")).thenReturn(true);
         when(workspaces.getWorkspace("workspace")).thenReturn(workspace);
         when(workspace.getComputer()).thenReturn("LocalComputer");
@@ -296,10 +292,9 @@ public class CheckoutActionTest {
     @Bug(3882)
     @Test
     public void assertCheckoutBySingleVersionSpecDeletesWorkspaceAtStartIfNotUsingUpdate() throws Exception {
-        when(server.getWorkspaces()).thenReturn(workspaces);
+        prepareCommonMocks();
         when(workspaces.exists("workspace")).thenReturn(true).thenReturn(false);
         when(workspaces.getWorkspace("workspace")).thenReturn(workspace);
-        when(server.getProject("project")).thenReturn(project);
         when(project.getProjectPath()).thenReturn("project");
         when(workspaces.newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class))).thenReturn(workspace);
         
@@ -316,10 +311,9 @@ public class CheckoutActionTest {
     @Bug(3882)
     @Test
     public void assertCheckoutDeletesWorkspaceAtStartIfNotUsingUpdate() throws Exception {
-        when(server.getWorkspaces()).thenReturn(workspaces);
+        prepareCommonMocks();
         when(workspaces.exists("workspace")).thenReturn(true).thenReturn(false);
         when(workspaces.getWorkspace("workspace")).thenReturn(workspace);
-        when(server.getProject("project")).thenReturn(project);
         when(project.getProjectPath()).thenReturn("project");
         when(workspaces.newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class))).thenReturn(workspace);
         
@@ -336,10 +330,9 @@ public class CheckoutActionTest {
     @Bug(3882)
     @Test
     public void assertCheckoutDoesNotDeleteWorkspaceAtStartIfUsingUpdate() throws Exception {
-        when(server.getWorkspaces()).thenReturn(workspaces);
+        prepareCommonMocks();
         when(workspaces.exists("workspace")).thenReturn(true).thenReturn(true);
         when(workspaces.getWorkspace("workspace")).thenReturn(workspace);
-        when(server.getProject("project")).thenReturn(project);
         
         new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, ".", true).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
         
@@ -352,10 +345,9 @@ public class CheckoutActionTest {
     @Bug(3882)
     @Test
     public void assertCheckoutBySingleVersionSpecDoesNotDeleteWorkspaceAtStartIfUsingUpdate() throws Exception {
-        when(server.getWorkspaces()).thenReturn(workspaces);
+        prepareCommonMocks();
         when(workspaces.exists("workspace")).thenReturn(true).thenReturn(true);
         when(workspaces.getWorkspace("workspace")).thenReturn(workspace);
-        when(server.getProject("project")).thenReturn(project);
         
         new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, ".", true).checkoutBySingleVersionSpec(server, hudsonWs, MY_LABEL);
         
@@ -368,10 +360,9 @@ public class CheckoutActionTest {
     @Bug(3882)
     @Test
     public void assertCheckoutDoesNotDeleteWorkspaceIfNotUsingUpdateAndThereIsNoWorkspace() throws Exception {
-        when(server.getWorkspaces()).thenReturn(workspaces);
+        prepareCommonMocks();
         when(workspaces.exists("workspace")).thenReturn(false).thenReturn(false);
         when(workspaces.newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class))).thenReturn(workspace);
-        when(server.getProject("project")).thenReturn(project);
         when(project.getProjectPath()).thenReturn("project");
 
         new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, ".", false).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
@@ -385,10 +376,9 @@ public class CheckoutActionTest {
     @Bug(3882)
     @Test
     public void assertCheckoutBySingleVersionSpecDoesNotDeleteWorkspaceIfNotUsingUpdateAndThereIsNoWorkspace() throws Exception {
-        when(server.getWorkspaces()).thenReturn(workspaces);
+        prepareCommonMocks();
         when(workspaces.exists("workspace")).thenReturn(false).thenReturn(false);
         when(workspaces.newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class))).thenReturn(workspace);
-        when(server.getProject("project")).thenReturn(project);
         when(project.getProjectPath()).thenReturn("project");
 
         new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, ".", false).checkoutBySingleVersionSpec(server, hudsonWs, MY_LABEL);
@@ -403,8 +393,7 @@ public class CheckoutActionTest {
     @Test
     public void assertCheckoutOnlyRetrievesChangesToTheStartTimestampForCurrentBuild() throws Exception {
         List<ChangeSet> list = new ArrayList<ChangeSet>();
-        when(server.getWorkspaces()).thenReturn(workspaces);
-        when(server.getProject("project")).thenReturn(project);
+        prepareCommonMocks();
         when(workspaces.exists("workspace")).thenReturn(true);
         when(workspaces.getWorkspace("workspace")).thenReturn(workspace);
         when(workspace.getComputer()).thenReturn("LocalComputer");

--- a/src/test/java/hudson/plugins/tfs/commands/NewWorkspaceCommandTest.java
+++ b/src/test/java/hudson/plugins/tfs/commands/NewWorkspaceCommandTest.java
@@ -1,5 +1,6 @@
 package hudson.plugins.tfs.commands;
 
+import com.microsoft.tfs.core.TFSTeamProjectCollection;
 import com.microsoft.tfs.core.clients.versioncontrol.WorkspaceLocation;
 import com.microsoft.tfs.core.clients.versioncontrol.WorkspaceOptions;
 import com.microsoft.tfs.core.clients.versioncontrol.soapextensions.WorkingFolder;
@@ -32,6 +33,11 @@ public class NewWorkspaceCommandTest extends AbstractCallableCommandTest {
             public Server createServer() {
                 return server;
             }
+
+            @Override
+            protected void updateCache(final TFSTeamProjectCollection connection) {
+                // no-op for tests
+            }
         };
         final Callable<Void, Exception> callable = command.getCallable();
 
@@ -58,6 +64,11 @@ public class NewWorkspaceCommandTest extends AbstractCallableCommandTest {
             @Override
             public Server createServer() {
                 return server;
+            }
+
+            @Override
+            protected void updateCache(final TFSTeamProjectCollection connection) {
+                // no-op for tests
             }
         };
         final Callable<Void, Exception> callable = command.getCallable();


### PR DESCRIPTION
A number of defects related to workspace mappings were fixed and the builds can now withstand all sorts of things that used to break the build, such as:
1. Corrupted configuration
2. Unmapped folder
3. Deleted workspace
4. Renamed workspace
5. Outdated configuration cache