### PR TITLE
Use default values for parameters when value not supplied

### DIFF
--- a/tfs/src/main/java/hudson/plugins/tfs/model/BuildCommand.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/model/BuildCommand.java
@@ -145,10 +145,12 @@ public class BuildCommand extends AbstractCommand {
         if (pp != null && requestPayload.containsKey(TeamBuildEndpoint.PARAMETER)) {
             final List<ParameterValue> values = new ArrayList<ParameterValue>();
             final JSONArray a = requestPayload.getJSONArray(TeamBuildEndpoint.PARAMETER);
+            final List<String> parameterNames = new ArrayList<>();
 
             for (final Object o : a) {
                 final JSONObject jo = (JSONObject) o;
                 final String name = jo.getString("name");
+                parameterNames.add(name);
 
                 final ParameterDefinition d = pp.getParameterDefinition(name);
                 if (d == null)
@@ -176,6 +178,13 @@ public class BuildCommand extends AbstractCommand {
                 }
                 else {
                     throw new IllegalArgumentException("Cannot retrieve the parameter value: " + name);
+                }
+            }
+
+            //Pick up default build parameters that have not been overridden
+            for(ParameterDefinition paramDef : pp.getParameterDefinitions()) {
+                if(!parameterNames.contains(paramDef.getName()) && paramDef instanceof SimpleParameterDefinition){
+                    values.add(paramDef.getDefaultParameterValue());
                 }
             }
 

--- a/tfs/src/main/java/hudson/plugins/tfs/model/BuildCommand.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/model/BuildCommand.java
@@ -140,7 +140,6 @@ public class BuildCommand extends AbstractCommand {
             }
         }
 
-        //noinspection UnnecessaryLocalVariable
         final ParametersDefinitionProperty pp = job.getProperty(ParametersDefinitionProperty.class);
         if (pp != null && requestPayload.containsKey(TeamBuildEndpoint.PARAMETER)) {
             final List<ParameterValue> values = new ArrayList<ParameterValue>();
@@ -182,7 +181,7 @@ public class BuildCommand extends AbstractCommand {
             }
 
             //Pick up default build parameters that have not been overridden
-            for(ParameterDefinition paramDef : pp.getParameterDefinitions()) {
+            for(final ParameterDefinition paramDef : pp.getParameterDefinitions()) {
                 if(!parameterNames.contains(paramDef.getName()) && paramDef instanceof SimpleParameterDefinition){
                     values.add(paramDef.getDefaultParameterValue());
                 }


### PR DESCRIPTION
Updated the build command to check for any parameters that have not been defined and uses their default value.