### PR TITLE
getCommits can return null

### DIFF
--- a/tfs/src/main/java/hudson/plugins/tfs/model/AbstractHookEvent.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/model/AbstractHookEvent.java
@@ -85,6 +85,10 @@ public abstract class AbstractHookEvent {
     List<GitStatus.ResponseContributor> pollOrQueueFromEvent(final GitCodePushedEventArgs gitCodePushedEventArgs, final List<Action> actions, final boolean bypassPolling) {
         List<GitStatus.ResponseContributor> result = new ArrayList<GitStatus.ResponseContributor>();
         final String commit = gitCodePushedEventArgs.commit;
+        if (commit == null) {
+            result.add(new GitStatus.MessageResponseContributor("No commits were pushed, skipping further event processing."));
+            return result;
+        }
         final URIish uri = gitCodePushedEventArgs.getRepoURIish();
 
         TeamGlobalStatusAction.addIfApplicable(actions);

--- a/tfs/src/main/java/hudson/plugins/tfs/model/GitPushEvent.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/model/GitPushEvent.java
@@ -97,7 +97,7 @@ public class GitPushEvent extends AbstractHookEvent {
 
     static String determineCommit(final GitPush gitPush) {
         final List<GitCommitRef> commits = gitPush.getCommits();
-        if (commits.size() < 1) {
+        if (commits == null || commits.size() < 1) {
             throw new IllegalArgumentException("No commits found");
         }
         final GitCommitRef commit = commits.get(0);

--- a/tfs/src/main/java/hudson/plugins/tfs/model/GitPushEvent.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/model/GitPushEvent.java
@@ -98,7 +98,7 @@ public class GitPushEvent extends AbstractHookEvent {
     static String determineCommit(final GitPush gitPush) {
         final List<GitCommitRef> commits = gitPush.getCommits();
         if (commits == null || commits.size() < 1) {
-            throw new IllegalArgumentException("No commits found");
+            return null;
         }
         final GitCommitRef commit = commits.get(0);
         return commit.getCommitId();

--- a/tfs/src/test/java/hudson/plugins/tfs/model/GitPushEventTest.java
+++ b/tfs/src/test/java/hudson/plugins/tfs/model/GitPushEventTest.java
@@ -1,9 +1,20 @@
 package hudson.plugins.tfs.model;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.microsoft.teamfoundation.core.webapi.model.TeamProjectReference;
+import com.microsoft.visualstudio.services.webapi.model.IdentityRef;
+import hudson.plugins.tfs.model.servicehooks.Event;
+import hudson.plugins.tfs.model.servicehooks.ResourceContainer;
+import hudson.plugins.tfs.util.EndpointHelper;
+import net.sf.json.JSONArray;
+import net.sf.json.JSONObject;
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.net.URI;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.UUID;
 
 /**
  * A class to test {@link GitPushEvent}.
@@ -18,6 +29,46 @@ public class GitPushEventTest {
 
         final URI expected = URI.create("https://fabrikam-fiber-inc.visualstudio.com/");
         Assert.assertEquals(expected, actual);
+    }
+
+    @Test
+    public void perform_noCommitsInPayload() throws Exception {
+
+        final GitPushEvent gpe = new GitPushEvent();
+        final ObjectMapper mapper = EndpointHelper.MAPPER;
+        final Event event = new Event();
+        final ResourceContainer collectionResourceContainer = new ResourceContainer() {{
+            setId(UUID.fromString("c12d0eb8-e382-443b-9f9c-c52cba5014c2"));
+        }};
+        final Map<String, ResourceContainer> resourceContainers = new LinkedHashMap<String, ResourceContainer>() {{
+            put("collection", collectionResourceContainer);
+        }};
+        event.setResourceContainers(resourceContainers);
+        final TeamProjectReference project = new TeamProjectReference() {{
+            setName("Fabrikam-Fiber-Git");
+        }};
+        final Map<String, Object> repository = new LinkedHashMap<String, Object>() {{
+            put("url", "https://fabrikam-fiber-inc.visualstudio.com/DefaultCollection/_apis/git/repositories/278d5cd2-584d-4b63-824a-2ba458937249");
+            put("project", project);
+            put("remoteUrl", "https://fabrikam-fiber-inc.visualstudio.com/DefaultCollection/_git/Fabrikam-Fiber-Git");
+        }};
+        final IdentityRef pushedBy = new IdentityRef() {{
+            setDisplayName("Jamal Hartnett");
+        }};
+        final Map<String, Object> resource = new LinkedHashMap<String, Object>() {{
+            put("commits", null);
+            put("repository", repository);
+            put("pushedBy", pushedBy);
+        }};
+        event.setResource(resource);
+
+
+        final JSONObject actual = gpe.perform(mapper, event, null, null);
+
+        final JSONArray messages = actual.getJSONArray("messages");
+        Assert.assertEquals(1, messages.size());
+        final String message = messages.getString(0).trim();
+        Assert.assertEquals("No commits were pushed, skipping further event processing.", message);
     }
 
 }


### PR DESCRIPTION
```
Dez 01, 2016 1:47:22 PM SCHWERWIEGEND hudson.plugins.tfs.TeamEventsEndpoint dispatch
Error while performing reaction to 'gitPush' event.
java.lang.NullPointerException
  at hudson.plugins.tfs.model.GitPushEvent.determineCommit(GitPushEvent.java:100)
  at hudson.plugins.tfs.model.GitPushEvent.decodeGitPush(GitPushEvent.java:120)
  at hudson.plugins.tfs.model.GitPushEvent.perform(GitPushEvent.java:44)
  at hudson.plugins.tfs.TeamEventsEndpoint.innerDispatch(TeamEventsEndpoint.java:163)
  at hudson.plugins.tfs.TeamEventsEndpoint.dispatch(TeamEventsEndpoint.java:133)
  at hudson.plugins.tfs.TeamEventsEndpoint.doGitPush(TeamEventsEndpoint.java:201) 
```