### PR TITLE
User account mapping

### DIFF
--- a/tfs/src/main/java/hudson/plugins/tfs/TeamPluginGlobalConfig.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/TeamPluginGlobalConfig.java
@@ -2,6 +2,9 @@ package hudson.plugins.tfs;
 
 import hudson.Extension;
 import hudson.ExtensionList;
+import hudson.plugins.tfs.model.DomainUserAccountMapper;
+import hudson.plugins.tfs.model.UserAccountMapper;
+import hudson.plugins.tfs.model.UserAccountMapperDescriptor;
 import jenkins.model.GlobalConfiguration;
 import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
@@ -27,6 +30,7 @@ public class TeamPluginGlobalConfig extends GlobalConfiguration {
     private boolean configFolderPerNode;
     private boolean enableTeamPushTriggerForAllJobs;
     private boolean enableTeamStatusForAllJobs;
+    private UserAccountMapper userAccountMapper;
 
     public TeamPluginGlobalConfig() {
         this(true);
@@ -82,6 +86,21 @@ public class TeamPluginGlobalConfig extends GlobalConfiguration {
 
     public void setEnableTeamStatusForAllJobs(final boolean enableTeamStatusForAllJobs) {
         this.enableTeamStatusForAllJobs = enableTeamStatusForAllJobs;
+    }
+
+    public UserAccountMapper getUserAccountMapper() {
+        if (userAccountMapper == null) {
+            userAccountMapper = new DomainUserAccountMapper();
+        }
+        return userAccountMapper;
+    }
+
+    public void setUserAccountMapper(UserAccountMapper userAccountMapper) {
+        this.userAccountMapper = userAccountMapper;
+    }
+
+    public List<UserAccountMapperDescriptor> getUserAccountMapperDescriptors() {
+        return UserAccountMapper.all();
     }
 
     @Override

--- a/tfs/src/main/java/hudson/plugins/tfs/model/AliasOnlyUserAccountMapper.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/model/AliasOnlyUserAccountMapper.java
@@ -1,0 +1,33 @@
+package hudson.plugins.tfs.model;
+
+import hudson.Extension;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+public class AliasOnlyUserAccountMapper extends UserAccountMapper {
+    private static final long serialVersionUID = 1L;
+
+    @DataBoundConstructor
+    public AliasOnlyUserAccountMapper() {
+
+    }
+
+    @Override
+    public String mapUserAccount(final String input) {
+        final String[] split = input.split("\\\\");
+        final String result;
+        if (split.length == 2) {
+            result = split[1];
+        } else {
+            result = input;
+        }
+        return result;
+    }
+
+    @Extension
+    public static final class DescriptorImpl extends UserAccountMapperDescriptor {
+        @Override
+        public String getDisplayName() {
+            return "Resolve user using 'alias' only, removing 'DOMAIN\\'";
+        }
+    }
+}

--- a/tfs/src/main/java/hudson/plugins/tfs/model/DomainUserAccountMapper.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/model/DomainUserAccountMapper.java
@@ -1,0 +1,26 @@
+package hudson.plugins.tfs.model;
+
+import hudson.Extension;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+public class DomainUserAccountMapper extends UserAccountMapper {
+    private static final long serialVersionUID = 1L;
+
+    @DataBoundConstructor
+    public DomainUserAccountMapper() {
+
+    }
+
+    @Override
+    public String mapUserAccount(final String input) {
+        return input;
+    }
+
+    @Extension
+    public static final class DescriptorImpl extends UserAccountMapperDescriptor {
+        @Override
+        public String getDisplayName() {
+            return "Resolve user using 'DOMAIN\\alias'";
+        }
+    }
+}

--- a/tfs/src/main/java/hudson/plugins/tfs/model/Project.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/model/Project.java
@@ -2,6 +2,7 @@ package hudson.plugins.tfs.model;
 
 import com.microsoft.tfs.core.clients.versioncontrol.specs.version.LatestVersionSpec;
 import hudson.model.User;
+import hudson.plugins.tfs.TeamPluginGlobalConfig;
 import hudson.plugins.tfs.commands.GetFilesToWorkFolderCommand;
 import hudson.plugins.tfs.commands.RemoteChangesetVersionCommand;
 import hudson.plugins.tfs.model.ChangeSet.Item;
@@ -110,7 +111,9 @@ public class Project {
             synchronized (this) {
                 if (userLookup == null) {
                     final IIdentityManagementService ims = server.createIdentityManagementService();
-                    userLookup = new TfsUserLookup(ims);
+                    final TeamPluginGlobalConfig teamPluginGlobalConfig = TeamPluginGlobalConfig.get();
+                    final UserAccountMapper mapper = teamPluginGlobalConfig.getUserAccountMapper();
+                    userLookup = new TfsUserLookup(ims, mapper);
                 }
             }
         }

--- a/tfs/src/main/java/hudson/plugins/tfs/model/UserAccountMapper.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/model/UserAccountMapper.java
@@ -1,0 +1,28 @@
+package hudson.plugins.tfs.model;
+
+import hudson.DescriptorExtensionList;
+import hudson.ExtensionPoint;
+import hudson.model.Describable;
+import jenkins.model.Jenkins;
+
+import java.io.Serializable;
+
+public abstract class UserAccountMapper implements ExtensionPoint, Describable<UserAccountMapper>, Serializable {
+    private static final long serialVersionUID = 1L;
+
+    public final String getDisplayName() {
+        return getDescriptor().getDisplayName();
+    }
+
+    public UserAccountMapperDescriptor getDescriptor() {
+        final Jenkins jenkins = Jenkins.getInstance();
+        return (UserAccountMapperDescriptor) jenkins.getDescriptorOrDie(getClass());
+    }
+
+    public abstract String mapUserAccount(final String input);
+
+    public static DescriptorExtensionList<UserAccountMapper, UserAccountMapperDescriptor> all() {
+        final Jenkins jenkins = Jenkins.getInstance();
+        return jenkins.getDescriptorList(UserAccountMapper.class);
+    }
+}

--- a/tfs/src/main/java/hudson/plugins/tfs/model/UserAccountMapperDescriptor.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/model/UserAccountMapperDescriptor.java
@@ -1,0 +1,6 @@
+package hudson.plugins.tfs.model;
+
+import hudson.model.Descriptor;
+
+public abstract class UserAccountMapperDescriptor extends Descriptor<UserAccountMapper> {
+}

--- a/tfs/src/main/resources/hudson/plugins/tfs/TeamPluginGlobalConfig/config.groovy
+++ b/tfs/src/main/resources/hudson/plugins/tfs/TeamPluginGlobalConfig/config.groovy
@@ -19,6 +19,13 @@ f.section(title: descriptor.displayName) {
             description: "Turning this on is equivalent to adding the 'Set build pending status in TFS/Team Services' build step and the 'Set build completion status in TFS/Team Services' post-build action to all jobs.") {
         f.checkbox (default: false)
     }
+    f.entry() {
+        f.dropdownDescriptorSelector(
+                title: _("User account name mapping strategy"),
+                field: "userAccountMapper",
+                descriptors: descriptor.getUserAccountMapperDescriptors()
+        )
+    }
     f.advanced() {
         f.entry(title: _("Store TFVC configuration in computer-specific folders"),
                 field: "configFolderPerNode",

--- a/tfs/src/main/resources/hudson/plugins/tfs/TeamPluginGlobalConfig/help-userAccountMapper.html
+++ b/tfs/src/main/resources/hudson/plugins/tfs/TeamPluginGlobalConfig/help-userAccountMapper.html
@@ -1,0 +1,8 @@
+<div>
+    <p>
+    When interpreting changesets from TFVC, the TFS plugin will attempt to map domain accounts (i.e. <code>DOMAIN\alias</code>) to Jenkins accounts.
+    </p>
+    <p>
+    The default mapping strategy (<b>Resolve user using 'DOMAIN\alias'</b>) is to provide the string (received from TFVC) as-is to Jenkins, which causes Jenkins to convert the username from <code>DOMAIN\alias</code> to <code>DOMAIN_alias</code>.  If your Jenkins users are named with a different convention, try another user mapping strategy.
+    </p>
+</div>

--- a/tfs/src/main/resources/hudson/plugins/tfs/model/AliasOnlyUserAccountMapper/config.groovy
+++ b/tfs/src/main/resources/hudson/plugins/tfs/model/AliasOnlyUserAccountMapper/config.groovy
@@ -1,0 +1,2 @@
+package hudson.plugins.tfs.model.AliasOnlyUserAccountMapper
+

--- a/tfs/src/main/resources/hudson/plugins/tfs/model/DomainUserAccountMapper/config.groovy
+++ b/tfs/src/main/resources/hudson/plugins/tfs/model/DomainUserAccountMapper/config.groovy
@@ -1,0 +1,2 @@
+package hudson.plugins.tfs.model.DomainUserAccountMapper
+


### PR DESCRIPTION
Hi @olivierdagenais , these are my testing results.

I ran the build through Maven and made sure that the jar and hpi files were successfully created.
Once the hpi file was created, I uploaded the file and installed it on our company's Test Jenkins.
The plugin worked as expected and the UI interface made it easy for us to chose whether to keep the User ID with the domain name or User ID without the domain name. 

Example: DomainName/User ID to Only User ID
![tfs ui](https://cloud.githubusercontent.com/assets/19438767/20944027/8dbeffde-bbc7-11e6-9a4d-d4a608f22e28.jpg)

