### PR TITLE
feat: default TFS workspace name to 'Jenkins-${JOB_NAME}'

### DIFF
--- a/tfs/src/main/java/hudson/plugins/tfs/TeamFoundationServerScm.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/TeamFoundationServerScm.java
@@ -127,7 +127,7 @@ public class TeamFoundationServerScm extends SCM {
     public TeamFoundationServerScm(String serverUrl, String projectPath, String workspaceName, String userName, Secret password) {
         this.serverUrl = serverUrl;
         this.projectPath = projectPath;
-        this.workspaceName = (Util.fixEmptyAndTrim(workspaceName) == null ? "Hudson-${JOB_NAME}-${NODE_NAME}" : workspaceName);
+        this.workspaceName = (Util.fixEmptyAndTrim(workspaceName) == null ? "Jenkins-${JOB_NAME}" : workspaceName);
         this.userName = userName;
         this.password = password;
     }

--- a/tfs/src/main/resources/hudson/plugins/tfs/TeamFoundationServerScm/config.jelly
+++ b/tfs/src/main/resources/hudson/plugins/tfs/TeamFoundationServerScm/config.jelly
@@ -26,7 +26,7 @@
 	    </f:entry>
 
         <f:entry field="workspaceName" title="Workspace name">
-            <f:textbox default="Hudson-$${JOB_NAME}-$${NODE_NAME}"
+            <f:textbox default="Jenkins-$${JOB_NAME}"
              checkUrl="'${rootURL}/scm/TeamFoundationServerScm/workspaceNameCheck?value='+escape(this.value)"/>
         </f:entry>
 

--- a/tfs/src/main/resources/hudson/plugins/tfs/TeamFoundationServerScm/help-workspaceName.html
+++ b/tfs/src/main/resources/hudson/plugins/tfs/TeamFoundationServerScm/help-workspaceName.html
@@ -1,18 +1,18 @@
 <div>
   <p>
-	The name of the Workspace under which the source should be retrieved. This workspace is 
+	The name of the Workspace under which the source should be retrieved. This workspace is
 	created as needed. You can normally
-	omit the property unless you want to name a workspace to avoid conflicts 
-	on the server (i.e. when you have multiple projects on one server talking 
+	omit the property unless you want to name a workspace to avoid conflicts
+	on the server (i.e. when you have multiple projects on one server talking
 	to TFS/Team Services)
   </p>
   <p>
-    The default value is to create a workspace named <tt>Hudson-${JOB_NAME}</tt>. The TFS plugin for Jenkins
+    The default value is to create a workspace named <tt>Jenkins-${JOB_NAME}</tt>. The TFS plugin for Jenkins
     supports the following macros that are replaced in the workspace name:
     <ul>
 	    <li><tt>${JOB_NAME}</tt> - The name of the job.</li>
 	    <li><tt>${USER_NAME}</tt> - The user name that the Hudson server or slave is running as.</li>
-	    <li><tt>${NODE_NAME}</tt> - The name of the node/slave that the plugin currently is executed on. 
+	    <li><tt>${NODE_NAME}</tt> - The name of the node/slave that the plugin currently is executed on.
 	    Note that this is not the hostname, this value is Hudson configured name of the slave/node.</li>
 	    <li><tt>${ENV}</tt> - The environment variable that is set on the master or slave.</li>
     </ul>


### PR DESCRIPTION
Consolidates documentation and default parameters from 'Hudson-${JOB_NAME}' and
'Hudson-${JOB_NAME}-${NODE_NAME} to 'Jenkins-${JOB_NAME}'. Having the node name
as part of the workspace name is not needed any more since the TFS plugin
transparently supports nodes/ agents/ slaves.