### PR TITLE
JENKINS-40155: Fix event's scope deserialization

### DIFF
--- a/tfs/src/main/java/hudson/plugins/tfs/model/servicehooks/EventScope.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/model/servicehooks/EventScope.java
@@ -1,5 +1,11 @@
 package hudson.plugins.tfs.model.servicehooks;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.TreeMap;
+
 public enum EventScope {
     /**
      * No input scope specified.
@@ -30,4 +36,28 @@ public enum EventScope {
      * Deployment scope.
      */
     Deployment,
+
+    ;
+
+    private static final Map<String, EventScope> CASE_INSENSITIVE_LOOKUP;
+
+    static {
+        final Map<String, EventScope> map = new TreeMap<String, EventScope>(String.CASE_INSENSITIVE_ORDER);
+        for (final EventScope value : EventScope.values()) {
+            map.put(value.name(), value);
+        }
+        CASE_INSENSITIVE_LOOKUP = Collections.unmodifiableMap(map);
+    }
+
+    @SuppressWarnings("unused" /* Invoked by Jackson via @JsonCreator */)
+    @JsonCreator
+    public static EventScope caseInsensitiveValueOf(final String name) {
+        if (name == null) {
+            throw new NullPointerException("Name is null");
+        }
+        if (!CASE_INSENSITIVE_LOOKUP.containsKey(name)) {
+            throw new IllegalArgumentException("No enum constant " + name);
+        }
+        return CASE_INSENSITIVE_LOOKUP.get(name);
+    }
 }

--- a/tfs/src/main/resources/hudson/plugins/tfs/model/GitPullRequestMergedEvent.json
+++ b/tfs/src/main/resources/hudson/plugins/tfs/model/GitPullRequestMergedEvent.json
@@ -2,6 +2,7 @@
   "id": "6872ee8c-b333-4eff-bfb9-0d5274943566",
   "eventType": "git.pullrequest.merged",
   "publisherId": "tfs",
+  "scope": "all",
   "message": {
     "text": "Jamal Hartnett has created a pull request merge commit",
     "html": "Jamal Hartnett has created a pull request merge commit",

--- a/tfs/src/main/resources/hudson/plugins/tfs/model/GitPushEvent.json
+++ b/tfs/src/main/resources/hudson/plugins/tfs/model/GitPushEvent.json
@@ -2,6 +2,7 @@
   "id": "03c164c2-8912-4d5e-8009-3707d5f83734",
   "eventType": "git.push",
   "publisherId": "tfs",
+  "scope": "all",
   "message": {
     "text": "Jamal Hartnett pushed updates to branch master of repository Fabrikam-Fiber-Git.",
     "html": "Jamal Hartnett pushed updates to branch master of repository Fabrikam-Fiber-Git.",

--- a/tfs/src/test/java/hudson/plugins/tfs/model/servicehooks/EventScopeTest.java
+++ b/tfs/src/test/java/hudson/plugins/tfs/model/servicehooks/EventScopeTest.java
@@ -1,0 +1,11 @@
+package hudson.plugins.tfs.model.servicehooks;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * A class to test {@link EventScope}.
+ */
+public class EventScopeTest {
+
+}

--- a/tfs/src/test/java/hudson/plugins/tfs/model/servicehooks/EventScopeTest.java
+++ b/tfs/src/test/java/hudson/plugins/tfs/model/servicehooks/EventScopeTest.java
@@ -1,5 +1,6 @@
 package hudson.plugins.tfs.model.servicehooks;
 
+import hudson.plugins.tfs.util.EndpointHelper;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -7,5 +8,14 @@ import org.junit.Test;
  * A class to test {@link EventScope}.
  */
 public class EventScopeTest {
+
+    @Test
+    public void deserialize_enumCasing() throws Exception {
+        final String input = "{\"scope\": \"all\"}";
+
+        final Event actual = EndpointHelper.MAPPER.readValue(input, Event.class);
+
+        Assert.assertEquals(EventScope.All, actual.getScope());
+    }
 
 }

--- a/tfs/src/test/resources/hudson/plugins/tfs/git.push-sample.json
+++ b/tfs/src/test/resources/hudson/plugins/tfs/git.push-sample.json
@@ -2,6 +2,7 @@
   "id": "03c164c2-8912-4d5e-8009-3707d5f83734",
   "eventType": "git.push",
   "publisherId": "tfs",
+  "scope": "all",
   "message": {
     "text": "Jamal Hartnett pushed updates to branch master of repository Fabrikam-Fiber-Git.",
     "html": "Jamal Hartnett pushed updates to branch master of repository Fabrikam-Fiber-Git.",


### PR DESCRIPTION
The new unit test reproduces [JENKINS-40155](https://issues.jenkins-ci.org/browse/JENKINS-40155) and the additions to `EventScope` fix it.  I also sprinkled `"scope": "all",` in JSON files used as examples and for tests, just to be sure. :smirk: 