### PR TITLE
ignoring eclipse files also in the modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,8 @@
-/.settings
+.settings
 **/target
 **/workspaces
 **/work
-/.project
-/.classpath
+.project
+.classpath
 /.idea
 **/*.iml


### PR DESCRIPTION
Eclipse/M2e maintains files in each module folder and since we have a multi-module project now we need to expand the exclusion to any folder...