### PR TITLE
Support WorkflowJob (Pipeline) jobs

### DIFF
--- a/tfs/src/main/java/hudson/plugins/tfs/model/AbstractCommand.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/model/AbstractCommand.java
@@ -1,7 +1,8 @@
 package hudson.plugins.tfs.model;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import hudson.model.AbstractProject;
+import hudson.model.BuildableItem;
+import hudson.model.Job;
 import hudson.plugins.tfs.model.servicehooks.Event;
 import jenkins.util.TimeDuration;
 import net.sf.json.JSONObject;
@@ -21,7 +22,8 @@ public abstract class AbstractCommand {
      * Actually do the work of the command, using the supplied {@code requestPayload} and
      * {@code teamBuildPayload}, then returning the output as a {@link JSONObject}.
      *
-     * @param project an {@link AbstractProject to operate on}
+     * @param job an {@link Job to operate on}
+     * @param buildableItem an {@link BuildableItem to operate on}
      * @param request a {@link StaplerRequest} to help build parameter values
      * @param requestPayload a {@link JSONObject} representing the command's input
      * @param mapper an {@link ObjectMapper} instance to use to convert the {@link Event#resource}
@@ -30,6 +32,6 @@ public abstract class AbstractCommand {
      *
      * @return a {@link JSONObject} representing the hook event's output
      */
-    public abstract JSONObject perform(final AbstractProject project, final StaplerRequest request, final JSONObject requestPayload, final ObjectMapper mapper, final TeamBuildPayload teamBuildPayload, final TimeDuration delay);
+    public abstract JSONObject perform(final Job<?, ?> job, final BuildableItem buildableItem, final StaplerRequest request, final JSONObject requestPayload, final ObjectMapper mapper, final TeamBuildPayload teamBuildPayload, final TimeDuration delay);
 
 }

--- a/tfs/src/main/java/hudson/plugins/tfs/model/PingCommand.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/model/PingCommand.java
@@ -1,7 +1,8 @@
 package hudson.plugins.tfs.model;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import hudson.model.AbstractProject;
+import hudson.model.BuildableItem;
+import hudson.model.Job;
 import jenkins.util.TimeDuration;
 import net.sf.json.JSONObject;
 import org.kohsuke.stapler.StaplerRequest;
@@ -27,7 +28,9 @@ public class PingCommand extends AbstractCommand {
     }
 
     @Override
-    public JSONObject perform(final AbstractProject project, final StaplerRequest request, final JSONObject requestPayload, final ObjectMapper mapper, final TeamBuildPayload teamBuildPayload, final TimeDuration delay) {
+    public JSONObject perform(final Job project, final BuildableItem buildableItem, final StaplerRequest request,
+                              final JSONObject requestPayload, final ObjectMapper mapper,
+                              final TeamBuildPayload teamBuildPayload, final TimeDuration delay) {
         return requestPayload;
     }
 


### PR DESCRIPTION
Today when triggering a Pipeline job, we will get a "Project not found" exception as `WorkflowJob` is not of `AbstractProject` type.  

All information the plugin requires can be retrieved by `BuildableItem` and `ParameterizedJobMixin.ParameterizedJob` interface, and `WorkflowJob` implements both interfaces.  The change is to explicitly cast both `AbstractProject` and `WorkflowJob` down to `BuildableItem` and `ParameterizedJobMixin.ParameterizedJob` and pass it around as such.
