### PR TITLE
Set the User-Agent header with plugin version

### DIFF
--- a/tfs/pom.xml
+++ b/tfs/pom.xml
@@ -50,6 +50,19 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>2.4</version>
+        <configuration>
+          <archive>
+            <manifest>
+              <!-- https://stackoverflow.com/a/6773868/ -->
+              <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+            </manifest>
+          </archive>
+        </configuration>
+      </plugin>
+      <plugin>
         <artifactId>maven-release-plugin</artifactId>
         <version>2.5.1</version>
         <configuration>

--- a/tfs/src/main/java/hudson/plugins/tfs/model/ModernHTTPClientFactory.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/model/ModernHTTPClientFactory.java
@@ -24,6 +24,18 @@ public class ModernHTTPClientFactory extends DefaultHTTPClientFactory {
     }
 
     @Override
+    protected String getUserAgentExtraString(final HttpClient httpClient, final ConnectionInstanceData connectionInstanceData) {
+        // https://stackoverflow.com/a/6773868/
+        final Class<? extends ModernHTTPClientFactory> me = this.getClass();
+        final Package us = me.getPackage();
+        String version = us.getImplementationVersion();
+        if (version == null) {
+            version = "devtest";
+        }
+        return "TFS Plugin for Jenkins " + version;
+    }
+
+    @Override
     public void configureClientProxy(final HttpClient httpClient, final HostConfiguration hostConfiguration,final HttpState httpState, final ConnectionInstanceData connectionInstanceData) {
         hostConfiguration.setProxyHost(proxyHost);
 

--- a/tfs/src/main/java/hudson/plugins/tfs/model/ModernHTTPClientFactory.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/model/ModernHTTPClientFactory.java
@@ -32,7 +32,7 @@ public class ModernHTTPClientFactory extends DefaultHTTPClientFactory {
         if (version == null) {
             version = "devtest";
         }
-        return "TFS Plugin for Jenkins " + version;
+        return "TFS-Jenkins " + version;
     }
 
     @Override


### PR DESCRIPTION
Note
----

I've implemented the User-Agent string using the TFS SDK's extension (`ConfigurableHTTPClientFactory#getUserAgentExtraString()`), which means we get 30 characters to append to what it generates and it's really tight with the current string: `5.1.1-SNAPSHOT` gets truncated to `5.1.1-S`.  We should still have enough room for 2 2-digit groups, such as `5.10.11`, but then it will be difficult to distinguish an official release from a SNAPSHOT build.  We could give ourselves a bit more breathing room if we shrunk the `TFS Plugin for Jenkins ` prefix and I'm open to suggestions.

Manual testing
==============

1. Launched Jenkins with the plugin in "development testing" mode (using the `.hpl` file), set a breakpoint in the `TeamRestClient` and clicked the [Test connection] button.
    1. The value of `userAgent` was `Team  Explorer  Everywhere, SKU:21 (SDK 14.0.3.201603291047 1.8.0_91; Windows 10 amd64 10.0; TFS Plugin for Jenkins devtest)` (we see "devtest" as the version because the manifest wasn't yet created)
2. Packaged the plugin (which now inserts `Implementation-Version: 5.1.1-SNAPSHOT` into `MANIFEST.MF`), uploaded it to a Jenkins server and restarted.  Once it came back up, I entered the URL to a collection hosted in TFS and clicked [Test connection].
    1. In the IIS logs of the TFS server, I found the following: `Team++Explorer++Everywhere,+SKU:21+(SDK+14.0.3.201603291047+1.8.0_92;+Windows+Server+2012+R2+amd64+6;+TFS+Plugin+for+Jenkins+5.1.1-S)`

Mission accomplished!