### PR TITLE
[JENKINS-40806] tfs plugin PCT issues against 2.19.4 and 2.32.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.580</version>
+    <version>2.19</version>
   </parent>
 
   <artifactId>tfs-parent</artifactId>
@@ -11,12 +11,15 @@
   <name>Team Foundation Server Plug-in parent</name>
   <version>5.2.2-SNAPSHOT</version>
   <properties>
-    <jenkins.version>1.580</jenkins.version>
+    <jenkins.version>1.625.1</jenkins.version>
+    <java.level>7</java.level>
     <maven-surefire-plugin.version>2.19.1</maven-surefire-plugin.version>
     <!--  overriding old version from parent to be consistent with the above in this project -->
     <maven-surefire-report-plugin.version>${maven-surefire-plugin.version}</maven-surefire-report-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    <maven-javadoc-plugin.version>2.8</maven-javadoc-plugin.version>
+    <findbugs.failOnError>false</findbugs.failOnError>
   </properties>
 
   <developers>
@@ -69,14 +72,14 @@
     <repositories>
         <repository>
             <id>repo.jenkins-ci.org</id>
-            <url>http://repo.jenkins-ci.org/public/</url>
+            <url>https://repo.jenkins-ci.org/public/</url>
         </repository>
     </repositories>
 
     <pluginRepositories>
         <pluginRepository>
             <id>repo.jenkins-ci.org</id>
-            <url>http://repo.jenkins-ci.org/public/</url>
+            <url>https://repo.jenkins-ci.org/public/</url>
         </pluginRepository>
     </pluginRepositories>
 </project>  

--- a/tfs/pom.xml
+++ b/tfs/pom.xml
@@ -105,27 +105,6 @@
           <excludedGroups>hudson.plugins.tfs.IntegrationTests</excludedGroups>
         </configuration>
       </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>animal-sniffer-maven-plugin</artifactId>
-        <!-- version inherited from parent pom -->
-        <configuration>
-          <signature>
-            <groupId>org.codehaus.mojo.signature</groupId>
-            <artifactId>java16</artifactId>
-            <version>1.1</version>
-          </signature>
-        </configuration>
-        <executions>
-          <execution>
-            <id>java.1.6.check</id>
-            <phase>verify</phase>
-            <goals>
-              <goal>check</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
     </plugins>
   </build>
 
@@ -193,12 +172,6 @@
       <version>${jenkins.version}</version>
       <scope>provided</scope>
     </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci.main</groupId>
-      <artifactId>jenkins-test-harness</artifactId>
-      <version>${jenkins.version}</version>
-      <scope>test</scope>
-    </dependency>
 
     <dependency>
       <!-- We need this plugin for the [current] TfsUserLookup implementation -->
@@ -210,7 +183,7 @@
       <!-- Used for configuring collections globally -->
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>credentials</artifactId>
-      <version>1.22</version>
+      <version>1.25</version>
     </dependency>
     <dependency>
       <!-- Used for augmenting Git-related activities, like commit status -->
@@ -246,6 +219,12 @@
       <groupId>org.littleshoot</groupId>
       <artifactId>littleproxy</artifactId>
       <version>1.1.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>junit</artifactId>
+      <version>1.6</version>
       <scope>test</scope>
     </dependency>
     

--- a/tfs/src/main/java/hudson/plugins/tfs/commands/AbstractCallableCommand.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/commands/AbstractCallableCommand.java
@@ -10,11 +10,12 @@ import hudson.plugins.tfs.model.ExtraSettings;
 import hudson.plugins.tfs.model.Server;
 import hudson.plugins.tfs.model.WebProxySettings;
 import hudson.remoting.Callable;
+import jenkins.security.MasterToSlaveCallable;
 
 import java.io.IOException;
 import java.io.Serializable;
 
-public abstract class AbstractCallableCommand implements Serializable {
+public abstract class AbstractCallableCommand<V, T extends Throwable> extends MasterToSlaveCallable<V, T> implements Serializable {
 
     private final String url;
     private final String userName;

--- a/tfs/src/main/java/hudson/plugins/tfs/commands/DeleteWorkspaceCommand.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/commands/DeleteWorkspaceCommand.java
@@ -16,7 +16,7 @@ import hudson.remoting.Callable;
 import java.io.IOException;
 import java.io.PrintStream;
 
-public class DeleteWorkspaceCommand extends AbstractCallableCommand implements Callable<Void, IOException> {
+public class DeleteWorkspaceCommand extends AbstractCallableCommand<Void, IOException> {
 
     private static final String DeletingTemplate = "Deleting workspaces named '%s' from computer '%s'...";
     private static final String DeletedTemplate = "Deleted %d workspace(s) named '%s'.";

--- a/tfs/src/main/java/hudson/plugins/tfs/commands/GetFilesToWorkFolderCommand.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/commands/GetFilesToWorkFolderCommand.java
@@ -14,7 +14,7 @@ import hudson.plugins.tfs.model.MockableVersionControlClient;
 import hudson.plugins.tfs.model.Server;
 import hudson.remoting.Callable;
 
-public class GetFilesToWorkFolderCommand extends AbstractCallableCommand implements Callable<Void, Exception>, GetListener {
+public class GetFilesToWorkFolderCommand extends AbstractCallableCommand<Void, Exception> implements GetListener {
 
     private static final String GettingTemplate = "Getting version '%s' to '%s'...";
     private static final String GotTemplate = "Finished getting version '%s'. Retrieved %d resources.";

--- a/tfs/src/main/java/hudson/plugins/tfs/commands/GetWorkspaceMappingCommand.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/commands/GetWorkspaceMappingCommand.java
@@ -9,7 +9,7 @@ import hudson.remoting.Callable;
 
 import java.io.PrintStream;
 
-public class GetWorkspaceMappingCommand extends AbstractCallableCommand implements Callable<String, Exception> {
+public class GetWorkspaceMappingCommand extends AbstractCallableCommand<String, Exception> {
 
     private static final String CheckingMappingTemplate = "Checking if there exists a mapping for %s...";
     private static final String FoundResultTemplate = "yes, in workspace '%s'.";

--- a/tfs/src/main/java/hudson/plugins/tfs/commands/LabelCommand.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/commands/LabelCommand.java
@@ -19,7 +19,7 @@ import java.io.PrintStream;
  * Command to create a label on TFS.
  * @author Rodrigo Lopes (rodrigolopes)
  */
-public class LabelCommand extends AbstractCallableCommand implements Callable<Void, Exception> {
+public class LabelCommand extends AbstractCallableCommand<Void, Exception> {
 
     private static final String CreatingTemplate = "Creating label '%s' on '%s' as of the current version in workspace '%s'...";
     private static final String CreatedTemplate = "Created label '%s'.";

--- a/tfs/src/main/java/hudson/plugins/tfs/commands/ListWorkspacesCommand.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/commands/ListWorkspacesCommand.java
@@ -17,7 +17,7 @@ import java.io.Reader;
 import java.util.ArrayList;
 import java.util.List;
 
-public class ListWorkspacesCommand extends AbstractCallableCommand implements Callable<List<Workspace>, Exception> {
+public class ListWorkspacesCommand extends AbstractCallableCommand<List<Workspace>, Exception> {
 
     private static final String ListingWorkspacesTemplate = "Downloading list of workspaces from %s...";
 

--- a/tfs/src/main/java/hudson/plugins/tfs/commands/NewWorkspaceCommand.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/commands/NewWorkspaceCommand.java
@@ -20,7 +20,7 @@ import java.util.Collection;
 import java.util.List;
 
 
-public class NewWorkspaceCommand extends AbstractCallableCommand implements Callable<Void, Exception> {
+public class NewWorkspaceCommand extends AbstractCallableCommand<Void, Exception> {
 
     private static final WorkingFolder[] EMPTY_WORKING_FOLDER_ARRAY = new WorkingFolder[0];
     private static final String CloakingTemplate = "Cloaking '%s' in workspace '%s'...";

--- a/tfs/src/main/java/hudson/plugins/tfs/commands/RemoteChangesetVersionCommand.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/commands/RemoteChangesetVersionCommand.java
@@ -30,7 +30,7 @@ import java.util.TimeZone;
  * @author Olivier Dagenais
  *
  */
-public class RemoteChangesetVersionCommand extends AbstractCallableCommand implements Callable<Integer, Exception> {
+public class RemoteChangesetVersionCommand extends AbstractCallableCommand<Integer, Exception> {
 
     private static final String QueryingTemplate = "Querying for remote changeset at '%s' as of '%s'...";
     private static final String ResultTemplate = "Query result is: Changeset #%d by '%s' on '%s'.";

--- a/tfs/src/main/java/hudson/plugins/tfs/model/Server.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/model/Server.java
@@ -26,6 +26,7 @@ import hudson.remoting.Callable;
 import hudson.remoting.VirtualChannel;
 import hudson.util.Secret;
 import jenkins.model.Jenkins;
+import jenkins.security.MasterToSlaveCallable;
 
 import java.io.IOException;
 import java.lang.reflect.Field;
@@ -136,7 +137,7 @@ public class Server implements ServerConfigurationProvider, Closable {
         if (jenkins == null) {
             if (channel != null) {
                 try {
-                    result = channel.call(new Callable<TeamPluginGlobalConfig, Throwable>() {
+                    result = channel.call(new MasterToSlaveCallable<TeamPluginGlobalConfig, Throwable>() {
                         @Override
                         public TeamPluginGlobalConfig call() throws Throwable {
                             final Jenkins jenkins = Jenkins.getInstance();
@@ -165,7 +166,7 @@ public class Server implements ServerConfigurationProvider, Closable {
         if (jenkins == null) {
             if (channel != null) {
                 try {
-                    proxyConfiguration = channel.call(new Callable<ProxyConfiguration, Throwable>() {
+                    proxyConfiguration = channel.call(new MasterToSlaveCallable<ProxyConfiguration, Throwable>() {
                         public ProxyConfiguration call() throws Throwable {
                             final Jenkins jenkins = Jenkins.getInstance();
                             final ProxyConfiguration result = jenkins != null ? jenkins.proxy : null;

--- a/tfs/src/main/resources/hudson/plugins/tfs/TFSLabeler/config.jelly
+++ b/tfs/src/main/resources/hudson/plugins/tfs/TFSLabeler/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 	<f:entry title="Label" help="/plugin/tfs/labelname.html">
 		<f:textbox name="tfsLabeler.labelName" value="${instance.labelName}" />

--- a/tfs/src/main/resources/hudson/plugins/tfs/TFSLabeler/global.jelly
+++ b/tfs/src/main/resources/hudson/plugins/tfs/TFSLabeler/global.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 
 </j:jelly>

--- a/tfs/src/main/resources/hudson/plugins/tfs/TeamFoundationServerScm/config.jelly
+++ b/tfs/src/main/resources/hudson/plugins/tfs/TeamFoundationServerScm/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
     <f:entry field="serverUrl" title="Collection URL" description="The URL to the team project collection">
         <f:combobox clazz="required" checkMessage="${%Collection URL is mandatory.}"/>

--- a/tfs/src/main/resources/hudson/plugins/tfs/browsers/TeamSystemWebAccessBrowser/config.jelly
+++ b/tfs/src/main/resources/hudson/plugins/tfs/browsers/TeamSystemWebAccessBrowser/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
   <f:entry title="URL" help="/plugin/tfs/browsers/tswa.html">
     <f:textbox name="tswa.tfs.urlExample" value="${browser.url}"/>

--- a/tfs/src/main/resources/hudson/plugins/tfs/model/ChangeLogSet/digest.jelly
+++ b/tfs/src/main/resources/hudson/plugins/tfs/model/ChangeLogSet/digest.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <j:choose>
     <j:when test="${it.emptySet}">

--- a/tfs/src/main/resources/hudson/plugins/tfs/model/ChangeLogSet/index.jelly
+++ b/tfs/src/main/resources/hudson/plugins/tfs/model/ChangeLogSet/index.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <j:set var="browser" value="${it.build.parent.scm.effectiveBrowser}"/>
   


### PR DESCRIPTION
[JENKINS-40806](https://issues.jenkins-ci.org/browse/JENKINS-40806)

- Increase parent POM version.
- Increase baseline.
- Include necessary dependencies.
- Include "escape-by-default" property in Jelly files.
- Use MasterToSlaveCallable needed in new baseline version.

@yacaovsnc @DavidStaheli @mosabua @reviewbybees 