### PR TITLE
Fix TeamRestClient for TFS on Windows and improve "Test connection" button

### DIFF
--- a/tfs/src/main/java/hudson/plugins/tfs/TeamBuildEndpoint.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/TeamBuildEndpoint.java
@@ -1,6 +1,5 @@
 package hudson.plugins.tfs;
 
-import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import hudson.Extension;
 import hudson.model.AbstractProject;
@@ -52,7 +51,6 @@ public class TeamBuildEndpoint implements UnprotectedRootAction {
 
     private static final Logger LOGGER = Logger.getLogger(TeamBuildEndpoint.class.getName());
     private static final Map<String, AbstractCommand.Factory> COMMAND_FACTORIES_BY_NAME;
-    private static final ObjectMapper MAPPER;
     public static final String URL_NAME = "team-build";
     public static final String PARAMETER = "parameter";
     static final String URL_PREFIX = "/" + URL_NAME + "/";
@@ -63,10 +61,6 @@ public class TeamBuildEndpoint implements UnprotectedRootAction {
         map.put("build", new BuildCommand.Factory());
         map.put("buildWithParameters", new BuildWithParametersCommand.Factory());
         COMMAND_FACTORIES_BY_NAME = Collections.unmodifiableMap(map);
-
-        MAPPER = new ObjectMapper();
-        MAPPER.enable(DeserializationFeature.READ_ENUMS_USING_TO_STRING);
-        MAPPER.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
     }
 
     private String commandName;
@@ -221,8 +215,9 @@ public class TeamBuildEndpoint implements UnprotectedRootAction {
         final AbstractCommand command = factory.create();
         final JSONObject response;
         final JSONObject formData = req.getSubmittedForm();
-        final TeamBuildPayload teamBuildPayload = MAPPER.convertValue(formData, TeamBuildPayload.class);
-        response = command.perform(project, req, formData, MAPPER, teamBuildPayload, actualDelay);
+        final ObjectMapper mapper = EndpointHelper.MAPPER;
+        final TeamBuildPayload teamBuildPayload = mapper.convertValue(formData, TeamBuildPayload.class);
+        response = command.perform(project, req, formData, mapper, teamBuildPayload, actualDelay);
         return response;
     }
 

--- a/tfs/src/main/java/hudson/plugins/tfs/TeamCollectionConfiguration.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/TeamCollectionConfiguration.java
@@ -104,7 +104,7 @@ public class TeamCollectionConfiguration extends AbstractDescribableImpl<TeamCol
             }
 
             try {
-                final StandardUsernamePasswordCredentials credential = findCredential(hostName, credentialsId);
+                final StandardUsernamePasswordCredentials credential = findCredentialsById(credentialsId);
                 if (isTeamServices(hostName)) {
                     if (credential == null) {
                         return FormValidation.error(errorTemplate, "Team Services accounts need credentials, preferably a Personal Access Token");

--- a/tfs/src/main/java/hudson/plugins/tfs/TeamCollectionConfiguration.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/TeamCollectionConfiguration.java
@@ -7,9 +7,13 @@ import com.cloudbees.plugins.credentials.common.StandardListBoxModel;
 import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
 import com.cloudbees.plugins.credentials.domains.DomainRequirement;
 import com.cloudbees.plugins.credentials.domains.HostnameRequirement;
+import com.microsoft.tfs.core.exceptions.TFSUnauthorizedException;
 import hudson.Extension;
 import hudson.model.AbstractDescribableImpl;
 import hudson.model.Descriptor;
+import hudson.plugins.tfs.model.ListOfGitRepositories;
+import hudson.plugins.tfs.model.MockableVersionControlClient;
+import hudson.plugins.tfs.model.Server;
 import hudson.plugins.tfs.util.StringHelper;
 import hudson.plugins.tfs.util.TeamRestClient;
 import hudson.plugins.tfs.util.UriHelper;
@@ -26,8 +30,11 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Collections;
 import java.util.List;
+import java.util.logging.Logger;
 
 public class TeamCollectionConfiguration extends AbstractDescribableImpl<TeamCollectionConfiguration> {
+
+    private static final Logger LOGGER = Logger.getLogger(TeamCollectionConfiguration.class.getName());
 
     private final String collectionUrl;
     private final String credentialsId;
@@ -110,14 +117,11 @@ public class TeamCollectionConfiguration extends AbstractDescribableImpl<TeamCol
                         return FormValidation.error(errorTemplate, "Team Services accounts need credentials, preferably a Personal Access Token");
                     }
                 }
-                final URI collectionUri = URI.create(collectionUrl);
-                testConnection(collectionUri, credential);
+                return testConnection(collectionUrl, credential);
             }
             catch (final IOException e) {
                 return FormValidation.error(e, errorTemplate, e.getMessage());
             }
-
-            return FormValidation.ok("Success!");
         }
 
         @SuppressWarnings("unused")
@@ -173,10 +177,28 @@ public class TeamCollectionConfiguration extends AbstractDescribableImpl<TeamCol
         return StringHelper.endsWithIgnoreCase(hostName, ".visualstudio.com");
     }
 
-    static void testConnection(final URI collectionUri, final StandardUsernamePasswordCredentials credentials) throws IOException {
+    static FormValidation testConnection(final String collectionUri, final StandardUsernamePasswordCredentials credentials) throws IOException {
 
+        final Server server = Server.create(null, null, collectionUri, credentials, null, null);
+        try {
+            final MockableVersionControlClient vcc = server.getVersionControlClient();
+            return FormValidation.ok("Success via SOAP API.");
+        }
+        catch (final TFSUnauthorizedException e) {
+            // performing TFVC requires All Scopes and someone might be setting up for Git only; ignore
+        }
         final TeamRestClient client = new TeamRestClient(collectionUri, credentials);
-        client.ping();
+
+        try {
+            final ListOfGitRepositories repositories = client.getRepositories();
+            if (repositories.count < 1) {
+                return FormValidation.warning("There does not seem to be any Git repositories");
+            }
+            return FormValidation.ok("Success via REST API.");
+        }
+        catch (final IOException e) {
+            return FormValidation.error("Error: " + e.getMessage());
+        }
     }
 
     static StandardUsernamePasswordCredentials findCredential(final String hostName, final String credentialsId) {

--- a/tfs/src/main/java/hudson/plugins/tfs/TeamEventsEndpoint.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/TeamEventsEndpoint.java
@@ -1,7 +1,5 @@
 package hudson.plugins.tfs;
 
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import hudson.Extension;
 import hudson.model.Item;
 import hudson.model.Job;
@@ -51,7 +49,6 @@ public class TeamEventsEndpoint implements UnprotectedRootAction {
 
     private static final Logger LOGGER = Logger.getLogger(TeamEventsEndpoint.class.getName());
     private static final Map<String, AbstractHookEvent.Factory> HOOK_EVENT_FACTORIES_BY_NAME;
-    private static final ObjectMapper MAPPER;
 
     static {
         final Map<String, AbstractHookEvent.Factory> eventMap =
@@ -60,10 +57,6 @@ public class TeamEventsEndpoint implements UnprotectedRootAction {
         eventMap.put("gitPullRequestMerged", new GitPullRequestMergedEvent.Factory());
         eventMap.put("gitPush", new GitPushEvent.Factory());
         HOOK_EVENT_FACTORIES_BY_NAME = Collections.unmodifiableMap(eventMap);
-
-        MAPPER = new ObjectMapper();
-        MAPPER.enable(DeserializationFeature.READ_ENUMS_USING_TO_STRING);
-        MAPPER.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
     }
 
     public static final String URL_NAME = "team-events";
@@ -167,11 +160,11 @@ public class TeamEventsEndpoint implements UnprotectedRootAction {
         final String message = serviceHookEvent.getMessage().getText();
         final String detailedMessage = serviceHookEvent.getDetailedMessage().getText();
         final AbstractHookEvent hookEvent = factory.create();
-        return hookEvent.perform(MAPPER, serviceHookEvent, message, detailedMessage);
+        return hookEvent.perform(EndpointHelper.MAPPER, serviceHookEvent, message, detailedMessage);
     }
 
     public static Event deserializeEvent(final String input) throws IOException {
-        final Event serviceHookEvent = MAPPER.readValue(input, Event.class);
+        final Event serviceHookEvent = EndpointHelper.MAPPER.readValue(input, Event.class);
         final String eventType = serviceHookEvent.getEventType();
         if (StringUtils.isEmpty(eventType)) {
             throw new IllegalArgumentException("Payload did not contain 'eventType'.");

--- a/tfs/src/main/java/hudson/plugins/tfs/TeamFoundationServerScm.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/TeamFoundationServerScm.java
@@ -438,9 +438,17 @@ public class TeamFoundationServerScm extends SCM {
         final CredentialsConfigurer credentialsConfigurer = getCredentialsConfigurer();
         final String collectionUri = getServerUrl(run);
         final StandardUsernamePasswordCredentials credentials = credentialsConfigurer.getCredentials(collectionUri);
-        final String username = credentials.getUsername();
-        final Secret password = credentials.getPassword();
-        final String userPassword = password.getPlainText();
+        final String username;
+        final String userPassword;
+        if (credentials == null) {
+            username = null;
+            userPassword = null;
+        }
+        else {
+            username = credentials.getUsername();
+            final Secret password = credentials.getPassword();
+            userPassword = password.getPlainText();
+        }
         return new Server(launcher, taskListener, collectionUri, username, userPassword);
     }
 

--- a/tfs/src/main/java/hudson/plugins/tfs/TeamFoundationServerScm.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/TeamFoundationServerScm.java
@@ -438,18 +438,7 @@ public class TeamFoundationServerScm extends SCM {
         final CredentialsConfigurer credentialsConfigurer = getCredentialsConfigurer();
         final String collectionUri = getServerUrl(run);
         final StandardUsernamePasswordCredentials credentials = credentialsConfigurer.getCredentials(collectionUri);
-        final String username;
-        final String userPassword;
-        if (credentials == null) {
-            username = null;
-            userPassword = null;
-        }
-        else {
-            username = credentials.getUsername();
-            final Secret password = credentials.getPassword();
-            userPassword = password.getPlainText();
-        }
-        return new Server(launcher, taskListener, collectionUri, username, userPassword);
+        return Server.create(launcher, taskListener, collectionUri, credentials, null, null);
     }
 
     @Override

--- a/tfs/src/main/java/hudson/plugins/tfs/model/BuildCommand.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/model/BuildCommand.java
@@ -1,6 +1,5 @@
 package hudson.plugins.tfs.model;
 
-import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.microsoft.teamfoundation.sourcecontrol.webapi.model.GitPush;
 import hudson.model.AbstractProject;
@@ -20,8 +19,8 @@ import hudson.plugins.tfs.PullRequestParameterAction;
 import hudson.plugins.tfs.TeamBuildDetailsAction;
 import hudson.plugins.tfs.TeamBuildEndpoint;
 import hudson.plugins.tfs.TeamPullRequestMergedDetailsAction;
-import hudson.plugins.tfs.model.servicehooks.Event;
 import hudson.plugins.tfs.UnsupportedIntegrationAction;
+import hudson.plugins.tfs.model.servicehooks.Event;
 import hudson.plugins.tfs.util.ActionHelper;
 import hudson.plugins.tfs.util.MediaType;
 import jenkins.model.Jenkins;
@@ -57,12 +56,6 @@ public class BuildCommand extends AbstractCommand {
 
     public static String formatUnsupportedReason(final String reason) {
         return String.format(UNSUPPORTED_TEMPLATE, reason);
-    }
-    private static final ObjectMapper MAPPER;
-
-    static {
-        MAPPER = new ObjectMapper();
-        MAPPER.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
     }
 
     public static class Factory implements AbstractCommand.Factory {

--- a/tfs/src/main/java/hudson/plugins/tfs/model/ExtraSettings.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/model/ExtraSettings.java
@@ -2,6 +2,7 @@ package hudson.plugins.tfs.model;
 
 import hudson.model.Computer;
 import hudson.plugins.tfs.TeamPluginGlobalConfig;
+import jenkins.model.Jenkins;
 
 import java.io.Serializable;
 
@@ -26,12 +27,13 @@ public class ExtraSettings implements Serializable {
     public ExtraSettings(final TeamPluginGlobalConfig teamPluginGlobalConfig) {
         if (teamPluginGlobalConfig != null) {
             this.configFolderPerNode = teamPluginGlobalConfig.isConfigFolderPerNode();
-            final Computer currentComputer = Computer.currentComputer();
-            if (currentComputer != null) {
-                this.nodeComputerName = currentComputer.getName();
-            }
-            else {
-                this.nodeComputerName = "";
+            final Jenkins instance = Jenkins.getInstance();
+            this.nodeComputerName = "";
+            if (instance != null) {
+                final Computer currentComputer = Computer.currentComputer();
+                if (currentComputer != null) {
+                    this.nodeComputerName = currentComputer.getName();
+                }
             }
         }
         else {

--- a/tfs/src/main/java/hudson/plugins/tfs/model/ListOfGitRepositories.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/model/ListOfGitRepositories.java
@@ -1,0 +1,10 @@
+package hudson.plugins.tfs.model;
+
+import com.microsoft.teamfoundation.sourcecontrol.webapi.model.GitRepository;
+
+import java.util.List;
+
+public class ListOfGitRepositories {
+    public int count;
+    public List<GitRepository> value;
+}

--- a/tfs/src/main/java/hudson/plugins/tfs/model/Server.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/model/Server.java
@@ -1,5 +1,6 @@
 package hudson.plugins.tfs.model;
 
+import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
 import com.microsoft.tfs.core.TFSConfigurationServer;
 import com.microsoft.tfs.core.TFSTeamProjectCollection;
 import com.microsoft.tfs.core.clients.versioncontrol.VersionControlClient;
@@ -23,6 +24,7 @@ import hudson.plugins.tfs.TeamPluginGlobalConfig;
 import hudson.plugins.tfs.commands.ServerConfigurationProvider;
 import hudson.remoting.Callable;
 import hudson.remoting.VirtualChannel;
+import hudson.util.Secret;
 import jenkins.model.Jenkins;
 
 import java.io.IOException;
@@ -53,6 +55,22 @@ public class Server implements ServerConfigurationProvider, Closable {
      */
     public Server(final Launcher launcher, final TaskListener taskListener, final String url, final String username, final String password) throws IOException {
         this(launcher, taskListener, url, username, password, null, null);
+    }
+
+    public static Server create(final Launcher launcher, final TaskListener taskListener, final String url, final StandardUsernamePasswordCredentials credentials, final WebProxySettings webProxySettings, final ExtraSettings extraSettings) throws IOException {
+
+        final String username;
+        final String userPassword;
+        if (credentials == null) {
+            username = null;
+            userPassword = null;
+        }
+        else {
+            username = credentials.getUsername();
+            final Secret password = credentials.getPassword();
+            userPassword = password.getPlainText();
+        }
+        return new Server(launcher, taskListener, url, username, userPassword, webProxySettings, extraSettings);
     }
 
     public Server(final Launcher launcher, final TaskListener taskListener, final String url, final String username, final String password, final WebProxySettings webProxySettings, final ExtraSettings extraSettings) throws IOException {

--- a/tfs/src/main/java/hudson/plugins/tfs/model/Server.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/model/Server.java
@@ -11,6 +11,7 @@ import com.microsoft.tfs.core.config.persistence.DefaultPersistenceStoreProvider
 import com.microsoft.tfs.core.config.persistence.PersistenceStoreProvider;
 import com.microsoft.tfs.core.httpclient.Credentials;
 import com.microsoft.tfs.core.httpclient.DefaultNTCredentials;
+import com.microsoft.tfs.core.httpclient.HttpClient;
 import com.microsoft.tfs.core.httpclient.UsernamePasswordCredentials;
 import com.microsoft.tfs.core.util.CredentialsUtils;
 import com.microsoft.tfs.core.util.URIUtils;
@@ -18,7 +19,6 @@ import com.microsoft.tfs.jni.helpers.LocalHost;
 import com.microsoft.tfs.util.Closable;
 import hudson.Launcher;
 import hudson.ProxyConfiguration;
-import hudson.Util;
 import hudson.model.TaskListener;
 import hudson.plugins.tfs.TeamPluginGlobalConfig;
 import hudson.plugins.tfs.commands.ServerConfigurationProvider;
@@ -37,7 +37,6 @@ import java.util.logging.Logger;
 public class Server implements ServerConfigurationProvider, Closable {
 
     private static final Logger LOGGER = Logger.getLogger(Server.class.getName());
-    private static final String nativeFolderPropertyName = "com.microsoft.tfs.jni.native.base-directory";
     private final String url;
     private final String userName;
     private final String userPassword;
@@ -211,6 +210,10 @@ public class Server implements ServerConfigurationProvider, Closable {
             }
         }
         return mockableVcc;
+    }
+
+    public HttpClient getHttpClient() {
+        return tpc.getHTTPClient();
     }
 
     public <T, E extends Exception> T execute(final Callable<T, E> callable) {

--- a/tfs/src/main/java/hudson/plugins/tfs/util/EndpointHelper.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/util/EndpointHelper.java
@@ -1,5 +1,7 @@
 package hudson.plugins.tfs.util;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.kohsuke.stapler.HttpResponses;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
@@ -9,6 +11,14 @@ import java.io.IOException;
 import java.io.PrintWriter;
 
 public class EndpointHelper {
+
+    public static final ObjectMapper MAPPER;
+
+    static {
+        MAPPER = new ObjectMapper();
+        MAPPER.enable(DeserializationFeature.READ_ENUMS_USING_TO_STRING);
+        MAPPER.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+    }
 
     public static void error(final int code, final Throwable cause) {
         throw new HttpResponses.HttpResponseException(cause) {

--- a/tfs/src/main/java/hudson/plugins/tfs/util/MediaType.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/util/MediaType.java
@@ -7,6 +7,7 @@ public class MediaType {
     public static final String APPLICATION_FORM_URLENCODED = "application/x-www-form-urlencoded";
     public static final String APPLICATION_JSON = "application/json";
     public static final String APPLICATION_JSON_UTF_8 = "application/json; charset=utf-8";
+    public static final String APPLICATION_JSON_PATCH_JSON = "application/json-patch+json";
     public static final String APPLICATION_JSON_PATCH_JSON_UTF_8 = "application/json-patch+json; charset=utf-8";
     public static final String APPLICATION_ZIP = "application/zip";
     public static final String TEXT_PLAIN = "text/plain";

--- a/tfs/src/main/java/hudson/plugins/tfs/util/TeamRestClient.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/util/TeamRestClient.java
@@ -9,6 +9,7 @@ import hudson.plugins.tfs.model.GitCodePushedEventArgs;
 import hudson.plugins.tfs.model.HttpMethod;
 import hudson.plugins.tfs.model.JsonPatchOperation;
 import hudson.plugins.tfs.model.Link;
+import hudson.plugins.tfs.model.ListOfGitRepositories;
 import hudson.plugins.tfs.model.PullRequestMergeCommitCreatedEventArgs;
 import hudson.plugins.tfs.model.Server;
 import hudson.plugins.tfs.model.TeamGitStatus;
@@ -140,7 +141,7 @@ public class TeamRestClient {
                 if (!StringUtil.isNullOrEmpty(responseText)) {
                     sb.append(": ").append(responseText);
                 }
-                throw new Error(sb.toString());
+                throw new IOException(sb.toString());
             }
             responseStream = clientMethod.getResponseBodyAsStream();
             stringResult = readResponseText(responseStream);
@@ -180,6 +181,19 @@ public class TeamRestClient {
         }
 
         return request(String.class, HttpMethod.GET, requestUri, null);
+    }
+
+    public ListOfGitRepositories getRepositories() throws IOException {
+        final QueryString qs = new QueryString(API_VERSION, "1.0");
+        final URI requestUri = UriHelper.join(
+                collectionUri,
+                "_apis",
+                "git",
+                "repositories",
+                qs
+        );
+
+        return request(ListOfGitRepositories.class, HttpMethod.GET, requestUri, null);
     }
 
     public TeamGitStatus addCommitStatus(final GitCodePushedEventArgs args, final TeamGitStatus status) throws IOException {

--- a/tfs/src/main/java/hudson/plugins/tfs/util/TeamRestClient.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/util/TeamRestClient.java
@@ -1,13 +1,11 @@
 package hudson.plugins.tfs.util;
 
 import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.microsoft.tfs.core.config.ConnectionInstanceData;
 import com.microsoft.tfs.util.GUID;
+import com.microsoft.visualstudio.services.webapi.patch.Operation;
 import hudson.ProxyConfiguration;
 import hudson.plugins.tfs.TeamCollectionConfiguration;
-import com.microsoft.visualstudio.services.webapi.patch.Operation;
 import hudson.plugins.tfs.model.GitCodePushedEventArgs;
 import hudson.plugins.tfs.model.HttpMethod;
 import hudson.plugins.tfs.model.JsonPatchOperation;
@@ -41,12 +39,6 @@ public class TeamRestClient {
     private static final String AUTHORIZATION = "Authorization";
     private static final String API_VERSION = "api-version";
     private static final String NEW_LINE = System.getProperty("line.separator");
-    private static final ObjectMapper MAPPER;
-
-    static {
-        MAPPER = new ObjectMapper();
-        MAPPER.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
-    }
 
     private final URI collectionUri;
     private final boolean isTeamServices;
@@ -158,7 +150,7 @@ public class TeamRestClient {
 
     public static <TResponse> TResponse deserialize(final Class<TResponse> responseClass, final String stringResponseBody) {
         try {
-            return MAPPER.readValue(stringResponseBody, responseClass);
+            return EndpointHelper.MAPPER.readValue(stringResponseBody, responseClass);
         }
         catch (final IOException e) {
             throw new Error(e);

--- a/tfs/src/main/java/hudson/plugins/tfs/util/TeamRestClient.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/util/TeamRestClient.java
@@ -69,6 +69,10 @@ public class TeamRestClient {
         }
     }
 
+    public TeamRestClient(final String collectionUri, final StandardUsernamePasswordCredentials credentials) {
+        this(URI.create(collectionUri), credentials);
+    }
+
     static String createAuthorization(final StandardUsernamePasswordCredentials credentials) {
         final String username = credentials.getUsername();
         final Secret secretPassword = credentials.getPassword();

--- a/tfs/src/main/java/hudson/plugins/tfs/util/TeamRestClient.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/util/TeamRestClient.java
@@ -45,16 +45,7 @@ public class TeamRestClient {
     private final String authorization;
 
     public TeamRestClient(final URI collectionUri) {
-        this.collectionUri = collectionUri;
-        final String hostName = collectionUri.getHost();
-        isTeamServices = TeamCollectionConfiguration.isTeamServices(hostName);
-        final StandardUsernamePasswordCredentials credentials = TeamCollectionConfiguration.findCredentialsForCollection(collectionUri);
-        if (credentials != null) {
-            authorization = createAuthorization(credentials);
-        }
-        else {
-            authorization = null;
-        }
+        this(collectionUri, TeamCollectionConfiguration.findCredentialsForCollection(collectionUri));
     }
 
     public TeamRestClient(final URI collectionUri, final StandardUsernamePasswordCredentials credentials) {


### PR DESCRIPTION
Details
-------

1. Some users reported that the [Test connection] button would give the same results regardless of the selected _Credentials_.  This is due to the `HttpURLConnection` attempting NTLM authentication on Windows, even if that's not what was requested.  The `TeamRestClient` was rewritten to use the Apache HttpClient instead.
2. The [Test connection] button didn't perform a very good test, so it was improved to attempt to connect with the SOAP API and then fallback to the REST API with a call that validates the code_read permission.

Manual testing
==============

All the following tests were performed on a Jenkins server running on Windows.

Team Services
-------------

1. Provided incorrect credentials for a Team Services account and clicked [Test connection]
    1. The result was `Error: HTTP 401 (Unauthorized)`
![image](https://cloud.githubusercontent.com/assets/297515/18366167/9ce0de58-75e3-11e6-8d28-ce6ee3d11f5c.png)
    2. The Jenkins log contained: `authenticating as pat (...) Failure authenticating with BASIC`
2. Provided correct credentials for a Team Services account, with `code_read` scope and clicked [Test connection]
    1. The result was `Success via REST API`
![image](https://cloud.githubusercontent.com/assets/297515/18366193/b7076310-75e3-11e6-95c0-dce531a30130.png)
3. Provided correct credentials for a Team Services account, with `code_read` scope but no Git repositories and clicked [Test connection]
    1. The result was `There does not seem to be any Git repositories`
![image](https://cloud.githubusercontent.com/assets/297515/18366262/fbd75608-75e3-11e6-965d-8d8ccd89f6dc.png)
4. Provided correct credentials for a Team Services account, with `All scopes` and clicked [Test connection]
    1. The result was `Success via SOAP API`

Team Foundation Server
----------------------

1. Provided no credentials for a TFS server on a different domain and clicked [Test connection]
    1. The result was `Error: HTTP 401 (Unauthorized): (...) 401 - Unauthorized: Access is denied due to invalid credentials.`
    2. The Jenkins log contained: `authenticating as logged in user (...) Failure authenticating with NTLM`
2. Provided valid credentials for a TFS server on a different domain and clicked [Test connection].  For each of the three variations below, the result was `Success via SOAP API`:
    1. `user@fully.qualified.domain`
    2. `domain\user`
    3. `user`
3. Provided no credentials for a TFS server on the same domain and clicked [Test connection]
    1. The result was `Success via SOAP API`
    2. The Jenkins log contained: `authenticating as logged in user`
4. Provided incorrect credentials for a TFS server on the same domain and clicked [Test connection]
    1. The result was `Error: HTTP 401 (Unauthorized): (...) 401 - Unauthorized: Access is denied due to invalid credentials.`
    2. The Jenkins log showed an attempt to connect using the specified user name (and not the process identity).
5. Provided valid credentials for a TFS server on a different domain and clicked [Test connection]. 
    1. The result was `Success via SOAP API`
    2. The Jenkins log showed an attempt to connect using the specified user name (and not the process identity).
6. Temporarily disabled the SOAP-based part of the `TeamCollectionConfiguration#testConnection()` method and repeated the TFS tests to make sure the `TeamRestClient` can talk to TFS just as well as the `VersionControlClient`.

Mission accomplished!