### PR TITLE
Automatic integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,11 @@ The plugin will automatically create a workspace in TFS/Team Services and map a 
 
 The TFS plug-in for Jenkins enhances the Git plug-in for Jenkins by adding some integration features:
 * A push trigger, to request builds of specific commits in Git repositories without needing to schedule SCM polling
+    * Instead of adding the **Build when a change is pushed to TFS/Team Services** trigger to every job, you can also check the checkbox next to **Enable Push Trigger for all jobs** in the Jenkins global configuration.  Individual jobs can still opt-out of this global opt-in by enabling the **Poll SCM** trigger and checking its **Ignore post-commit hooks** checkbox.
 * A build step that adds a "build pending" status to the associated pull request and/or commit in TFS/Team Services
+    * Instead of adding the **Set build pending status in TFS/Team Services** build step to every job, you can also check the checkbox next to **Enable Team Status for all jobs** in the Jenkins global configuration.
 * A post-build action that add a "build completed" status to the associated pull request and/or commit in TFS/Team Services
+    * Instead of adding the **Set build completion status in TFS/Team Services** post-build action to every job, you can also check the checkboxbox next to **Enable Team Status for all jobs** in the Jenkins global configuration.
 * A link to (and summary information about) the associated TFS/Team Services build that triggered the Jenkins build.
 * A link to (and summary information about) the associated TFS/Team Services pull request that triggered the Jenkins build.
     * Links to associated TFS/Team Services work items.

--- a/tfs/src/main/java/hudson/plugins/tfs/TeamCompletedStatusPostBuildAction.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/TeamCompletedStatusPostBuildAction.java
@@ -36,6 +36,12 @@ public class TeamCompletedStatusPostBuildAction extends Notifier implements Simp
             @Nonnull final Launcher launcher,
             @Nonnull final TaskListener listener
     ) throws InterruptedException, IOException {
+        if (!TeamGlobalStatusAction.isApplicable(run)){
+            perform(run, listener);
+        }
+    }
+
+    public void perform(final @Nonnull Run<?, ?> run, final @Nonnull TaskListener listener) {
         try {
             TeamStatus.createFromRun(run, listener, getDisplayName());
         }

--- a/tfs/src/main/java/hudson/plugins/tfs/TeamGlobalStatusAction.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/TeamGlobalStatusAction.java
@@ -1,0 +1,28 @@
+package hudson.plugins.tfs;
+
+import hudson.model.Action;
+import hudson.model.InvisibleAction;
+import hudson.model.Run;
+
+import java.io.Serializable;
+import java.util.List;
+
+/**
+ * Added to the build when triggered by TFS/Team Services AND the "Enable Team Status for all jobs"
+ * option was enabled.
+ */
+public class TeamGlobalStatusAction extends InvisibleAction implements Serializable {
+
+    public static void addIfApplicable(final List<Action> actions) {
+        final TeamPluginGlobalConfig config = TeamPluginGlobalConfig.get();
+        if (config.isEnableTeamStatusForAllJobs()) {
+            actions.add(new TeamGlobalStatusAction());
+        }
+    }
+
+    public static boolean isApplicable(final Run<?, ?> run) {
+        final TeamGlobalStatusAction action = run.getAction(TeamGlobalStatusAction.class);
+        return action != null;
+    }
+
+}

--- a/tfs/src/main/java/hudson/plugins/tfs/TeamGlobalStatusPoster.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/TeamGlobalStatusPoster.java
@@ -1,0 +1,51 @@
+package hudson.plugins.tfs;
+
+import hudson.Extension;
+import hudson.FilePath;
+import hudson.Launcher;
+import hudson.model.AbstractBuild;
+import hudson.model.TaskListener;
+import hudson.model.listeners.RunListener;
+import jenkins.model.Jenkins;
+import jenkins.tasks.SimpleBuildStep;
+
+import javax.annotation.Nonnull;
+import java.io.IOException;
+
+/**
+ * Posts the status to TFS/Team Services if the {@link TeamGlobalStatusAction} was contributed.
+ */
+@Extension
+public class TeamGlobalStatusPoster extends RunListener<AbstractBuild> {
+
+    @Override
+    public void onStarted(final AbstractBuild build, final TaskListener listener) {
+        if (TeamGlobalStatusAction.isApplicable(build)) {
+            final TeamPendingStatusBuildStep step = new TeamPendingStatusBuildStep();
+            performStep(step, build, listener);
+        }
+    }
+
+    @Override
+    public void onCompleted(final AbstractBuild build, @Nonnull final TaskListener listener) {
+        if (TeamGlobalStatusAction.isApplicable(build)) {
+            final TeamCompletedStatusPostBuildAction step = new TeamCompletedStatusPostBuildAction();
+            performStep(step, build, listener);
+        }
+    }
+
+    static void performStep(final SimpleBuildStep step, final AbstractBuild build, final TaskListener listener) {
+        final Jenkins jenkins = Jenkins.getInstance();
+        final FilePath workspace = build.getWorkspace();
+        final Launcher launcher = jenkins.createLauncher(listener);
+        try {
+            step.perform(build, workspace, launcher, listener);
+        }
+        catch (final InterruptedException e) {
+            throw new Error(e);
+        }
+        catch (final IOException e) {
+            throw new Error(e);
+        }
+    }
+}

--- a/tfs/src/main/java/hudson/plugins/tfs/TeamGlobalStatusPoster.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/TeamGlobalStatusPoster.java
@@ -1,16 +1,11 @@
 package hudson.plugins.tfs;
 
 import hudson.Extension;
-import hudson.FilePath;
-import hudson.Launcher;
 import hudson.model.AbstractBuild;
 import hudson.model.TaskListener;
 import hudson.model.listeners.RunListener;
-import jenkins.model.Jenkins;
-import jenkins.tasks.SimpleBuildStep;
 
 import javax.annotation.Nonnull;
-import java.io.IOException;
 
 /**
  * Posts the status to TFS/Team Services if the {@link TeamGlobalStatusAction} was contributed.
@@ -22,7 +17,7 @@ public class TeamGlobalStatusPoster extends RunListener<AbstractBuild> {
     public void onStarted(final AbstractBuild build, final TaskListener listener) {
         if (TeamGlobalStatusAction.isApplicable(build)) {
             final TeamPendingStatusBuildStep step = new TeamPendingStatusBuildStep();
-            performStep(step, build, listener);
+            step.perform(build, listener);
         }
     }
 
@@ -30,22 +25,8 @@ public class TeamGlobalStatusPoster extends RunListener<AbstractBuild> {
     public void onCompleted(final AbstractBuild build, @Nonnull final TaskListener listener) {
         if (TeamGlobalStatusAction.isApplicable(build)) {
             final TeamCompletedStatusPostBuildAction step = new TeamCompletedStatusPostBuildAction();
-            performStep(step, build, listener);
+            step.perform(build, listener);
         }
     }
 
-    static void performStep(final SimpleBuildStep step, final AbstractBuild build, final TaskListener listener) {
-        final Jenkins jenkins = Jenkins.getInstance();
-        final FilePath workspace = build.getWorkspace();
-        final Launcher launcher = jenkins.createLauncher(listener);
-        try {
-            step.perform(build, workspace, launcher, listener);
-        }
-        catch (final InterruptedException e) {
-            throw new Error(e);
-        }
-        catch (final IOException e) {
-            throw new Error(e);
-        }
-    }
 }

--- a/tfs/src/main/java/hudson/plugins/tfs/TeamPendingStatusBuildStep.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/TeamPendingStatusBuildStep.java
@@ -33,6 +33,12 @@ public class TeamPendingStatusBuildStep extends Builder implements SimpleBuildSt
             @Nonnull final Launcher launcher,
             @Nonnull final TaskListener listener
     ) throws InterruptedException, IOException {
+        if (!TeamGlobalStatusAction.isApplicable(run)){
+            perform(run, listener);
+        }
+    }
+
+    public void perform(final @Nonnull Run<?, ?> run, final @Nonnull TaskListener listener) {
         try {
             TeamStatus.createFromRun(run, listener, getDisplayName());
         }

--- a/tfs/src/main/java/hudson/plugins/tfs/TeamPluginGlobalConfig.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/TeamPluginGlobalConfig.java
@@ -25,6 +25,7 @@ public class TeamPluginGlobalConfig extends GlobalConfiguration {
     private List<TeamCollectionConfiguration> collectionConfigurations = new ArrayList<TeamCollectionConfiguration>();
 
     private boolean configFolderPerNode;
+    private boolean enableTeamPushTriggerForAllJobs;
 
     public TeamPluginGlobalConfig() {
         this(true);
@@ -64,6 +65,14 @@ public class TeamPluginGlobalConfig extends GlobalConfiguration {
 
     public void setConfigFolderPerNode(final boolean configFolderPerNode) {
         this.configFolderPerNode = configFolderPerNode;
+    }
+
+    public boolean isEnableTeamPushTriggerForAllJobs() {
+        return enableTeamPushTriggerForAllJobs;
+    }
+
+    public void setEnableTeamPushTriggerForAllJobs(final boolean enableTeamPushTriggerForAllJobs) {
+        this.enableTeamPushTriggerForAllJobs = enableTeamPushTriggerForAllJobs;
     }
 
     @Override

--- a/tfs/src/main/java/hudson/plugins/tfs/TeamPluginGlobalConfig.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/TeamPluginGlobalConfig.java
@@ -26,6 +26,7 @@ public class TeamPluginGlobalConfig extends GlobalConfiguration {
 
     private boolean configFolderPerNode;
     private boolean enableTeamPushTriggerForAllJobs;
+    private boolean enableTeamStatusForAllJobs;
 
     public TeamPluginGlobalConfig() {
         this(true);
@@ -73,6 +74,14 @@ public class TeamPluginGlobalConfig extends GlobalConfiguration {
 
     public void setEnableTeamPushTriggerForAllJobs(final boolean enableTeamPushTriggerForAllJobs) {
         this.enableTeamPushTriggerForAllJobs = enableTeamPushTriggerForAllJobs;
+    }
+
+    public boolean isEnableTeamStatusForAllJobs() {
+        return enableTeamStatusForAllJobs;
+    }
+
+    public void setEnableTeamStatusForAllJobs(final boolean enableTeamStatusForAllJobs) {
+        this.enableTeamStatusForAllJobs = enableTeamStatusForAllJobs;
     }
 
     @Override

--- a/tfs/src/main/java/hudson/plugins/tfs/TeamPushTrigger.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/TeamPushTrigger.java
@@ -43,6 +43,10 @@ public class TeamPushTrigger extends Trigger<Job<?, ?>> {
     public TeamPushTrigger() {
     }
 
+    public TeamPushTrigger(final Job<?, ?> job) {
+        this.job = job;
+    }
+
     public void execute(final GitCodePushedEventArgs gitCodePushedEventArgs, final List<Action> actions, final boolean bypassPolling) {
         // TODO: Consider executing the poll + queue asynchronously
         final Runner runner = new Runner(gitCodePushedEventArgs, actions, bypassPolling);

--- a/tfs/src/main/java/hudson/plugins/tfs/TeamPushTrigger.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/TeamPushTrigger.java
@@ -24,7 +24,6 @@ import java.io.IOException;
 import java.io.PrintStream;
 import java.io.Writer;
 import java.text.DateFormat;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
@@ -133,11 +132,17 @@ public class TeamPushTrigger extends Trigger<Job<?, ?>> {
                 final String name = "#" + p.getNextBuildNumber();
                 final String pushedBy = gitCodePushedEventArgs.pushedBy;
                 TeamPushCause cause;
-                try {
-                    cause = new TeamPushCause(getLogFile(), pushedBy);
+                final File logFile = getLogFile();
+                if (logFile.isFile()) {
+                    try {
+                        cause = new TeamPushCause(logFile, pushedBy);
+                    }
+                    catch (IOException e) {
+                        LOGGER.log(Level.WARNING, "Failed to parse the polling log", e);
+                        cause = new TeamPushCause(pushedBy);
+                    }
                 }
-                catch (IOException e) {
-                    LOGGER.log(Level.WARNING, "Failed to parse the polling log", e);
+                else {
                     cause = new TeamPushCause(pushedBy);
                 }
                 final int quietPeriod = p.getQuietPeriod();

--- a/tfs/src/main/java/hudson/plugins/tfs/model/AbstractHookEvent.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/model/AbstractHookEvent.java
@@ -12,6 +12,7 @@ import hudson.plugins.git.GitStatus;
 import hudson.plugins.git.extensions.impl.IgnoreNotifyCommit;
 import hudson.plugins.tfs.TeamEventsEndpoint;
 import hudson.plugins.tfs.TeamHookCause;
+import hudson.plugins.tfs.TeamPluginGlobalConfig;
 import hudson.plugins.tfs.TeamPushTrigger;
 import hudson.plugins.tfs.model.servicehooks.Event;
 import hudson.plugins.tfs.util.ActionHelper;
@@ -132,7 +133,27 @@ public abstract class AbstractHookEvent {
 
                                 boolean triggered = false;
                                 if (!triggered) {
-                                    // TODO: check global override here
+                                    final TeamPluginGlobalConfig config = TeamPluginGlobalConfig.get();
+                                    if (config.isEnableTeamPushTriggerForAllJobs()) {
+                                        triggered = true;
+                                        final SCMTrigger scmTrigger = TeamEventsEndpoint.findTrigger(job, SCMTrigger.class);
+                                        if (scmTrigger != null && scmTrigger.isIgnorePostCommitHooks()) {
+                                            // job has explicitly opted out of hooks
+                                            triggered = false;
+                                        }
+                                    }
+                                    if (triggered) {
+                                        final TeamPushTrigger trigger = new TeamPushTrigger(job);
+                                        trigger.execute(gitCodePushedEventArgs, actions, bypassPolling);
+                                        final GitStatus.ResponseContributor response;
+                                        if (bypassPolling) {
+                                            response = new TeamEventsEndpoint.ScheduledResponseContributor(project);
+                                        }
+                                        else {
+                                            response = new TeamEventsEndpoint.PollingScheduledResponseContributor(project);
+                                        }
+                                        result.add(response);
+                                    }
                                 }
                                 if (!triggered) {
                                     final SCMTrigger scmTrigger = TeamEventsEndpoint.findTrigger(job, SCMTrigger.class);

--- a/tfs/src/main/java/hudson/plugins/tfs/model/AbstractHookEvent.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/model/AbstractHookEvent.java
@@ -11,6 +11,7 @@ import hudson.plugins.git.GitSCM;
 import hudson.plugins.git.GitStatus;
 import hudson.plugins.git.extensions.impl.IgnoreNotifyCommit;
 import hudson.plugins.tfs.TeamEventsEndpoint;
+import hudson.plugins.tfs.TeamGlobalStatusAction;
 import hudson.plugins.tfs.TeamHookCause;
 import hudson.plugins.tfs.TeamPluginGlobalConfig;
 import hudson.plugins.tfs.TeamPushTrigger;
@@ -85,6 +86,8 @@ public abstract class AbstractHookEvent {
         List<GitStatus.ResponseContributor> result = new ArrayList<GitStatus.ResponseContributor>();
         final String commit = gitCodePushedEventArgs.commit;
         final URIish uri = gitCodePushedEventArgs.getRepoURIish();
+
+        TeamGlobalStatusAction.addIfApplicable(actions);
 
         // run in high privilege to see all the projects anonymous users don't see.
         // this is safe because when we actually schedule a build, it's a build that can

--- a/tfs/src/main/java/hudson/plugins/tfs/model/BuildCommand.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/model/BuildCommand.java
@@ -18,6 +18,7 @@ import hudson.plugins.tfs.CommitParameterAction;
 import hudson.plugins.tfs.PullRequestParameterAction;
 import hudson.plugins.tfs.TeamBuildDetailsAction;
 import hudson.plugins.tfs.TeamBuildEndpoint;
+import hudson.plugins.tfs.TeamGlobalStatusAction;
 import hudson.plugins.tfs.TeamPullRequestMergedDetailsAction;
 import hudson.plugins.tfs.UnsupportedIntegrationAction;
 import hudson.plugins.tfs.model.servicehooks.Event;
@@ -117,6 +118,7 @@ public class BuildCommand extends AbstractCommand {
                 final GitCodePushedEventArgs args = GitPushEvent.decodeGitPush(gitPush, event);
                 final Action action = new CommitParameterAction(args);
                 actions.add(action);
+                TeamGlobalStatusAction.addIfApplicable(actions);
             }
             else if ("git.pullrequest.merged".equals(eventType)) {
                 final GitPullRequestEx gitPullRequest = mapper.convertValue(resource, GitPullRequestEx.class);
@@ -130,6 +132,7 @@ public class BuildCommand extends AbstractCommand {
                 final String detailedMessage = event.getDetailedMessage().getText();
                 final Action teamPullRequestMergedDetailsAction = new TeamPullRequestMergedDetailsAction(gitPullRequest, message, detailedMessage, args.collectionUri.toString());
                 actions.add(teamPullRequestMergedDetailsAction);
+                TeamGlobalStatusAction.addIfApplicable(actions);
             }
         }
 

--- a/tfs/src/main/resources/hudson/plugins/tfs/TeamPluginGlobalConfig/config.groovy
+++ b/tfs/src/main/resources/hudson/plugins/tfs/TeamPluginGlobalConfig/config.groovy
@@ -9,6 +9,11 @@ f.section(title: descriptor.displayName) {
 
         f.repeatableProperty(field: "collectionConfigurations")
     }
+    f.entry(title: _("Enable Push Trigger for all jobs"),
+            field: "enableTeamPushTriggerForAllJobs",
+            description: "Turning this on is equivalent to adding the 'Build when a change is pushed to TFS/Team Services' trigger to all jobs.") {
+        f.checkbox (default: false)
+    }
     f.advanced() {
         f.entry(title: _("Store TFVC configuration in computer-specific folders"),
                 field: "configFolderPerNode",

--- a/tfs/src/main/resources/hudson/plugins/tfs/TeamPluginGlobalConfig/config.groovy
+++ b/tfs/src/main/resources/hudson/plugins/tfs/TeamPluginGlobalConfig/config.groovy
@@ -14,6 +14,11 @@ f.section(title: descriptor.displayName) {
             description: "Turning this on is equivalent to adding the 'Build when a change is pushed to TFS/Team Services' trigger to all jobs.") {
         f.checkbox (default: false)
     }
+    f.entry(title: _("Enable Team Status for all jobs"),
+            field: "enableTeamStatusForAllJobs",
+            description: "Turning this on is equivalent to adding the 'Set build pending status in TFS/Team Services' build step and the 'Set build completion status in TFS/Team Services' post-build action to all jobs.") {
+        f.checkbox (default: false)
+    }
     f.advanced() {
         f.entry(title: _("Store TFVC configuration in computer-specific folders"),
                 field: "configFolderPerNode",

--- a/tfs/src/main/resources/hudson/plugins/tfs/TeamPluginGlobalConfig/help-enableTeamPushTriggerForAllJobs.html
+++ b/tfs/src/main/resources/hudson/plugins/tfs/TeamPluginGlobalConfig/help-enableTeamPushTriggerForAllJobs.html
@@ -1,3 +1,5 @@
 <div>
-    If enabled, when an event is received from TFS/Team Services for a Git repository, all the Jenkins jobs that use that Git repository will be automatically triggered, even if they didn't enable the "Build when a change is pushed to TFS/Team Services" trigger.
+    If enabled, when an event is received from TFS/Team Services for a Git repository, all the Jenkins jobs that use that Git repository will be automatically triggered, even if they didn't enable the "Build when a change is pushed to TFS/Team Services" trigger.<br />
+    <br />
+    Individual jobs can opt-out of this global opt-in by enabling the <b>Poll SCM</b> trigger and checking its <b>Ignore post-commit hooks</b> checkbox.
 </div>

--- a/tfs/src/main/resources/hudson/plugins/tfs/TeamPluginGlobalConfig/help-enableTeamPushTriggerForAllJobs.html
+++ b/tfs/src/main/resources/hudson/plugins/tfs/TeamPluginGlobalConfig/help-enableTeamPushTriggerForAllJobs.html
@@ -1,0 +1,3 @@
+<div>
+    If enabled, when an event is received from TFS/Team Services for a Git repository, all the Jenkins jobs that use that Git repository will be automatically triggered, even if they didn't enable the "Build when a change is pushed to TFS/Team Services" trigger.
+</div>

--- a/tfs/src/main/resources/hudson/plugins/tfs/TeamPluginGlobalConfig/help-enableTeamStatusForAllJobs.html
+++ b/tfs/src/main/resources/hudson/plugins/tfs/TeamPluginGlobalConfig/help-enableTeamStatusForAllJobs.html
@@ -1,0 +1,3 @@
+<div>
+    If enabled, when an event is received from TFS/Team Services for a Git repository, all the Jenkins jobs that use that Git repository will post their status to the associated pull request and/or commit in TFS/Team Services, even if they didn't add the "Set build pending status in TFS/Team Services" build step nor the "Set build completion status in TFS/Team Services" post-build action.
+</div>


### PR DESCRIPTION
This pull request adds two "global options" to Jenkins, pictured below:

1. **Enable Push Trigger for all jobs**
2. **Enable Team Status for all jobs**

![image](https://cloud.githubusercontent.com/assets/297515/18290957/95558698-7453-11e6-9bf3-40e5d9d993d9.png)


Manual testing
==============

1. Enable both new options and configure a few jobs with special cases:
    1. One job to opt-out of the global push trigger.
    2. One job with the "Build when a change is pushed to TFS/Team Services" trigger enabled.
    3. One job with the "Set build pending status in TFS/Team Services" build step.
    4. One job with the "Set build completion status in TFS/Team Services" post-build action.
    5. One job with both the "Set build pending status in TFS/Team Services" build step and the "Set build completion status in TFS/Team Services" post-build action.
2. Hit the `/team-events/gitPullRequestMerged` endpoint with a payload that matches the Git repository used by all the jobs above.
    1. All the jobs that used the Git SCM with the same repository URL as the event, EXCEPT the job that had opted out, were queued.
    2. Looking at the statuses posted to the Git commit and the pull request in Team Services, there were both a pending status and a completed status for each build that ran, regardless of overlap in configuration.
3. Disabled both new options and hit the same endpoint with the same payload.
    1. Only the job that had the push trigger enabled was triggered.
    2. It only posted the completion status to the commit and pull request (that was how it was configured).

Mission accomplished!