### PR TITLE
Improve support for proxy servers (including those that need authentication)

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,9 +203,9 @@ Now, the next time you want to queue a build, you will need to provide a value f
 
 ## Proxy server support (New since version 4.1.0)
 
-In the event Jenkins is deployed on a network with no direct access to other networks (such as the internet), the TFS plugin now supports connecting through _unauthenticated_ proxy servers.
+In the event Jenkins is deployed on a network with no direct access to other networks (such as the internet), the TFS plugin now supports connecting through proxy servers.
 
-> :information_source: Support for proxy servers requiring authentication is planned. :information_source:
+> :information_source: Support for proxy servers requiring authentication was added in version 5.1.0. :information_source:
 
 Follow the instructions at [JenkinsBehindProxy](https://wiki.jenkins-ci.org/display/JENKINS/JenkinsBehindProxy) to configure Jenkins' use of a proxy server, which the TFS plugin also uses.
 

--- a/src/main/java/hudson/plugins/tfs/model/ModernConnectionAdvisor.java
+++ b/src/main/java/hudson/plugins/tfs/model/ModernConnectionAdvisor.java
@@ -8,18 +8,17 @@ import com.microsoft.tfs.core.config.DefaultConnectionAdvisor;
 import com.microsoft.tfs.core.config.httpclient.HTTPClientFactory;
 import com.microsoft.tfs.core.config.persistence.DefaultPersistenceStoreProvider;
 import com.microsoft.tfs.core.config.persistence.PersistenceStoreProvider;
-import com.microsoft.tfs.core.httpclient.ProxyHost;
 
 public class ModernConnectionAdvisor extends DefaultConnectionAdvisor {
 
-    private final ProxyHost proxyHost;
+    private final ProxyHostEx proxyHost;
     private final PersistenceStoreProvider persistenceStoreProvider;
 
-    public ModernConnectionAdvisor(final ProxyHost proxyHost) {
+    public ModernConnectionAdvisor(final ProxyHostEx proxyHost) {
         this(proxyHost, null);
     }
 
-    public ModernConnectionAdvisor(final ProxyHost proxyHost, final PersistenceStoreProvider persistenceStoreProvider) {
+    public ModernConnectionAdvisor(final ProxyHostEx proxyHost, final PersistenceStoreProvider persistenceStoreProvider) {
         super(Locale.getDefault(), TimeZone.getDefault());
         this.proxyHost = proxyHost;
         this.persistenceStoreProvider = persistenceStoreProvider;

--- a/src/main/java/hudson/plugins/tfs/model/ModernHTTPClientFactory.java
+++ b/src/main/java/hudson/plugins/tfs/model/ModernHTTPClientFactory.java
@@ -2,9 +2,13 @@ package hudson.plugins.tfs.model;
 
 import com.microsoft.tfs.core.config.ConnectionInstanceData;
 import com.microsoft.tfs.core.config.httpclient.DefaultHTTPClientFactory;
+import com.microsoft.tfs.core.httpclient.DefaultNTCredentials;
 import com.microsoft.tfs.core.httpclient.HostConfiguration;
 import com.microsoft.tfs.core.httpclient.HttpClient;
 import com.microsoft.tfs.core.httpclient.HttpState;
+import com.microsoft.tfs.core.httpclient.UsernamePasswordCredentials;
+import com.microsoft.tfs.core.httpclient.auth.AuthScope;
+import hudson.util.Secret;
 
 public class ModernHTTPClientFactory extends DefaultHTTPClientFactory {
 
@@ -22,5 +26,20 @@ public class ModernHTTPClientFactory extends DefaultHTTPClientFactory {
     @Override
     public void configureClientProxy(final HttpClient httpClient, final HostConfiguration hostConfiguration,final HttpState httpState, final ConnectionInstanceData connectionInstanceData) {
         hostConfiguration.setProxyHost(proxyHost);
+
+        final String proxyUser = proxyHost.getProxyUser();
+        final Secret proxySecret = proxyHost.getProxySecret();
+        if (proxyUser != null && proxySecret != null) {
+            httpState.setProxyCredentials(
+                    AuthScope.ANY,
+                    new UsernamePasswordCredentials(proxyUser, proxySecret.getPlainText())
+            );
+        }
+        else {
+            httpState.setProxyCredentials(
+                    AuthScope.ANY,
+                    new DefaultNTCredentials()
+            );
+        }
     }
 }

--- a/src/main/java/hudson/plugins/tfs/model/ModernHTTPClientFactory.java
+++ b/src/main/java/hudson/plugins/tfs/model/ModernHTTPClientFactory.java
@@ -27,19 +27,21 @@ public class ModernHTTPClientFactory extends DefaultHTTPClientFactory {
     public void configureClientProxy(final HttpClient httpClient, final HostConfiguration hostConfiguration,final HttpState httpState, final ConnectionInstanceData connectionInstanceData) {
         hostConfiguration.setProxyHost(proxyHost);
 
-        final String proxyUser = proxyHost.getProxyUser();
-        final Secret proxySecret = proxyHost.getProxySecret();
-        if (proxyUser != null && proxySecret != null) {
-            httpState.setProxyCredentials(
-                    AuthScope.ANY,
-                    new UsernamePasswordCredentials(proxyUser, proxySecret.getPlainText())
-            );
-        }
-        else {
-            httpState.setProxyCredentials(
-                    AuthScope.ANY,
-                    new DefaultNTCredentials()
-            );
+        if (proxyHost != null) {
+            final String proxyUser = proxyHost.getProxyUser();
+            final Secret proxySecret = proxyHost.getProxySecret();
+            if (proxyUser != null && proxySecret != null) {
+                httpState.setProxyCredentials(
+                        AuthScope.ANY,
+                        new UsernamePasswordCredentials(proxyUser, proxySecret.getPlainText())
+                );
+            }
+            else {
+                httpState.setProxyCredentials(
+                        AuthScope.ANY,
+                        new DefaultNTCredentials()
+                );
+            }
         }
     }
 }

--- a/src/main/java/hudson/plugins/tfs/model/ModernHTTPClientFactory.java
+++ b/src/main/java/hudson/plugins/tfs/model/ModernHTTPClientFactory.java
@@ -5,17 +5,16 @@ import com.microsoft.tfs.core.config.httpclient.DefaultHTTPClientFactory;
 import com.microsoft.tfs.core.httpclient.HostConfiguration;
 import com.microsoft.tfs.core.httpclient.HttpClient;
 import com.microsoft.tfs.core.httpclient.HttpState;
-import com.microsoft.tfs.core.httpclient.ProxyHost;
 
 public class ModernHTTPClientFactory extends DefaultHTTPClientFactory {
 
-    private final ProxyHost proxyHost;
+    private final ProxyHostEx proxyHost;
 
     public ModernHTTPClientFactory(final ConnectionInstanceData connectionInstanceData) {
         this(connectionInstanceData,  null);
     }
 
-    public ModernHTTPClientFactory(final ConnectionInstanceData connectionInstanceData, final ProxyHost proxyHost) {
+    public ModernHTTPClientFactory(final ConnectionInstanceData connectionInstanceData, final ProxyHostEx proxyHost) {
         super(connectionInstanceData);
         this.proxyHost = proxyHost;
     }

--- a/src/main/java/hudson/plugins/tfs/model/ProxyHostEx.java
+++ b/src/main/java/hudson/plugins/tfs/model/ProxyHostEx.java
@@ -1,0 +1,23 @@
+package hudson.plugins.tfs.model;
+
+import hudson.util.Secret;
+
+public class ProxyHostEx extends com.microsoft.tfs.core.httpclient.ProxyHost {
+
+    private final String proxyUser;
+    private final Secret proxySecret;
+
+    public ProxyHostEx(final String hostname, final int port, final String proxyUser, final Secret proxySecret) {
+        super(hostname, port);
+        this.proxyUser = proxyUser;
+        this.proxySecret = proxySecret;
+    }
+
+    public String getProxyUser() {
+        return proxyUser;
+    }
+
+    public Secret getProxySecret() {
+        return proxySecret;
+    }
+}

--- a/src/main/java/hudson/plugins/tfs/model/Server.java
+++ b/src/main/java/hudson/plugins/tfs/model/Server.java
@@ -10,7 +10,6 @@ import com.microsoft.tfs.core.config.persistence.DefaultPersistenceStoreProvider
 import com.microsoft.tfs.core.config.persistence.PersistenceStoreProvider;
 import com.microsoft.tfs.core.httpclient.Credentials;
 import com.microsoft.tfs.core.httpclient.DefaultNTCredentials;
-import com.microsoft.tfs.core.httpclient.ProxyHost;
 import com.microsoft.tfs.core.httpclient.UsernamePasswordCredentials;
 import com.microsoft.tfs.core.util.CredentialsUtils;
 import com.microsoft.tfs.core.util.URIUtils;
@@ -86,7 +85,7 @@ public class Server implements ServerConfigurationProvider, Closable {
                 this.webProxySettings = new WebProxySettings(proxyConfiguration);
             }
             final String host = uri.getHost();
-            final ProxyHost proxyHost = this.webProxySettings.toProxyHost(host);
+            final ProxyHostEx proxyHost = this.webProxySettings.toProxyHost(host);
 
             if (extraSettings != null) {
                 this.extraSettings = extraSettings;

--- a/src/main/java/hudson/plugins/tfs/model/WebProxySettings.java
+++ b/src/main/java/hudson/plugins/tfs/model/WebProxySettings.java
@@ -1,6 +1,5 @@
 package hudson.plugins.tfs.model;
 
-import com.microsoft.tfs.core.httpclient.ProxyHost;
 import hudson.ProxyConfiguration;
 import hudson.util.Secret;
 
@@ -11,7 +10,7 @@ import java.util.List;
 import java.util.regex.Pattern;
 
 /**
- * A {@link Serializable} adapter between {@link ProxyConfiguration} and {@link ProxyHost}.
+ * A {@link Serializable} adapter between {@link ProxyConfiguration} and {@link ProxyHostEx}.
  */
 public class WebProxySettings implements Serializable {
     private static final long serialVersionUID = 401L;
@@ -80,20 +79,19 @@ public class WebProxySettings implements Serializable {
     }
 
     /**
-     * Initialize a {@link ProxyHost} from this {@link WebProxySettings} for the provided hostToProxy.
+     * Initialize a {@link ProxyHostEx} from this {@link WebProxySettings} for the provided hostToProxy.
      * May return null, which either means there is no proxy server configured or it does not apply
      * to the provided hostToProxy.
      *
      * @param hostToProxy the name of the host for which proxying is considered.
-     * @return an instance of {@link ProxyHost} or {@code null} if no proxy is to be used.
+     * @return an instance of {@link ProxyHostEx} or {@code null} if no proxy is to be used.
      */
-    public ProxyHost toProxyHost(final String hostToProxy) {
-        final ProxyHost proxyHost;
+    public ProxyHostEx toProxyHost(final String hostToProxy) {
+        final ProxyHostEx proxyHost;
         if (this.hostName != null) {
             final boolean shouldProxy = shouldProxy(hostToProxy, noProxyHostPatterns);
             if (shouldProxy) {
-                // TODO: The version of httpclient used by the TFS SDK does not support proxy auth
-                proxyHost = new ProxyHost(hostName, port);
+                proxyHost = new ProxyHostEx(hostName, port, proxyUser, proxySecret);
             } else {
                 proxyHost = null;
             }


### PR DESCRIPTION
This pull request passes along the `User name` and `Password` values, if supplied, from the Jenkins **HTTP Proxy Configuration** to the HTTP client factory used by the TFS SDK for Java.

This pull request also adds proxy support (authenticated or otherwise) to the `TeamRestClient`, which is used for further integration with TFS/Team Services.

Manual testing
--------------

1. Installed Squid and enabled authentication.
2. Configured Jenkins to use the Squid instance, minus the credentials.
    1. The `Validate Proxy` button correctly showed a result of HTTP 407.
    2. Queued a TFVC-based build against a repo hosted in Team Services.
        1. Confirmed that it was attempting to use the proxy server and failing with HTTP 407.
    3. Triggered Team Services Git-based build via the `/team-build/` endpoint for a pull request event.
        1. The build failed to retrieve source code from the Git repository (HTTP 407).
        2. The integration was unable to update Team Services (HTTP 407).
3. Configured Jenkins to use the Squid instance, this time with credentials.
    1. The `Validate Proxy` button correctly showed a result of HTTP 200.
    2. Queued a TFVC-based build against a repo hosted in Team Services.
        1. The build was able to download the source code.
    3. Triggered Team Services Git-based build via the `/team-build/` endpoint for a pull request event.
        1. The build retrieved source code from the Git repository.
        2. The integration was able to update Team Services.

Mission accomplished!