### PR TITLE
Converted ERROR into NOTICE & improved wording

### DIFF
--- a/tfs/src/main/java/hudson/plugins/tfs/TeamCompletedStatusPostBuildAction.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/TeamCompletedStatusPostBuildAction.java
@@ -4,11 +4,13 @@ import hudson.Extension;
 import hudson.FilePath;
 import hudson.Launcher;
 import hudson.model.AbstractProject;
+import hudson.model.Descriptor;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.plugins.tfs.util.TeamStatus;
 import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.BuildStepMonitor;
+import hudson.tasks.Builder;
 import hudson.tasks.Notifier;
 import hudson.tasks.Publisher;
 import jenkins.tasks.SimpleBuildStep;
@@ -35,7 +37,7 @@ public class TeamCompletedStatusPostBuildAction extends Notifier implements Simp
             @Nonnull final TaskListener listener
     ) throws InterruptedException, IOException {
         try {
-            TeamStatus.createFromRun(run, listener);
+            TeamStatus.createFromRun(run, listener, getDisplayName());
         }
         catch (final IllegalArgumentException e) {
             listener.error(e.getMessage());
@@ -43,6 +45,11 @@ public class TeamCompletedStatusPostBuildAction extends Notifier implements Simp
         catch (final Exception e) {
             e.printStackTrace(listener.error("Error while trying to update completion status in TFS/Team Services"));
         }
+    }
+
+    String getDisplayName() {
+        final Descriptor<Builder> descriptor = getDescriptor();
+        return descriptor.getDisplayName();
     }
 
     @Override

--- a/tfs/src/main/java/hudson/plugins/tfs/TeamPendingStatusBuildStep.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/TeamPendingStatusBuildStep.java
@@ -4,6 +4,7 @@ import hudson.Extension;
 import hudson.FilePath;
 import hudson.Launcher;
 import hudson.model.AbstractProject;
+import hudson.model.Descriptor;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.plugins.tfs.util.TeamStatus;
@@ -33,7 +34,7 @@ public class TeamPendingStatusBuildStep extends Builder implements SimpleBuildSt
             @Nonnull final TaskListener listener
     ) throws InterruptedException, IOException {
         try {
-            TeamStatus.createFromRun(run, listener);
+            TeamStatus.createFromRun(run, listener, getDisplayName());
         }
         catch (final IllegalArgumentException e) {
             listener.error(e.getMessage());
@@ -41,6 +42,11 @@ public class TeamPendingStatusBuildStep extends Builder implements SimpleBuildSt
         catch (final Exception e) {
             e.printStackTrace(listener.error("Error while trying to update pending status in TFS/Team Services"));
         }
+    }
+
+    String getDisplayName() {
+        final Descriptor<Builder> descriptor = getDescriptor();
+        return descriptor.getDisplayName();
     }
 
     @Extension

--- a/tfs/src/main/java/hudson/plugins/tfs/UnsupportedIntegrationAction.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/UnsupportedIntegrationAction.java
@@ -4,7 +4,6 @@ import hudson.model.Action;
 import hudson.model.InvisibleAction;
 import hudson.model.Run;
 import hudson.model.TaskListener;
-import hudson.plugins.tfs.model.BuildCommand;
 
 import javax.annotation.Nonnull;
 import java.io.Serializable;
@@ -25,12 +24,7 @@ public class UnsupportedIntegrationAction extends InvisibleAction implements Ser
 
     public static boolean isSupported(@Nonnull final Run<?, ?> run, @Nonnull final TaskListener listener) {
         final UnsupportedIntegrationAction action = run.getAction(UnsupportedIntegrationAction.class);
-        if (action != null) {
-            final String message = BuildCommand.formatUnsupportedReason(action.reason);
-            listener.error(message);
-            return false;
-        }
-        return true;
+        return action == null;
     }
 
     public static void addToBuild(final List<Action> actions, final String reason) {

--- a/tfs/src/main/java/hudson/plugins/tfs/util/TeamStatus.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/util/TeamStatus.java
@@ -1,11 +1,9 @@
 package hudson.plugins.tfs.util;
 
-import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.plugins.tfs.CommitParameterAction;
 import hudson.plugins.tfs.PullRequestParameterAction;
-import hudson.plugins.tfs.TeamCollectionConfiguration;
 import hudson.plugins.tfs.UnsupportedIntegrationAction;
 import hudson.plugins.tfs.model.GitCodePushedEventArgs;
 import hudson.plugins.tfs.model.PullRequestMergeCommitCreatedEventArgs;
@@ -13,12 +11,18 @@ import hudson.plugins.tfs.model.TeamGitStatus;
 
 import javax.annotation.Nonnull;
 import java.io.IOException;
+import java.io.PrintStream;
 import java.net.URI;
 
 public class TeamStatus {
-    public static void createFromRun(@Nonnull final Run<?, ?> run, @Nonnull final TaskListener listener) throws IOException {
+    public static void createFromRun(@Nonnull final Run<?, ?> run, @Nonnull final TaskListener listener, final String featureDisplayName) throws IOException {
 
         if (!UnsupportedIntegrationAction.isSupported(run, listener)) {
+            final PrintStream logger = listener.getLogger();
+            logger.print("NOTICE: ");
+            logger.print("You selected '");
+            logger.print(featureDisplayName);
+            logger.println("' on your Jenkins job, but this option has no effect when calling the job from the 'Jenkins Queue Job' task in TFS/Team Services.");
             return;
         }
 


### PR DESCRIPTION
Manual testing
--------------

1. Configured a job with the **Set build pending status in TFS/Team Services** build step and the **Set build completion status in TFS/Team Services** post-build action.
2. Triggered a build via the `/team-build/` endpoint with a payload containing a `team-build` section (just like the Jenkins Queue Job task would do).
    1. The _Console Output_ contained: `NOTICE: You selected 'Set build pending status in TFS/Team Services' on your Jenkins job, but this option has no effect when calling the job from the 'Jenkins Queue Job' task in TFS/Team Services.` as well as `NOTICE: You selected 'Set build completion status in TFS/Team Services' on your Jenkins job, but this option has no effect when calling the job from the 'Jenkins Queue Job' task in TFS/Team Services.`
    2. The Jenkins build still linked to the corresponding Team Services build.

Mission accomplished!