### PR TITLE
Added the opton to toggle show workspaces in log

### DIFF
--- a/tfs/src/main/java/hudson/plugins/tfs/commands/ListWorkspacesCommand.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/commands/ListWorkspacesCommand.java
@@ -28,9 +28,8 @@ public class ListWorkspacesCommand extends AbstractCallableCommand implements Ca
         Workspace createWorkspace(String name, String computer, String owner, String comment);
     }
     
-    public ListWorkspacesCommand(final ServerConfigurationProvider server) {
-        // TODO: shouldLogWorkspaces could be controlled by a property
-        this(server, null, false);
+    public ListWorkspacesCommand(final Server server) {
+        this(server, null, server.getShouldLogWorkspaces());
     }
 
     ListWorkspacesCommand(final ServerConfigurationProvider server, final String computer, final boolean shouldLogWorkspaces) {

--- a/tfs/src/main/java/hudson/plugins/tfs/model/Server.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/model/Server.java
@@ -49,16 +49,25 @@ public class Server implements ServerConfigurationProvider, Closable {
     private final ExtraSettings extraSettings;
     private MockableVersionControlClient mockableVcc;
     private static HashMap<String, PersistenceStoreProvider> persistenceStoreProviderCache = new HashMap<String, PersistenceStoreProvider>();
+    private boolean shouldLogWorkspaces;
 
 
     /**
      * This constructor overload assumes a Jenkins instance is present.
      */
     public Server(final Launcher launcher, final TaskListener taskListener, final String url, final String username, final String password) throws IOException {
-        this(launcher, taskListener, url, username, password, null, null);
+        this(launcher, taskListener, url, username, password, null, null,false);
+    }
+
+    public Server(final Launcher launcher, final TaskListener taskListener, final String url, final String username, final String password, boolean shouldLogWorkspaces) throws IOException {
+        this(launcher, taskListener, url, username, password, null, null, shouldLogWorkspaces);
     }
 
     public static Server create(final Launcher launcher, final TaskListener taskListener, final String url, final StandardUsernamePasswordCredentials credentials, final WebProxySettings webProxySettings, final ExtraSettings extraSettings) throws IOException {
+        return create(launcher, taskListener, url, credentials, webProxySettings, extraSettings, false);
+    }
+
+    public static Server create(final Launcher launcher, final TaskListener taskListener, final String url, final StandardUsernamePasswordCredentials credentials, final WebProxySettings webProxySettings, final ExtraSettings extraSettings, boolean shouldLogWorkspaces) throws IOException {
 
         final String username;
         final String userPassword;
@@ -71,15 +80,21 @@ public class Server implements ServerConfigurationProvider, Closable {
             final Secret password = credentials.getPassword();
             userPassword = password.getPlainText();
         }
-        return new Server(launcher, taskListener, url, username, userPassword, webProxySettings, extraSettings);
+        return new Server(launcher, taskListener, url, username, userPassword, webProxySettings, extraSettings, shouldLogWorkspaces);
     }
 
     public Server(final Launcher launcher, final TaskListener taskListener, final String url, final String username, final String password, final WebProxySettings webProxySettings, final ExtraSettings extraSettings) throws IOException {
+        this(launcher, taskListener, url, username, password, webProxySettings, extraSettings, false) ;
+    }
+
+    public Server(final Launcher launcher, final TaskListener taskListener, final String url, final String username, final String password, final WebProxySettings webProxySettings, final ExtraSettings extraSettings, boolean shouldLogWorkspaces) throws IOException {
         this.launcher = launcher;
         this.taskListener = taskListener;
         this.url = url;
         this.userName = username;
         this.userPassword = password;
+        this.shouldLogWorkspaces = shouldLogWorkspaces;
+
         final URI uri = URIUtils.newURI(url);
 
         NativeLibraryManager.initialize();
@@ -256,6 +271,10 @@ public class Server implements ServerConfigurationProvider, Closable {
 
     public ExtraSettings getExtraSettings() {
         return extraSettings;
+    }
+
+    public boolean getShouldLogWorkspaces() {
+        return this.shouldLogWorkspaces;
     }
 
     public TaskListener getListener() {

--- a/tfs/src/main/resources/hudson/plugins/tfs/TeamFoundationServerScm/config.jelly
+++ b/tfs/src/main/resources/hudson/plugins/tfs/TeamFoundationServerScm/config.jelly
@@ -30,6 +30,10 @@
              checkUrl="'${rootURL}/scm/TeamFoundationServerScm/workspaceNameCheck?value='+escape(this.value)"/>
         </f:entry>
 
+        <f:entry field="showWorkspaceInBuildLog" title="Show all workspaces" description="If checked, all workspaces from server will be shown in the build log.">
+			<f:checkbox default="false"/>
+		</f:entry>
+
         <f:entry field="cloakedPaths" title="Cloaked paths" description="A collection of server paths to cloak to exclude from the workspace and from the build trigger.  Multiple entries must be placed onto separate lines.">
             <f:textarea checkUrl="'${rootURL}/scm/TeamFoundationServerScm/cloakedPathsCheck?value='+escape(this.value)"/>
         </f:entry>

--- a/tfs/src/test/java/hudson/plugins/tfs/TeamFoundationServerScmTest.java
+++ b/tfs/src/test/java/hudson/plugins/tfs/TeamFoundationServerScmTest.java
@@ -1,35 +1,9 @@
 package hudson.plugins.tfs;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.*;
-import static org.mockito.Matchers.isA;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.when;
-
-import java.io.File;
-import java.io.IOException;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.GregorianCalendar;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-
 import com.microsoft.tfs.core.clients.versioncontrol.specs.version.VersionSpec;
 import com.thoughtworks.xstream.XStream;
 import hudson.FilePath;
-import hudson.model.AbstractBuild;
-import hudson.model.AbstractProject;
-import hudson.model.BuildListener;
-import hudson.model.Computer;
-import hudson.model.Node;
-import hudson.model.ParametersAction;
-
+import hudson.model.*;
 import hudson.plugins.tfs.model.Project;
 import hudson.util.Secret;
 import hudson.util.SecretOverride;
@@ -37,6 +11,15 @@ import hudson.util.XStream2;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.*;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.isA;
+import static org.mockito.Mockito.*;
 
 
 @SuppressWarnings("unchecked")
@@ -88,6 +71,7 @@ public class TeamFoundationServerScmTest {
                             "  <userName>example\\tfsbuilder</userName>\n" +
                             "  <credentialsConfigurer class=\"hudson.plugins.tfs.model.ManualCredentialsConfigurer\"/>\n" +
                             "  <useUpdate>false</useUpdate>\n" +
+                            "  <showWorkspaceInBuildLog>false</showWorkspaceInBuildLog>\n" +
                             "</hudson.plugins.tfs.TeamFoundationServerScm>";
 
             final String actualUpgradedXml = serializer.toXML(tfsScmObject);


### PR DESCRIPTION
A new UI checkbox under Advanced settings gives option to show or not show the workspaces in the build log file. Sometimes, we send the build log failure by Jenkins Ext-Email plugin where we don't want to clutter log with all workspaces. In some other cases, we want to see workspaces in the log. With this configuration option, we can control each Jenkins build the way we want it.
![image](https://cloud.githubusercontent.com/assets/9042580/25302090/b672a186-26ea-11e7-8436-f4fa3cf1aba4.png)