### PR TITLE
Fix tfs push trigger

### DIFF
--- a/tfs/src/main/java/hudson/plugins/tfs/TeamPushTrigger.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/TeamPushTrigger.java
@@ -119,7 +119,7 @@ public class TeamPushTrigger extends Trigger<Job<?, ?>> {
             boolean shouldSchedule = bypassPolling;
             String changesDetected = "";
             if (!bypassPolling) {
-                if (runPolling() || gitCodePushedEventArgs.commit != null) {
+                if (runPolling() || StringUtils.isNotBlank(gitCodePushedEventArgs.commit)) {
                     changesDetected = "SCM changes detected in " + job.getFullDisplayName() + ". ";
                     shouldSchedule = true;
                 }

--- a/tfs/src/main/java/hudson/plugins/tfs/TeamPushTrigger.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/TeamPushTrigger.java
@@ -119,13 +119,13 @@ public class TeamPushTrigger extends Trigger<Job<?, ?>> {
             boolean shouldSchedule = bypassPolling;
             String changesDetected = "";
             if (!bypassPolling) {
-                if (runPolling()) {
+                if (runPolling() || gitCodePushedEventArgs.commit != null) {
                     changesDetected = "SCM changes detected in " + job.getFullDisplayName() + ". ";
                     shouldSchedule = true;
                 }
             }
             else {
-                changesDetected = "Polling bypassed for " + job.getFullDisplayName() + ". ";;
+                changesDetected = "Polling bypassed for " + job.getFullDisplayName() + ". ";
             }
             if (shouldSchedule) {
                 final SCMTriggerItem p = job();

--- a/tfs/src/main/java/hudson/plugins/tfs/TeamPushTrigger.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/TeamPushTrigger.java
@@ -17,6 +17,7 @@ import hudson.util.StreamTaskListener;
 import jenkins.model.ParameterizedJobMixIn;
 import jenkins.triggers.SCMTriggerItem;
 import org.apache.commons.jelly.XMLOutput;
+import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import java.io.File;

--- a/tfs/src/main/java/hudson/plugins/tfs/TeamPushTrigger.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/TeamPushTrigger.java
@@ -120,6 +120,8 @@ public class TeamPushTrigger extends Trigger<Job<?, ?>> {
             boolean shouldSchedule = bypassPolling;
             String changesDetected = "";
             if (!bypassPolling) {
+                // pipeline jobs might have runPolling() returned as false, while still should be scheduled.
+                // we should shedule them as long as they are associated with a valid commit.
                 if (runPolling() || StringUtils.isNotBlank(gitCodePushedEventArgs.commit)) {
                     changesDetected = "SCM changes detected in " + job.getFullDisplayName() + ". ";
                     shouldSchedule = true;

--- a/tfs/src/main/java/hudson/plugins/tfs/model/AbstractHookEvent.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/model/AbstractHookEvent.java
@@ -167,50 +167,18 @@ public abstract class AbstractHookEvent {
                 LOGGER.severe("Jenkins.getInstance() is null");
                 return result;
             }
-            int totalRepositoryMatches = 0;  
+            int totalRepositoryMatches = 0;
             for (final Item project : Jenkins.getInstance().getAllItems()) {
                 final SCMTriggerItem scmTriggerItem = SCMTriggerItem.SCMTriggerItems.asSCMTriggerItem(project);
-                if (scmTriggerItem == null || scmTriggerItem.getSCMs() == null) {
+                if (scmTriggerItem == null) {
                     continue;
                 }
 
-                if (scmTriggerItem.getSCMs().isEmpty())
-                {
-                    GitStatus.ResponseContributor triggerResult = triggerJob(gitCodePushedEventArgs, actions, bypassPolling, project, scmTriggerItem);
-                    if (triggerResult != null) {
-                        result.add(triggerResult);
-                    }
-                    continue;
+                GitStatus.ResponseContributor triggerResult = triggerJob(gitCodePushedEventArgs, actions, bypassPolling, project, scmTriggerItem);
+                if (triggerResult != null) {
+                    result.add(triggerResult);
                 }
-                
-                for (final SCM scm : scmTriggerItem.getSCMs()) {
-                    if (!(scm instanceof GitSCM)) {
-                        continue;
-                    }
-                    final GitSCM git = (GitSCM) scm;
-                    scmFound = true;
-                    
-                    for (final RemoteConfig repository : git.getRepositories()) {
-                        boolean repositoryMatches = false;
-                        for (final URIish remoteURL : repository.getURIs()) {
-                            if (UriHelper.areSameGitRepo(uri, remoteURL)) {
-                                repositoryMatches = true;
-                                totalRepositoryMatches++;
-                                break;
-                            }
-                        }
-
-                        if (!repositoryMatches || git.getExtensions().get(IgnoreNotifyCommit.class)!=null) {
-                            continue;
-                        }                      
-
-                        GitStatus.ResponseContributor triggerResult = triggerJob(gitCodePushedEventArgs, actions, bypassPolling, project, scmTriggerItem);
-                        if (triggerResult != null) {
-                            result.add(triggerResult);
-                            break;
-                        }
-                    }
-                }
+                continue;
             }
             if (!scmFound) {
                 result.add(new GitStatus.MessageResponseContributor("No Git jobs found"));

--- a/tfs/src/main/java/hudson/plugins/tfs/model/AbstractHookEvent.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/model/AbstractHookEvent.java
@@ -170,15 +170,47 @@ public abstract class AbstractHookEvent {
             int totalRepositoryMatches = 0;
             for (final Item project : Jenkins.getInstance().getAllItems()) {
                 final SCMTriggerItem scmTriggerItem = SCMTriggerItem.SCMTriggerItems.asSCMTriggerItem(project);
-                if (scmTriggerItem == null) {
+                if (scmTriggerItem == null || scmTriggerItem.getSCMs() == null) {
                     continue;
                 }
 
-                GitStatus.ResponseContributor triggerResult = triggerJob(gitCodePushedEventArgs, actions, bypassPolling, project, scmTriggerItem);
-                if (triggerResult != null) {
-                    result.add(triggerResult);
+                if (scmTriggerItem.getSCMs().isEmpty())
+                {
+                    GitStatus.ResponseContributor triggerResult = triggerJob(gitCodePushedEventArgs, actions, bypassPolling, project, scmTriggerItem);
+                    if (triggerResult != null) {
+                        result.add(triggerResult);
+                    }
+                    continue;
                 }
-                continue;
+                
+                for (final SCM scm : scmTriggerItem.getSCMs()) {
+                    if (!(scm instanceof GitSCM)) {
+                        continue;
+                    }
+                    final GitSCM git = (GitSCM) scm;
+                    scmFound = true;
+                    
+                    for (final RemoteConfig repository : git.getRepositories()) {
+                        boolean repositoryMatches = false;
+                        for (final URIish remoteURL : repository.getURIs()) {
+                            if (UriHelper.areSameGitRepo(uri, remoteURL)) {
+                                repositoryMatches = true;
+                                totalRepositoryMatches++;
+                                break;
+                            }
+                        }
+
+                        if (!repositoryMatches || git.getExtensions().get(IgnoreNotifyCommit.class)!=null) {
+                            continue;
+                        }                      
+
+                        GitStatus.ResponseContributor triggerResult = triggerJob(gitCodePushedEventArgs, actions, bypassPolling, project, scmTriggerItem);
+                        if (triggerResult != null) {
+                            result.add(triggerResult);
+                            break;
+                        }
+                    }
+                }
             }
             if (!scmFound) {
                 result.add(new GitStatus.MessageResponseContributor("No Git jobs found"));

--- a/tfs/src/main/java/hudson/plugins/tfs/model/AbstractHookEvent.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/model/AbstractHookEvent.java
@@ -81,6 +81,68 @@ public abstract class AbstractHookEvent {
         return result;
     }
 
+    GitStatus.ResponseContributor triggerJob(final GitCodePushedEventArgs gitCodePushedEventArgs, final List<Action> actions, final boolean bypassPolling, final Item project, final SCMTriggerItem scmTriggerItem) {
+        GitStatus.ResponseContributor gitResponse = null;
+        
+        if (!(project instanceof AbstractProject && ((AbstractProject) project).isDisabled())) {
+            if (project instanceof Job) {
+                // TODO: Add default parameters defined in the job
+                final Job job = (Job) project;
+                final int quietPeriod = scmTriggerItem.getQuietPeriod();                
+                
+                boolean triggered = false;
+                if (!triggered) {
+                    final TeamPluginGlobalConfig config = TeamPluginGlobalConfig.get();
+                    if (config.isEnableTeamPushTriggerForAllJobs()) {
+                        triggered = true;
+                        final SCMTrigger scmTrigger = TeamEventsEndpoint.findTrigger(job, SCMTrigger.class);
+                        if (scmTrigger != null && scmTrigger.isIgnorePostCommitHooks()) {
+                            // job has explicitly opted out of hooks
+                            triggered = false;
+                        }
+                    }
+                    if (triggered) {
+                        final TeamPushTrigger trigger = new TeamPushTrigger(job);
+                        trigger.execute(gitCodePushedEventArgs, actions, bypassPolling);
+                        if (bypassPolling) {
+                            gitResponse = new TeamEventsEndpoint.ScheduledResponseContributor(project);
+                        }
+                        else {
+                            gitResponse = new TeamEventsEndpoint.PollingScheduledResponseContributor(project);
+                        }
+                    }
+                }
+                if (!triggered) {
+                    final SCMTrigger scmTrigger = TeamEventsEndpoint.findTrigger(job, SCMTrigger.class);
+                    if (scmTrigger != null && !scmTrigger.isIgnorePostCommitHooks()) {
+                        // queue build without first polling
+                        final Cause cause = new TeamHookCause(gitCodePushedEventArgs.commit);
+                        final CauseAction causeAction = new CauseAction(cause);
+                        final Action[] actionArray = ActionHelper.create(actions, causeAction);
+                        scmTriggerItem.scheduleBuild2(quietPeriod, actionArray);
+                        gitResponse = new TeamEventsEndpoint.ScheduledResponseContributor(project);
+                        triggered = true;
+                    }
+                }
+                if (!triggered) {
+                    final TeamPushTrigger pushTrigger = TeamEventsEndpoint.findTrigger(job, TeamPushTrigger.class);
+                    if (pushTrigger != null) {
+                        pushTrigger.execute(gitCodePushedEventArgs, actions, bypassPolling);
+                        final GitStatus.ResponseContributor response;
+                        if (bypassPolling) {
+                            gitResponse = new TeamEventsEndpoint.ScheduledResponseContributor(project);
+                        }
+                        else {
+                            gitResponse = new TeamEventsEndpoint.PollingScheduledResponseContributor(project);
+                        }
+                        triggered = true;
+                    }
+                }
+            }
+        }
+        return gitResponse;
+    }    
+    
     // TODO: it would be easiest if pollOrQueueFromEvent built a JSONObject directly
     List<GitStatus.ResponseContributor> pollOrQueueFromEvent(final GitCodePushedEventArgs gitCodePushedEventArgs, final List<Action> actions, final boolean bypassPolling) {
         List<GitStatus.ResponseContributor> result = new ArrayList<GitStatus.ResponseContributor>();
@@ -105,19 +167,29 @@ public abstract class AbstractHookEvent {
                 LOGGER.severe("Jenkins.getInstance() is null");
                 return result;
             }
-            int totalRepositoryMatches = 0;
+            int totalRepositoryMatches = 0;  
             for (final Item project : Jenkins.getInstance().getAllItems()) {
                 final SCMTriggerItem scmTriggerItem = SCMTriggerItem.SCMTriggerItems.asSCMTriggerItem(project);
-                if (scmTriggerItem == null) {
+                if (scmTriggerItem == null || scmTriggerItem.getSCMs() == null) {
                     continue;
                 }
+
+                if (scmTriggerItem.getSCMs().isEmpty())
+                {
+                    GitStatus.ResponseContributor triggerResult = triggerJob(gitCodePushedEventArgs, actions, bypassPolling, project, scmTriggerItem);
+                    if (triggerResult != null) {
+                        result.add(triggerResult);
+                    }
+                    continue;
+                }
+                
                 for (final SCM scm : scmTriggerItem.getSCMs()) {
                     if (!(scm instanceof GitSCM)) {
                         continue;
                     }
                     final GitSCM git = (GitSCM) scm;
                     scmFound = true;
-
+                    
                     for (final RemoteConfig repository : git.getRepositories()) {
                         boolean repositoryMatches = false;
                         for (final URIish remoteURL : repository.getURIs()) {
@@ -130,69 +202,12 @@ public abstract class AbstractHookEvent {
 
                         if (!repositoryMatches || git.getExtensions().get(IgnoreNotifyCommit.class)!=null) {
                             continue;
-                        }
+                        }                      
 
-                        if (!(project instanceof AbstractProject && ((AbstractProject) project).isDisabled())) {
-                            if (project instanceof Job) {
-                                // TODO: Add default parameters defined in the job
-                                final Job job = (Job) project;
-                                final int quietPeriod = scmTriggerItem.getQuietPeriod();
-
-                                boolean triggered = false;
-                                if (!triggered) {
-                                    final TeamPluginGlobalConfig config = TeamPluginGlobalConfig.get();
-                                    if (config.isEnableTeamPushTriggerForAllJobs()) {
-                                        triggered = true;
-                                        final SCMTrigger scmTrigger = TeamEventsEndpoint.findTrigger(job, SCMTrigger.class);
-                                        if (scmTrigger != null && scmTrigger.isIgnorePostCommitHooks()) {
-                                            // job has explicitly opted out of hooks
-                                            triggered = false;
-                                        }
-                                    }
-                                    if (triggered) {
-                                        final TeamPushTrigger trigger = new TeamPushTrigger(job);
-                                        trigger.execute(gitCodePushedEventArgs, actions, bypassPolling);
-                                        final GitStatus.ResponseContributor response;
-                                        if (bypassPolling) {
-                                            response = new TeamEventsEndpoint.ScheduledResponseContributor(project);
-                                        }
-                                        else {
-                                            response = new TeamEventsEndpoint.PollingScheduledResponseContributor(project);
-                                        }
-                                        result.add(response);
-                                    }
-                                }
-                                if (!triggered) {
-                                    final SCMTrigger scmTrigger = TeamEventsEndpoint.findTrigger(job, SCMTrigger.class);
-                                    if (scmTrigger != null && !scmTrigger.isIgnorePostCommitHooks()) {
-                                        // queue build without first polling
-                                        final Cause cause = new TeamHookCause(commit);
-                                        final CauseAction causeAction = new CauseAction(cause);
-                                        final Action[] actionArray = ActionHelper.create(actions, causeAction);
-                                        scmTriggerItem.scheduleBuild2(quietPeriod, actionArray);
-                                        result.add(new TeamEventsEndpoint.ScheduledResponseContributor(project));
-                                        triggered = true;
-                                    }
-                                }
-                                if (!triggered) {
-                                    final TeamPushTrigger pushTrigger = TeamEventsEndpoint.findTrigger(job, TeamPushTrigger.class);
-                                    if (pushTrigger != null) {
-                                        pushTrigger.execute(gitCodePushedEventArgs, actions, bypassPolling);
-                                        final GitStatus.ResponseContributor response;
-                                        if (bypassPolling) {
-                                            response = new TeamEventsEndpoint.ScheduledResponseContributor(project);
-                                        }
-                                        else {
-                                            response = new TeamEventsEndpoint.PollingScheduledResponseContributor(project);
-                                        }
-                                        result.add(response);
-                                        triggered = true;
-                                    }
-                                }
-                                if (triggered) {
-                                    break;
-                                }
-                            }
+                        GitStatus.ResponseContributor triggerResult = triggerJob(gitCodePushedEventArgs, actions, bypassPolling, project, scmTriggerItem);
+                        if (triggerResult != null) {
+                            result.add(triggerResult);
+                            break;
                         }
                     }
                 }

--- a/tfs/src/main/java/hudson/plugins/tfs/model/AbstractHookEvent.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/model/AbstractHookEvent.java
@@ -182,7 +182,7 @@ public abstract class AbstractHookEvent {
                     }
                     continue;
                 }
-                
+
                 for (final SCM scm : scmTriggerItem.getSCMs()) {
                     if (!(scm instanceof GitSCM)) {
                         continue;
@@ -202,7 +202,7 @@ public abstract class AbstractHookEvent {
 
                         if (!repositoryMatches || git.getExtensions().get(IgnoreNotifyCommit.class)!=null) {
                             continue;
-                        }                      
+                        }
 
                         GitStatus.ResponseContributor triggerResult = triggerJob(gitCodePushedEventArgs, actions, bypassPolling, project, scmTriggerItem);
                         if (triggerResult != null) {

--- a/tfs/src/main/java/hudson/plugins/tfs/model/AbstractHookEvent.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/model/AbstractHookEvent.java
@@ -182,7 +182,7 @@ public abstract class AbstractHookEvent {
                     }
                     continue;
                 }
-
+                
                 for (final SCM scm : scmTriggerItem.getSCMs()) {
                     if (!(scm instanceof GitSCM)) {
                         continue;
@@ -202,7 +202,7 @@ public abstract class AbstractHookEvent {
 
                         if (!repositoryMatches || git.getExtensions().get(IgnoreNotifyCommit.class)!=null) {
                             continue;
-                        }
+                        }                      
 
                         GitStatus.ResponseContributor triggerResult = triggerJob(gitCodePushedEventArgs, actions, bypassPolling, project, scmTriggerItem);
                         if (triggerResult != null) {

--- a/tfs/src/main/java/hudson/plugins/tfs/model/AbstractHookEvent.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/model/AbstractHookEvent.java
@@ -170,47 +170,15 @@ public abstract class AbstractHookEvent {
             int totalRepositoryMatches = 0;
             for (final Item project : Jenkins.getInstance().getAllItems()) {
                 final SCMTriggerItem scmTriggerItem = SCMTriggerItem.SCMTriggerItems.asSCMTriggerItem(project);
-                if (scmTriggerItem == null || scmTriggerItem.getSCMs() == null) {
+                if (scmTriggerItem == null) {
                     continue;
                 }
 
-                if (scmTriggerItem.getSCMs().isEmpty())
-                {
-                    GitStatus.ResponseContributor triggerResult = triggerJob(gitCodePushedEventArgs, actions, bypassPolling, project, scmTriggerItem);
-                    if (triggerResult != null) {
-                        result.add(triggerResult);
-                    }
-                    continue;
+                GitStatus.ResponseContributor triggerResult = triggerJob(gitCodePushedEventArgs, actions, bypassPolling, project, scmTriggerItem);
+                if (triggerResult != null) {
+                    result.add(triggerResult);
                 }
-                
-                for (final SCM scm : scmTriggerItem.getSCMs()) {
-                    if (!(scm instanceof GitSCM)) {
-                        continue;
-                    }
-                    final GitSCM git = (GitSCM) scm;
-                    scmFound = true;
-                    
-                    for (final RemoteConfig repository : git.getRepositories()) {
-                        boolean repositoryMatches = false;
-                        for (final URIish remoteURL : repository.getURIs()) {
-                            if (UriHelper.areSameGitRepo(uri, remoteURL)) {
-                                repositoryMatches = true;
-                                totalRepositoryMatches++;
-                                break;
-                            }
-                        }
-
-                        if (!repositoryMatches || git.getExtensions().get(IgnoreNotifyCommit.class)!=null) {
-                            continue;
-                        }                      
-
-                        GitStatus.ResponseContributor triggerResult = triggerJob(gitCodePushedEventArgs, actions, bypassPolling, project, scmTriggerItem);
-                        if (triggerResult != null) {
-                            result.add(triggerResult);
-                            break;
-                        }
-                    }
-                }
+                continue;
             }
             if (!scmFound) {
                 result.add(new GitStatus.MessageResponseContributor("No Git jobs found"));

--- a/tfs/src/main/java/hudson/plugins/tfs/model/AbstractHookEvent.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/model/AbstractHookEvent.java
@@ -178,7 +178,6 @@ public abstract class AbstractHookEvent {
                 if (triggerResult != null) {
                     result.add(triggerResult);
                 }
-                continue;
             }
             if (!scmFound) {
                 result.add(new GitStatus.MessageResponseContributor("No Git jobs found"));


### PR DESCRIPTION
The fix is ready, which basically:

    Handles the case when SCM configuration of a job is empty, which was the
    root cause of the previous random TFS push trigger failure.

    Add an additional case when a job should be executed – the commit is NOT
    null:
    a. runPolling() actually checks SCM changes, which in our cases are
    none.
    b. As long as a commit in linked repro triggers this push (commit is NOT
    null), the job should be executed.

    Refactors original trigger logic into function “triggerJob”, to avoid
    dupe code as these code will be called twice in AbstractHookEvent.java.

    I removed existing code in AbstractHookEvent.java, which goes through all SCMs and Repos and might still be applied to some old free style projects. This is because its logic is dupe with the one in runPolling().

Now if you merge any change to dotnet-linker/enable-ci, all four jobs
starting with “testing” (on link below) will be triggered, and ONLY
those three will be triggered.

https://dotnet-vsts.westus2.cloudapp.azure.com/job/DevDiv_dotnet-linker/job/enable-ci/

Original PR (created against private master) is:
https://github.com/smile21prc/tfs-plugin/pull/1

Re-created this PR towards master in jenkinsci/tfs-plugin.