### PR TITLE
Allow users to map sub-folders of cloaked paths

### DIFF
--- a/tfs/src/main/java/hudson/plugins/tfs/TeamFoundationServerScm.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/TeamFoundationServerScm.java
@@ -429,7 +429,7 @@ public class TeamFoundationServerScm extends SCM {
             final Project project = server.getProject(projPath);
             final int changeSet = recordWorkspaceChangesetVersion(build, listener, project, projPath, singleVersionSpec);
 
-            CheckoutAction action = new CheckoutAction(workspaceConfiguration.getWorkspaceName(), workspaceConfiguration.getProjectPath(), workspaceConfiguration.getCloakedPaths(), workspaceConfiguration.getWorkfolder(), isUseUpdate(), isUseOverwrite());
+            CheckoutAction action = new CheckoutAction(workspaceConfiguration.getWorkspaceName(), workspaceConfiguration.getProjectPath(), workspaceConfiguration.getCloakedPaths(), workspaceConfiguration.getMappedPaths(), workspaceConfiguration.getWorkfolder(), isUseUpdate(), isUseOverwrite());
             List<ChangeSet> list;
             if (StringUtils.isNotEmpty(singleVersionSpec)) {
                 list = action.checkoutBySingleVersionSpec(server, workspaceFilePath, singleVersionSpec);
@@ -502,7 +502,8 @@ public class TeamFoundationServerScm extends SCM {
                 return (server.getProject(getProjectPath(lastRun)).getDetailedHistoryWithoutCloakedPaths(
                             lastRun.getTimestamp(),
                             Calendar.getInstance(),
-                            getCloakedPaths(lastRun)
+                            getCloakedPaths(lastRun),
+                            getMappedPaths(lastRun).keySet()
                         ).size() > 0);
             } finally {
                 server.close();
@@ -823,7 +824,7 @@ public class TeamFoundationServerScm extends SCM {
         }
         final Project tfsProject = server.getProject(projectPath);
         try {
-            final ChangeSet latest = tfsProject.getLatestUncloakedChangeset(tfsBaseline.changesetVersion, cloakedPaths);
+            final ChangeSet latest = tfsProject.getLatestUncloakedChangeset(tfsBaseline.changesetVersion, cloakedPaths, mappedPaths.keySet());
             final TFSRevisionState tfsRemote =
                     (latest != null)
                     ? new TFSRevisionState(latest.getVersion(), projectPath)

--- a/tfs/src/main/java/hudson/plugins/tfs/TeamFoundationServerScm.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/TeamFoundationServerScm.java
@@ -266,8 +266,12 @@ public class TeamFoundationServerScm extends SCM {
         while (iter.hasNext()) {
             Entry<String, String> entry = iter.next();
             sb.append(entry.getKey());
-            sb.append(' ').append(':').append(' ');
-            sb.append(entry.getValue());
+            
+            final String mappedPath = entry.getValue();
+            if (mappedPath != null) {
+                sb.append(' ').append(':').append(' ');
+                sb.append(entry.getValue());
+            }
             if (iter.hasNext()) {
                 sb.append('\n');
             }
@@ -320,8 +324,13 @@ public class TeamFoundationServerScm extends SCM {
             while (iter.hasNext()) {
                 Entry<String, String> entry = iter.next();
                 final String serverPath = Util.replaceMacro(substituteBuildParameter(run, entry.getKey()), resolver);
-                final String localPath = Util.replaceMacro(substituteBuildParameter(run, entry.getValue()), resolver);
-                
+
+                String localPath = null;
+                String storedLocalPath = entry.getValue();
+                if (storedLocalPath != null) {
+                    localPath = Util.replaceMacro(substituteBuildParameter(run, storedLocalPath), resolver);
+                }
+
                 paths.put(serverPath, localPath);
             }
         }
@@ -385,7 +394,13 @@ public class TeamFoundationServerScm extends SCM {
 
             if (path.length() > 0) {
                 String[] combinedPaths = splitMappedPath(path.toString());
-                mappedPathsCollection.put(combinedPaths[0].trim(), combinedPaths[1].trim());
+
+                final String serverPath = combinedPaths[0].trim();
+                String localPath = null;
+                if (combinedPaths.length > 1) {
+                    localPath = combinedPaths[1].trim();
+                }
+                mappedPathsCollection.put(serverPath, localPath);
             }
         }
         return mappedPathsCollection;

--- a/tfs/src/main/java/hudson/plugins/tfs/TeamFoundationServerScm.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/TeamFoundationServerScm.java
@@ -414,7 +414,7 @@ public class TeamFoundationServerScm extends SCM {
     public void checkout(final Run<?, ?> build, final Launcher launcher, final FilePath workspaceFilePath, final TaskListener listener, final File changelogFile, final SCMRevisionState baseline) throws IOException, InterruptedException {
         Server server = createServer(launcher, listener, build);
         try {
-            WorkspaceConfiguration workspaceConfiguration = new WorkspaceConfiguration(server.getUrl(), getWorkspaceName(build, workspaceFilePath.toComputer()), getProjectPath(build), getCloakedPaths(build), getLocalPath());
+            WorkspaceConfiguration workspaceConfiguration = new WorkspaceConfiguration(server.getUrl(), getWorkspaceName(build, workspaceFilePath.toComputer()), getProjectPath(build), getCloakedPaths(build), getMappedPaths(build), getLocalPath());
             final Run<?, ?> previousBuild = build.getPreviousBuild();
             // Check if the configuration has changed
             if (previousBuild != null) {
@@ -824,7 +824,8 @@ public class TeamFoundationServerScm extends SCM {
                         return (server.getProject(getProjectPath(build)).getDetailedHistoryWithoutCloakedPaths(
                                 build.getTimestamp(),
                                 Calendar.getInstance(),
-                                getCloakedPaths(build)
+                                getCloakedPaths(build),
+                                getMappedPaths(build).keySet()
                         ).size() > 0) ? PollingResult.BUILD_NOW : PollingResult.NO_CHANGES;
                     } finally {
                         server.close();

--- a/tfs/src/main/java/hudson/plugins/tfs/TeamFoundationServerScm.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/TeamFoundationServerScm.java
@@ -381,8 +381,12 @@ public class TeamFoundationServerScm extends SCM {
                     case '\n':
                         if (path.length() > 0) {
                             String[] combinedPaths = splitMappedPath(path.toString());
-                            mappedPathsCollection.put(combinedPaths[0].trim(), combinedPaths[1].trim());
-                            
+                            String localPath = null;
+                            if (combinedPaths.length > 1) {
+                                localPath = combinedPaths[1].trim();
+                            }
+                            mappedPathsCollection.put(combinedPaths[0].trim(), localPath);
+
                             path.setLength(0);
                         }
                         break;

--- a/tfs/src/main/java/hudson/plugins/tfs/TeamFoundationServerScm.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/TeamFoundationServerScm.java
@@ -311,6 +311,24 @@ public class TeamFoundationServerScm extends SCM {
         return paths;
     }
 
+    Map<String, String> getMappedPaths(final Run<?, ?> run) {
+        final Map<String, String> paths = new TreeMap<String, String>();
+        if (mappedPaths != null) {
+            final BuildVariableResolver resolver = new BuildVariableResolver(run.getParent());
+            
+            Iterator<Entry<String, String>> iter = mappedPaths.entrySet().iterator();
+            while (iter.hasNext()) {
+                Entry<String, String> entry = iter.next();
+                final String serverPath = Util.replaceMacro(substituteBuildParameter(run, entry.getKey()), resolver);
+                final String localPath = Util.replaceMacro(substituteBuildParameter(run, entry.getValue()), resolver);
+                
+                paths.put(serverPath, localPath);
+            }
+        }
+
+        return paths;
+    }
+
     private String substituteBuildParameter(final Run<?, ?> run, final String text) {
         if (run instanceof AbstractBuild<?, ?>) {
             AbstractBuild<?, ?> build = (AbstractBuild<?, ?>) run;

--- a/tfs/src/main/java/hudson/plugins/tfs/actions/CheckoutAction.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/actions/CheckoutAction.java
@@ -144,7 +144,7 @@ public class CheckoutAction {
                 localFolderPath.deleteContents();
             }
             final String serverPath = project.getProjectPath();
-            workspace = workspaces.newWorkspace(workspaceName, serverPath, cloakedPaths, localPath);
+            workspace = workspaces.newWorkspace(workspaceName, serverPath, cloakedPaths, mappedPaths, localPath);
         } else {
             workspace = workspaces.getWorkspace(workspaceName);
         }

--- a/tfs/src/main/java/hudson/plugins/tfs/actions/CheckoutAction.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/actions/CheckoutAction.java
@@ -20,20 +20,23 @@ import java.util.Calendar;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 
 public class CheckoutAction {
 
     private final String workspaceName;
     private final String projectPath;
     private final Collection<String> cloakedPaths;
+    private final Map<String, String> mappedPaths;
     private final String localFolder;
     private final boolean useUpdate;
     private final boolean useOverwrite;
 
-    public CheckoutAction(String workspaceName, String projectPath, Collection<String> cloakedPaths, String localFolder, boolean useUpdate, boolean useOverwrite) {
+    public CheckoutAction(String workspaceName, String projectPath, Collection<String> cloakedPaths, Map<String, String> mappedPaths, String localFolder, boolean useUpdate, boolean useOverwrite) {
         this.workspaceName = workspaceName;
         this.projectPath = projectPath;
         this.cloakedPaths = cloakedPaths;
+        this.mappedPaths = mappedPaths;
         this.localFolder = localFolder;
         this.useUpdate = useUpdate;
         this.useOverwrite = useOverwrite;
@@ -63,7 +66,7 @@ public class CheckoutAction {
         project.getFiles(normalizedFolder, versionSpecString, useOverwrite);
 
         if (lastBuildVersionSpec != null) {
-            return project.getDetailedHistoryWithoutCloakedPaths(lastBuildVersionSpec, currentBuildVersionSpec, cloakedPaths);
+            return project.getDetailedHistoryWithoutCloakedPaths(lastBuildVersionSpec, currentBuildVersionSpec, cloakedPaths, mappedPaths.keySet());
         }
 
         return new ArrayList<ChangeSet>();

--- a/tfs/src/main/java/hudson/plugins/tfs/commands/NewWorkspaceCommand.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/commands/NewWorkspaceCommand.java
@@ -14,11 +14,17 @@ import hudson.plugins.tfs.model.MockableVersionControlClient;
 import hudson.plugins.tfs.model.Server;
 import hudson.remoting.Callable;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.regex.Matcher;
 
 
 public class NewWorkspaceCommand extends AbstractCallableCommand<Void, Exception> {
@@ -32,13 +38,15 @@ public class NewWorkspaceCommand extends AbstractCallableCommand<Void, Exception
     private final String workspaceName;
     private final String serverPath;
     private final Collection<String> cloakedPaths;
+    private final Map<String, String> mappedPaths;
     private final String localPath;
 
-    public NewWorkspaceCommand(final ServerConfigurationProvider server, final String workspaceName, final String serverPath, Collection<String> cloakedPaths, final String localPath) {
+    public NewWorkspaceCommand(final ServerConfigurationProvider server, final String workspaceName, final String serverPath, Collection<String> cloakedPaths, Map<String, String> mappedPaths, final String localPath) {
         super(server);
         this.workspaceName = workspaceName;
         this.serverPath = serverPath;
         this.cloakedPaths = cloakedPaths;
+        this.mappedPaths = mappedPaths;
         this.localPath = localPath;
     }
 
@@ -59,7 +67,7 @@ public class NewWorkspaceCommand extends AbstractCallableCommand<Void, Exception
         
         WorkingFolder[] foldersToMap = null;
         if (serverPath != null && localPath != null) {
-            final String mappingMessage = String.format(MappingTemplate, serverPath, localPath, workspaceName);
+            String mappingMessage = String.format(MappingTemplate, serverPath, localPath, workspaceName);
             logger.println(mappingMessage);
 
             final List<WorkingFolder> folderList = new ArrayList<WorkingFolder>();
@@ -72,6 +80,26 @@ public class NewWorkspaceCommand extends AbstractCallableCommand<Void, Exception
                 logger.println(cloakingMessage);
 
                 folderList.add(new WorkingFolder(cloakedPath, null, WorkingFolderType.CLOAK));
+            }
+
+            Iterator<Entry<String, String>> iter = mappedPaths.entrySet().iterator();
+            while (iter.hasNext()) {
+                Entry<String, String> entry = iter.next();
+                final String mappedServerPath = entry.getKey();
+                final String storedMappedLocalPath = entry.getValue();
+                String mappedLocalPath = null;
+                if (storedMappedLocalPath != null) {
+                    mappedLocalPath = Paths.get(localPath, storedMappedLocalPath).toString().replaceAll(Matcher.quoteReplacement(File.separator), "/");
+                }
+                else {
+                    final String relativePath = mappedServerPath.substring(serverPath.length());
+                    mappedLocalPath = Paths.get(localPath, relativePath).toString().replaceAll(Matcher.quoteReplacement(File.separator), "/");
+                }
+                
+                mappingMessage = String.format(MappingTemplate, mappedServerPath, mappedLocalPath, workspaceName);
+                logger.println(mappingMessage);
+
+                folderList.add(new WorkingFolder(mappedServerPath, LocalPath.canonicalize(mappedLocalPath), WorkingFolderType.MAP, RecursionType.FULL));
             }
             foldersToMap = folderList.toArray(EMPTY_WORKING_FOLDER_ARRAY);
         }

--- a/tfs/src/main/java/hudson/plugins/tfs/model/Project.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/model/Project.java
@@ -175,16 +175,17 @@ public class Project {
      * Gets the latest changeset that isn't in a cloaked path.
      * @param fromChangeset the changeset that was last seen, as a point of reference
      * @param cloakedPaths the list of cloaked paths in the project
+     * @param mappedPaths the list of server paths that are explicitly mapped in the project
      * @return the {@link ChangeSet} instance representing the last entry in the history for the path
      */
-    public ChangeSet getLatestUncloakedChangeset(final int fromChangeset, final Collection<String> cloakedPaths) {
+    public ChangeSet getLatestUncloakedChangeset(final int fromChangeset, final Collection<String> cloakedPaths, final Collection<String> mappedPaths) {
         final ChangesetVersionSpec fromVersion = new ChangesetVersionSpec(fromChangeset);
         final List<ChangeSet> changeSets = getVCCHistory(fromVersion, LatestVersionSpec.INSTANCE, true, Integer.MAX_VALUE);
-        final ChangeSet result = findLatestUncloakedChangeset(cloakedPaths, changeSets);
+        final ChangeSet result = findLatestUncloakedChangeset(cloakedPaths, mappedPaths, changeSets);
         return result;
     }
 
-    static ChangeSet findLatestUncloakedChangeset(final Collection<String> cloakedPaths, final List<ChangeSet> changeSets) {
+    static ChangeSet findLatestUncloakedChangeset(final Collection<String> cloakedPaths, final Collection<String> mappedPaths, final List<ChangeSet> changeSets) {
         ChangeSet result = null;
 
         // We need to search from latest to earliest, otherwise an incorrect result is produced
@@ -198,7 +199,7 @@ public class Project {
             lastChangeSetNumber = changeSetNumber;
             final Collection<String> changes = s.getAffectedPaths();
 
-            final boolean fullyCloaked = isChangesetFullyCloaked(changes, cloakedPaths);
+            final boolean fullyCloaked = isChangesetFullyCloaked(changes, cloakedPaths, mappedPaths);
             if (!fullyCloaked) {
                 result = s;
                 break;
@@ -215,18 +216,18 @@ public class Project {
      *                     changesets that are fully covered by one or more of these paths
      * @return a list of change sets
      */
-    public List<ChangeSet> getDetailedHistoryWithoutCloakedPaths(final Calendar fromTimestamp, final Calendar toTimestamp, final Collection<String> cloakedPaths) {
+    public List<ChangeSet> getDetailedHistoryWithoutCloakedPaths(final Calendar fromTimestamp, final Calendar toTimestamp, final Collection<String> cloakedPaths, final Collection<String> mappedPaths) {
         final DateVersionSpec fromVersion = new DateVersionSpec(fromTimestamp);
         final DateVersionSpec toVersion = new DateVersionSpec(toTimestamp);
-        return getDetailedHistoryWithoutCloakedPaths(fromVersion, toVersion, cloakedPaths);
+        return getDetailedHistoryWithoutCloakedPaths(fromVersion, toVersion, cloakedPaths, mappedPaths);
     }
 
-    public List<ChangeSet> getDetailedHistoryWithoutCloakedPaths(final VersionSpec fromVersion, final VersionSpec toVersion, final Collection<String> cloakedPaths) {
+    public List<ChangeSet> getDetailedHistoryWithoutCloakedPaths(final VersionSpec fromVersion, final VersionSpec toVersion, final Collection<String> cloakedPaths, final Collection<String> mappedPaths) {
         final List<ChangeSet> changeSets = getVCCHistory(fromVersion, toVersion, true, Integer.MAX_VALUE);
         final ArrayList<ChangeSet> changeSetNoCloaked = new ArrayList<ChangeSet>();
         for (final ChangeSet changeset : changeSets) {
             final Collection<String> affectedPaths = changeset.getAffectedPaths();
-            final boolean fullyCloaked = isChangesetFullyCloaked(affectedPaths, cloakedPaths);
+            final boolean fullyCloaked = isChangesetFullyCloaked(affectedPaths, cloakedPaths, mappedPaths);
             if (!fullyCloaked) {
                 changeSetNoCloaked.add(changeset);
             }
@@ -234,19 +235,32 @@ public class Project {
         return changeSetNoCloaked;
     }
 
-    static boolean isChangesetFullyCloaked(final Collection<String> changesetPaths, final Collection<String> cloakedPaths) {
+    static boolean isChangesetFullyCloaked(final Collection<String> changesetPaths, final Collection<String> cloakedPaths, final Collection<String> mappedPaths) {
         if (cloakedPaths == null) {
             return false;
         }
         for (final String tfsPath : changesetPaths) {
-            boolean isPathCloaked = false;
+            String mostSpecificCloakedPath = null;
             for (final String cloakedPath : cloakedPaths) {
                 if (tfsPath.regionMatches(true, 0, cloakedPath, 0, cloakedPath.length())) {
-                    isPathCloaked = true;
-                    break;
+                    
+                    if ((mostSpecificCloakedPath == null) || (mostSpecificCloakedPath.length() < cloakedPath.length())) {
+                        mostSpecificCloakedPath = cloakedPath;
+                    }
                 }
             }
-            if (!isPathCloaked) {
+
+            if (mostSpecificCloakedPath != null) {
+                if (mappedPaths != null) {
+                    for (final String mappedPath : mappedPaths) {
+                        if ((mappedPath.regionMatches(true, 0, mostSpecificCloakedPath, 0, mostSpecificCloakedPath.length())) &&
+                            (tfsPath.regionMatches(true, 0, mappedPath, 0, mappedPath.length()))) {
+                            return false;
+                        }
+                    }
+                }
+            }
+            else {
                 return false;
             }
         }

--- a/tfs/src/main/java/hudson/plugins/tfs/model/WorkspaceConfiguration.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/model/WorkspaceConfiguration.java
@@ -149,8 +149,15 @@ public class WorkspaceConfiguration extends InvisibleAction implements Serializa
                 }
 
                 final String expectedItem = other.mappedPaths.get(key);
-                if (!actualItem.getValue().equals(expectedItem)) {
-                    return false;
+                final String actualMappedPath = actualItem.getValue();
+                if (actualMappedPath == null) {
+                    if (expectedItem != null)
+                        return false;
+                }
+                else {
+                    if (!actualMappedPath.equals(expectedItem)) {
+                        return false;
+                    }
                 }
             }
         }

--- a/tfs/src/main/java/hudson/plugins/tfs/model/WorkspaceConfiguration.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/model/WorkspaceConfiguration.java
@@ -3,6 +3,9 @@ package hudson.plugins.tfs.model;
 
 import java.io.Serializable;
 import java.util.Collection;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Map.Entry;
 
 import hudson.model.InvisibleAction;
 
@@ -21,14 +24,16 @@ public class WorkspaceConfiguration extends InvisibleAction implements Serializa
     private final String serverUrl;
     private boolean workspaceExists;
     private Collection<String> cloakedPaths;
+    private Map<String, String> mappedPaths;
 
-    public WorkspaceConfiguration(String serverUrl, String workspaceName, String projectPath, Collection<String> cloakedPaths, String workfolder) {
+    public WorkspaceConfiguration(String serverUrl, String workspaceName, String projectPath, Collection<String> cloakedPaths, Map<String, String> mappedPaths, String workfolder) {
         this.workspaceName = workspaceName;
         this.workfolder = workfolder;
         this.projectPath = projectPath;
         this.serverUrl = serverUrl;
         this.workspaceExists = true;
         this.cloakedPaths = cloakedPaths;
+        this.mappedPaths = mappedPaths;
     }
 
     public WorkspaceConfiguration(WorkspaceConfiguration configuration) {
@@ -38,6 +43,7 @@ public class WorkspaceConfiguration extends InvisibleAction implements Serializa
         this.serverUrl = configuration.serverUrl;
         this.workspaceExists = configuration.workspaceExists;
         this.cloakedPaths = configuration.cloakedPaths;
+        this.mappedPaths = configuration.mappedPaths;
     }
 
     public String getWorkspaceName() {
@@ -68,6 +74,10 @@ public class WorkspaceConfiguration extends InvisibleAction implements Serializa
         return cloakedPaths;
     }
 
+    public Map<String, String> getMappedPaths() {
+        return mappedPaths;
+    }
+
     @Override
     public int hashCode() {
         final int prime = 31;
@@ -78,6 +88,7 @@ public class WorkspaceConfiguration extends InvisibleAction implements Serializa
         result = prime * result + (workspaceExists ? 1231 : 1237);
         result = prime * result + ((workspaceName == null) ? 0 : workspaceName.hashCode());
         result = prime * result + ((cloakedPaths == null) ? 0 : cloakedPaths.hashCode());
+        result = prime * result + ((mappedPaths == null) ? 0 : mappedPaths.hashCode());
         return result;
     }
 
@@ -121,6 +132,28 @@ public class WorkspaceConfiguration extends InvisibleAction implements Serializa
             return false;
         else if (!cloakedPaths.containsAll(other.cloakedPaths))
             return false;
+        if (mappedPaths == null) {
+            if (other.mappedPaths != null)
+                return false;
+        } else if (other.mappedPaths == null)
+            return false;
+        else if (mappedPaths.size() != other.mappedPaths.size())
+            return false;
+        else {
+            final Iterator<Entry<String, String>> localPaths = mappedPaths.entrySet().iterator();
+            while (localPaths.hasNext()) {
+                final Entry<String, String> actualItem = localPaths.next();
+                String key = actualItem.getKey();
+                if (!other.mappedPaths.containsKey(key)) {
+                    return false;
+                }
+
+                final String expectedItem = other.mappedPaths.get(key);
+                if (!actualItem.getValue().equals(expectedItem)) {
+                    return false;
+                }
+            }
+        }
         return true;
     }
 

--- a/tfs/src/main/java/hudson/plugins/tfs/model/Workspaces.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/model/Workspaces.java
@@ -104,8 +104,8 @@ public class Workspaces implements ListWorkspacesCommand.WorkspaceFactory {
      * @param localPath the path in the local filesystem to map
      * @return a workspace
      */
-    public Workspace newWorkspace(final String workspaceName, final String serverPath, Collection<String> cloakedPaths, final String localPath) {
-        NewWorkspaceCommand command = new NewWorkspaceCommand(server, workspaceName, serverPath, cloakedPaths, localPath);
+    public Workspace newWorkspace(final String workspaceName, final String serverPath, Collection<String> cloakedPaths, Map<String, String> mappedPaths, final String localPath) {
+        NewWorkspaceCommand command = new NewWorkspaceCommand(server, workspaceName, serverPath, cloakedPaths, mappedPaths, localPath);
         server.execute(command.getCallable());
         Workspace workspace = new Workspace(workspaceName);
         workspaces.put(workspaceName, workspace);

--- a/tfs/src/main/resources/hudson/plugins/tfs/TeamFoundationServerScm/config.jelly
+++ b/tfs/src/main/resources/hudson/plugins/tfs/TeamFoundationServerScm/config.jelly
@@ -38,6 +38,10 @@
         <f:entry field="cloakedPaths" title="Cloaked paths" description="A collection of server paths to cloak to exclude from the workspace and from the build trigger.  Multiple entries must be placed onto separate lines.">
             <f:textarea checkUrl="'${rootURL}/scm/TeamFoundationServerScm/cloakedPathsCheck?value='+escape(this.value)"/>
         </f:entry>
+
+        <f:entry field="mappedPaths" title="Mapped paths" description="A collection of server paths that should be mapped even if their parent paths are cloaked.  Multiple entries must be placed onto separate lines.">
+            <f:textarea checkUrl="'${rootURL}/scm/TeamFoundationServerScm/mappedPathsCheck?value='+escape(this.value)"/>
+        </f:entry>
     </f:advanced>
     
     <t:listScmBrowsers name="tfs.browser" />

--- a/tfs/src/main/resources/hudson/plugins/tfs/TeamFoundationServerScm/help-mappedPaths.html
+++ b/tfs/src/main/resources/hudson/plugins/tfs/TeamFoundationServerScm/help-mappedPaths.html
@@ -1,0 +1,56 @@
+<div>
+    <p>
+      Mapped paths will be pulled into the local workspace during a GET
+      from the TFVC repository even if the parent folder is cloaked.
+      <br />
+      Check-ins that contain files only in mapped folders will trigger a build,
+      whereas a check-in containing any path that is in a sub-folder of a cloaked folder
+      will not trigger a build.
+    </p>
+    <p>
+      For example, suppose the <b>Project path</b> is <tt>$/Example/project/path</tt>,
+      and the repository contains the following subfolders:
+      <blockquote>
+        $/Example/project/path/A <br />
+        $/Example/project/path/A/1 <br />
+        $/Example/project/path/A/2 <br />
+        $/Example/project/path/B <br />
+        $/Example/project/path/B/1 <br />
+        $/Example/project/path/B/2 <br />
+        $/Example/project/path/C <br />
+      </blockquote>
+      Now, suppose the following paths were entered as <b>Cloaked Paths</b>:
+      <blockquote>
+        $/Example/project/path/A/2 <br />
+        $/Example/project/path/B <br />
+      </blockquote>
+      And the following paths were <b>Mapped Paths</b>:
+      <blockquote>
+          $/Example/project/path/B/1 : project/path/B1/1 <br />
+      </blockquote>
+      ...then the resulting workspace on the Jenkins server would only have the following folders:
+      <blockquote>
+        [Workspace_Directory]/Example/project/path/A <br />
+        [Workspace_Directory]/Example/project/path/A/1 <br />
+        [Workspace_Directory]/Example/project/path/C <br />
+        [Workspace_Directory]/project/path/B/1 <br />
+      </blockquote>
+    </p>
+    <p>
+      To continue with the example,
+      the following check-in <em>will not</em> trigger a build,
+      because it only contains changes under cloaked paths:
+      <blockquote>
+        $/Example/project/path/A/2/alpha.txt <br />
+        $/Example/project/path/A/2/second.txt <br />
+        $/Example/project/path/B/bravo.txt <br />
+      </blockquote>
+      ...whereas this check-in <em>will</em> trigger a build,
+      because it contains at least one path that isn't cloaked:
+      <blockquote>
+        $/Example/project/path/A/2/second.txt <br />
+        $/Example/project/path/B/bravo.txt <br />
+        $/Example/project/path/B/2/other.txt <br />
+      </blockquote>
+    </p>
+  </div>

--- a/tfs/src/test/java/hudson/plugins/tfs/TeamFoundationServerScmTest.java
+++ b/tfs/src/test/java/hudson/plugins/tfs/TeamFoundationServerScmTest.java
@@ -322,6 +322,19 @@ public class TeamFoundationServerScmTest {
     }
 
     @Test
+    public void deserializeMappedPathCollectionFromString_tfsPathOnly() {
+        final String input = " $/foo/\n $/bar/\n $/baz/ ";
+
+        final Map<String, String> actual = TeamFoundationServerScm.deserializeMappedPathCollectionFromString(input);
+
+        final Map<String, String> expected = new TreeMap<String, String>();
+        expected.put("$/foo/", null);
+        expected.put("$/bar/", null);
+        expected.put("$/baz/", null);
+        areEqual(actual, expected);
+    }
+
+    @Test
     public void deserializeMappedPathCollectionFromString_newlinesWithLiberalSpacing() {
         final String input = " $/foo/ : foo \n $/bar/ : bar \n $/baz/ : baz ";
 

--- a/tfs/src/test/java/hudson/plugins/tfs/TeamFoundationServerScmTest.java
+++ b/tfs/src/test/java/hudson/plugins/tfs/TeamFoundationServerScmTest.java
@@ -28,6 +28,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.TreeMap;
 import java.util.Map.Entry;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -239,7 +240,7 @@ public class TeamFoundationServerScmTest {
 
     @Test
     public void serializeMappedPathCollectionToString_two() {
-        final Map<String, String> pathCollection = new HashMap<String, String>();
+        final Map<String, String> pathCollection = new TreeMap<String, String>();
         pathCollection.put("$/foo", "foo");
         pathCollection.put("$/bar", "bar");
 
@@ -250,7 +251,7 @@ public class TeamFoundationServerScmTest {
 
     @Test
     public void serializeMappedPathCollectionToString_many() {
-        final Map<String, String> pathCollection = new HashMap<String, String>();
+        final Map<String, String> pathCollection = new TreeMap<String, String>();
         pathCollection.put("$/foo/", "foo");
         pathCollection.put("$/bar/", "bar");
         pathCollection.put("$/baz/", "baz");
@@ -302,7 +303,7 @@ public class TeamFoundationServerScmTest {
 
         final Map<String, String> actual = TeamFoundationServerScm.deserializeMappedPathCollectionFromString(input);
 
-        final Map<String, String> expected = new HashMap<String, String>();
+        final Map<String, String> expected = new TreeMap<String, String>();
         expected.put("$/foo/", "foo");
         areEqual(actual, expected);
     }
@@ -313,7 +314,7 @@ public class TeamFoundationServerScmTest {
 
         final Map<String, String> actual = TeamFoundationServerScm.deserializeMappedPathCollectionFromString(input);
 
-        final Map<String, String> expected = new HashMap<String, String>();
+        final Map<String, String> expected = new TreeMap<String, String>();
         expected.put("$/foo/", "foo");
         expected.put("$/bar/", "bar");
         expected.put("$/baz/", "baz");
@@ -326,7 +327,7 @@ public class TeamFoundationServerScmTest {
 
         final Map<String, String> actual = TeamFoundationServerScm.deserializeMappedPathCollectionFromString(input);
 
-        final Map<String, String> expected = new HashMap<String, String>();
+        final Map<String, String> expected = new TreeMap<String, String>();
         expected.put("$/foo/", "foo");
         expected.put("$/bar/", "bar");
         expected.put("$/baz/", "baz");
@@ -339,7 +340,7 @@ public class TeamFoundationServerScmTest {
 
         final Map<String, String> actual = TeamFoundationServerScm.deserializeMappedPathCollectionFromString(input);
 
-        final Map<String, String> expected = new HashMap<String, String>();
+        final Map<String, String> expected = new TreeMap<String, String>();
         expected.put("$/foo/", "foo");
         expected.put("$/bar/", "bar");
         expected.put("$/baz/", "baz");

--- a/tfs/src/test/java/hudson/plugins/tfs/TeamFoundationServerScmTest.java
+++ b/tfs/src/test/java/hudson/plugins/tfs/TeamFoundationServerScmTest.java
@@ -28,6 +28,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
@@ -176,66 +177,173 @@ public class TeamFoundationServerScmTest {
     }
 
     @Test
-    public void serializeCloakedPathCollectionToString_one() {
-        final List<String> cloakedPaths = Collections.singletonList("$/foo");
+    public void assertMappedPathsCheckRegexWorks() {
 
-        final String actual = TeamFoundationServerScm.serializeCloakedPathCollectionToString(cloakedPaths);
+        final String shouldNotMatch = "Mapped paths regex matched an invalid mapped path";
+        assertFalse(shouldNotMatch, isMappedPathValid("tfsandbox"));
+        assertFalse(shouldNotMatch, isMappedPathValid("tfsandbox/with/sub/pathes"));
+        assertFalse(shouldNotMatch, isMappedPathValid("tfsandbox$/with/sub/pathes"));
+        assertFalse(shouldNotMatch, isMappedPathValid("$/tfsandbox/path1;$/tfsandbox/path2"));
+        assertFalse(shouldNotMatch, isMappedPathValid("$/tfsandbox/path1 ; $/tfsandbox/path2 ; $/tfsandbox/path3"));
+        assertFalse(shouldNotMatch, isMappedPathValid("$/foo/;$/bar/;$/baz/"));
+        assertFalse(shouldNotMatch, isMappedPathValid("$/foo/;\n$/bar/;\n$/baz/"));
+
+        final String shoudMatch = "Mapped paths regex did not match a valid Mapped path";
+        assertTrue(shoudMatch, isMappedPathValid("$/tfsandbox"));
+        assertTrue(shoudMatch, isMappedPathValid("$/tfsandbox/path with space/subpath"));
+        assertTrue(shoudMatch, isMappedPathValid("$/tfsandbox/with/${parameter}/path"));
+        assertTrue(shoudMatch, isMappedPathValid("$/foo/\n$/bar/\n$/baz/"));
+        assertTrue(shoudMatch, isMappedPathValid(" $/foo/ \n $/bar/ \n $/baz/ "));
+        assertTrue(shoudMatch, isMappedPathValid("\n$/foo/\n\n$/bar/\n\n$/baz/\n"));
+    }
+
+    private static boolean isMappedPathValid(final String path) {
+        return TeamFoundationServerScm.DescriptorImpl.MAPPED_PATHS_REGEX.matcher(path).matches();
+    }
+
+    @Test
+    public void serializeCloakedPathCollectionToString_one() {
+        final List<String> pathCollection = Collections.singletonList("$/foo");
+
+        final String actual = TeamFoundationServerScm.serializeCloakedPathCollectionToString(pathCollection);
 
         Assert.assertEquals("$/foo", actual);
     }
 
     @Test
     public void serializeCloakedPathCollectionToString_two() {
-        final List<String> cloakedPaths = Arrays.asList("$/foo", "$/bar");
+        final List<String> pathCollection = Arrays.asList("$/foo", "$/bar");
 
-        final String actual = TeamFoundationServerScm.serializeCloakedPathCollectionToString(cloakedPaths);
+        final String actual = TeamFoundationServerScm.serializeCloakedPathCollectionToString(pathCollection);
 
         Assert.assertEquals("$/foo\n$/bar", actual);
     }
 
     @Test
     public void serializeCloakedPathCollectionToString_many() {
-        final List<String> cloakedPaths = Arrays.asList("$/foo/", "$/bar/", "$/baz/");
+        final List<String> pathCollection = Arrays.asList("$/foo/", "$/bar/", "$/baz/");
 
-        final String actual = TeamFoundationServerScm.serializeCloakedPathCollectionToString(cloakedPaths);
+        final String actual = TeamFoundationServerScm.serializeCloakedPathCollectionToString(pathCollection);
 
         Assert.assertEquals("$/foo/\n$/bar/\n$/baz/", actual);
     }
 
     @Test
-    public void splitCloakedPaths_one() {
+    public void serializeMappedPathCollectionToString_one() {
+        final Map<String, String> pathCollection = Collections.singletonMap("$/foo", "foo");
+
+        final String actual = TeamFoundationServerScm.serializeMappedPathCollectionToString(pathCollection);
+
+        Assert.assertEquals("$/foo : foo", actual);
+    }
+
+    @Test
+    public void serializeMappedPathCollectionToString_two() {
+        final Map<String, String> pathCollection = new HashMap<String, String>();
+        pathCollection.put("$/foo", "foo");
+        pathCollection.put("$/bar", "bar");
+
+        final String actual = TeamFoundationServerScm.serializeMappedPathCollectionToString(pathCollection);
+
+        Assert.assertEquals("$/bar : bar\n$/foo : foo", actual);
+    }
+
+    @Test
+    public void serializeMappedPathCollectionToString_many() {
+        final Map<String, String> pathCollection = new HashMap<String, String>();
+        pathCollection.put("$/foo/", "foo");
+        pathCollection.put("$/bar/", "bar");
+        pathCollection.put("$/baz/", "baz");
+
+        final String actual = TeamFoundationServerScm.serializeMappedPathCollectionToString(pathCollection);
+
+        Assert.assertEquals("$/bar/ : bar\n$/baz/ : baz\n$/foo/ : foo", actual);
+    }
+
+    @Test
+    public void deserializeCloakedPathCollectionFromString_one() {
         final String input = "$/foo/";
 
-        final Collection<String> actual = TeamFoundationServerScm.splitCloakedPaths(input);
+        final Collection<String> actual = TeamFoundationServerScm.deserializeCloakedPathCollectionFromString(input);
 
         areEqual(actual, input);
     }
 
     @Test
-    public void splitCloakedPaths_newlinesMany() {
+    public void deserializeCloakedPathCollectionFromString_newlinesMany() {
         final String input = "$/foo/\n$/bar/\n$/baz/";
 
-        final Collection<String> actual = TeamFoundationServerScm.splitCloakedPaths(input);
+        final Collection<String> actual = TeamFoundationServerScm.deserializeCloakedPathCollectionFromString(input);
 
         areEqual(actual, "$/foo/", "$/bar/", "$/baz/");
     }
 
     @Test
-    public void splitCloakedPaths_newlinesWithLiberalSpacing() {
+    public void deserializeCloakedPathCollectionFromString_newlinesWithLiberalSpacing() {
         final String input = " $/foo/ \n $/bar/ \n $/baz/ ";
 
-        final Collection<String> actual = TeamFoundationServerScm.splitCloakedPaths(input);
+        final Collection<String> actual = TeamFoundationServerScm.deserializeCloakedPathCollectionFromString(input);
 
         areEqual(actual, "$/foo/", "$/bar/", "$/baz/");
     }
 
     @Test
-    public void splitCloakedPaths_newlinesWithBlankLines() {
+    public void deserializeCloakedPathCollectionFromString_newlinesWithBlankLines() {
         final String input = "\n$/foo/\n\n$/bar/\n\n$/baz/\n";
 
-        final Collection<String> actual = TeamFoundationServerScm.splitCloakedPaths(input);
+        final Collection<String> actual = TeamFoundationServerScm.deserializeCloakedPathCollectionFromString(input);
 
         areEqual(actual, "$/foo/", "$/bar/", "$/baz/");
+    }
+
+    @Test
+    public void deserializeMappedPathCollectionFromString_one() {
+        final String input = "$/foo/:foo";
+
+        final Map<String, String> actual = TeamFoundationServerScm.deserializeMappedPathCollectionFromString(input);
+
+        final Map<String, String> expected = new HashMap<String, String>();
+        expected.put("$/foo/", "foo");
+        areEqual(actual, expected);
+    }
+
+    @Test
+    public void deserializeMappedPathCollectionFromString_newlinesMany() {
+        final String input = "$/foo/:foo\n$/bar/:bar\n$/baz/:baz";
+
+        final Map<String, String> actual = TeamFoundationServerScm.deserializeMappedPathCollectionFromString(input);
+
+        final Map<String, String> expected = new HashMap<String, String>();
+        expected.put("$/foo/", "foo");
+        expected.put("$/bar/", "bar");
+        expected.put("$/baz/", "baz");
+        areEqual(actual, expected);
+    }
+
+    @Test
+    public void deserializeMappedPathCollectionFromString_newlinesWithLiberalSpacing() {
+        final String input = " $/foo/ : foo \n $/bar/ : bar \n $/baz/ : baz ";
+
+        final Map<String, String> actual = TeamFoundationServerScm.deserializeMappedPathCollectionFromString(input);
+
+        final Map<String, String> expected = new HashMap<String, String>();
+        expected.put("$/foo/", "foo");
+        expected.put("$/bar/", "bar");
+        expected.put("$/baz/", "baz");
+        areEqual(actual, expected);
+    }
+
+    @Test
+    public void deserializeMappedPathCollectionFromString_newlinesWithBlankLines() {
+        final String input = "\n$/foo/:foo\n\n$/bar/:bar\n\n$/baz/:baz\n";
+
+        final Map<String, String> actual = TeamFoundationServerScm.deserializeMappedPathCollectionFromString(input);
+
+        final Map<String, String> expected = new HashMap<String, String>();
+        expected.put("$/foo/", "foo");
+        expected.put("$/bar/", "bar");
+        expected.put("$/baz/", "baz");
+        areEqual(actual, expected);
     }
 
     private static <T> void areEqual(final Collection<T> actual, T... expected) {
@@ -258,6 +366,33 @@ public class TeamFoundationServerScmTest {
             }
         }
     }
+
+    private static <T> void areEqual(final Map<T, T> actual, Map<T, T> expected) {
+        if (actual.size() > expected.size())
+        {
+            Assert.fail("There were more elements than expected");
+            return;
+        }
+
+        if (actual.size() < expected.size()) {
+            Assert.fail("Some elements were missing from actual.");
+            return;
+        }
+
+        final Iterator<Entry<T, T>> ai = actual.entrySet().iterator();
+        while (ai.hasNext()) {
+            final Entry<T, T> actualItem = ai.next();
+            T key = actualItem.getKey();
+            if (!expected.containsKey(key)) {
+                Assert.fail();
+                continue;
+            }
+
+            final T expectedItem = expected.get(key);
+            Assert.assertEquals(expectedItem, actualItem.getValue());
+        }
+    }
+
     @Test
     public void assertDefaultValueIsUsedForNullLocalPath() {
         TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", "workspace");

--- a/tfs/src/test/java/hudson/plugins/tfs/actions/CheckoutActionTest.java
+++ b/tfs/src/test/java/hudson/plugins/tfs/actions/CheckoutActionTest.java
@@ -73,12 +73,12 @@ public class CheckoutActionTest {
         prepareCommonMocks();
         when(project.getProjectPath()).thenReturn("project");
     	when(workspaces.exists("workspace")).thenReturn(true).thenReturn(false);
-        when(workspaces.newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class))).thenReturn(workspace);
+        when(workspaces.newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), eq(EMPTY_MAPPED_PATHS_MAP), isA(String.class))).thenReturn(workspace);
     	when(workspaces.getWorkspace("workspace")).thenReturn(workspace);
     	
         new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, EMPTY_MAPPED_PATHS_MAP, ".", false, false).checkoutBySingleVersionSpec(server, hudsonWs, MY_LABEL);
 
-        verify(workspaces).newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class));
+        verify(workspaces).newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), eq(EMPTY_MAPPED_PATHS_MAP), isA(String.class));
     	verify(project).getFiles(isA(String.class), eq(MY_LABEL), eq(false));
     	verify(workspaces).deleteWorkspace(workspace);    	
     }
@@ -88,12 +88,12 @@ public class CheckoutActionTest {
         prepareCommonMocks();
         when(project.getProjectPath()).thenReturn("project");
         when(workspaces.exists("workspace")).thenReturn(true).thenReturn(false);
-        when(workspaces.newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class))).thenReturn(workspace);
+        when(workspaces.newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), eq(EMPTY_MAPPED_PATHS_MAP), isA(String.class))).thenReturn(workspace);
         when(workspaces.getWorkspace("workspace")).thenReturn(workspace);
         
         new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, EMPTY_MAPPED_PATHS_MAP, ".", false, false).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
         
-        verify(workspaces).newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class));
+        verify(workspaces).newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), eq(EMPTY_MAPPED_PATHS_MAP), isA(String.class));
         verify(project).getFiles(isA(String.class), eq("D2009-09-24T00:00:00Z"), eq(false));
         verify(workspaces).deleteWorkspace(workspace);
     }
@@ -103,11 +103,11 @@ public class CheckoutActionTest {
         prepareCommonMocks();
         when(project.getProjectPath()).thenReturn("project");
         when(workspaces.exists(new Workspace("workspace"))).thenReturn(false);
-        when(workspaces.newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class))).thenReturn(workspace);
+        when(workspaces.newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), eq(EMPTY_MAPPED_PATHS_MAP), isA(String.class))).thenReturn(workspace);
         
         new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, EMPTY_MAPPED_PATHS_MAP, ".", true, false).checkoutBySingleVersionSpec(server, hudsonWs, MY_LABEL);
         
-        verify(workspaces).newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class));
+        verify(workspaces).newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), eq(EMPTY_MAPPED_PATHS_MAP), isA(String.class));
         verify(project).getFiles(isA(String.class), eq(MY_LABEL), eq(false));
         verify(workspaces, never()).deleteWorkspace(isA(Workspace.class));
     }
@@ -117,11 +117,11 @@ public class CheckoutActionTest {
         prepareCommonMocks();
         when(project.getProjectPath()).thenReturn("project");
     	when(workspaces.exists(new Workspace("workspace"))).thenReturn(false);
-        when(workspaces.newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class))).thenReturn(workspace);
+        when(workspaces.newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), eq(EMPTY_MAPPED_PATHS_MAP), isA(String.class))).thenReturn(workspace);
     	
         new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, EMPTY_MAPPED_PATHS_MAP, ".", true, false).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
     	
-        verify(workspaces).newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class));
+        verify(workspaces).newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), eq(EMPTY_MAPPED_PATHS_MAP), isA(String.class));
     	verify(project).getFiles(isA(String.class), eq("D2009-09-24T00:00:00Z"), eq(false));
     	verify(workspaces, never()).deleteWorkspace(isA(Workspace.class));
     }
@@ -136,7 +136,7 @@ public class CheckoutActionTest {
         new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, EMPTY_MAPPED_PATHS_MAP, ".", true, false).checkoutBySingleVersionSpec(server, hudsonWs, MY_LABEL);
 
         verify(project).getFiles(isA(String.class), eq(MY_LABEL), eq(false));
-        verify(workspaces, never()).newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class));
+        verify(workspaces, never()).newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), eq(EMPTY_MAPPED_PATHS_MAP), isA(String.class));
         verify(workspaces, never()).deleteWorkspace(isA(Workspace.class));
     }
     
@@ -150,7 +150,7 @@ public class CheckoutActionTest {
         new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, EMPTY_MAPPED_PATHS_MAP, ".", true, false).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
 
         verify(project).getFiles(isA(String.class), eq("D2009-09-24T00:00:00Z"), eq(false));
-        verify(workspaces, never()).newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class));
+        verify(workspaces, never()).newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), eq(EMPTY_MAPPED_PATHS_MAP), isA(String.class));
         verify(workspaces, never()).deleteWorkspace(isA(Workspace.class));
     }
 
@@ -159,12 +159,12 @@ public class CheckoutActionTest {
         prepareCommonMocks();
         when(project.getProjectPath()).thenReturn("project");
         when(workspaces.exists("workspace")).thenReturn(true).thenReturn(false);
-        when(workspaces.newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class))).thenReturn(workspace);
+        when(workspaces.newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), eq(EMPTY_MAPPED_PATHS_MAP), isA(String.class))).thenReturn(workspace);
         when(workspaces.getWorkspace("workspace")).thenReturn(workspace);
         
         new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, EMPTY_MAPPED_PATHS_MAP, ".", false, false).checkoutBySingleVersionSpec(server, hudsonWs, MY_LABEL);
 
-        verify(workspaces).newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class));
+        verify(workspaces).newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), eq(EMPTY_MAPPED_PATHS_MAP), isA(String.class));
         verify(project).getFiles(isA(String.class), eq(MY_LABEL), eq(false));
         verify(workspaces).deleteWorkspace(workspace);
     }
@@ -174,12 +174,12 @@ public class CheckoutActionTest {
         prepareCommonMocks();
         when(project.getProjectPath()).thenReturn("project");
         when(workspaces.exists("workspace")).thenReturn(true).thenReturn(false);
-        when(workspaces.newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class))).thenReturn(workspace);
+        when(workspaces.newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), eq(EMPTY_MAPPED_PATHS_MAP), isA(String.class))).thenReturn(workspace);
         when(workspaces.getWorkspace("workspace")).thenReturn(workspace);
         
         new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, EMPTY_MAPPED_PATHS_MAP, ".", false, false).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
 
-        verify(workspaces).newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class));
+        verify(workspaces).newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), eq(EMPTY_MAPPED_PATHS_MAP), isA(String.class));
         verify(project).getFiles(isA(String.class), eq("D2009-09-24T00:00:00Z"), eq(false));
         verify(workspaces).deleteWorkspace(workspace);
     }
@@ -252,7 +252,7 @@ public class CheckoutActionTest {
         
         prepareCommonMocks();
         when(workspaces.exists(new Workspace("workspace"))).thenReturn(false);
-        when(workspaces.newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class))).thenReturn(workspace);
+        when(workspaces.newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), eq(EMPTY_MAPPED_PATHS_MAP), isA(String.class))).thenReturn(workspace);
         
         new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, EMPTY_MAPPED_PATHS_MAP, "tfs-ws", false, false).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
         
@@ -270,7 +270,7 @@ public class CheckoutActionTest {
         
         prepareCommonMocks();
         when(workspaces.exists(new Workspace("workspace"))).thenReturn(false);
-        when(workspaces.newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class))).thenReturn(workspace);
+        when(workspaces.newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), eq(EMPTY_MAPPED_PATHS_MAP), isA(String.class))).thenReturn(workspace);
         
         new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, EMPTY_MAPPED_PATHS_MAP, "tfs-ws", false, false).checkoutBySingleVersionSpec(server, hudsonWs, MY_LABEL);
         
@@ -303,7 +303,7 @@ public class CheckoutActionTest {
         when(workspaces.exists("workspace")).thenReturn(true).thenReturn(false);
         when(workspaces.getWorkspace("workspace")).thenReturn(workspace);
         when(project.getProjectPath()).thenReturn("project");
-        when(workspaces.newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class))).thenReturn(workspace);
+        when(workspaces.newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), eq(EMPTY_MAPPED_PATHS_MAP), isA(String.class))).thenReturn(workspace);
         
         new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, EMPTY_MAPPED_PATHS_MAP, ".", false, false).checkoutBySingleVersionSpec(server, hudsonWs, MY_LABEL);
         
@@ -311,7 +311,7 @@ public class CheckoutActionTest {
         verify(workspaces, times(2)).exists("workspace");
         verify(workspaces).getWorkspace("workspace");
         verify(workspaces).deleteWorkspace(workspace);
-        verify(workspaces).newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class));
+        verify(workspaces).newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), eq(EMPTY_MAPPED_PATHS_MAP), isA(String.class));
         verify(workspaces).getWorkspaceMapping(anyString());
         verifyNoMoreInteractions(workspaces);
     }
@@ -323,7 +323,7 @@ public class CheckoutActionTest {
         when(workspaces.exists("workspace")).thenReturn(true).thenReturn(false);
         when(workspaces.getWorkspace("workspace")).thenReturn(workspace);
         when(project.getProjectPath()).thenReturn("project");
-        when(workspaces.newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class))).thenReturn(workspace);
+        when(workspaces.newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), eq(EMPTY_MAPPED_PATHS_MAP), isA(String.class))).thenReturn(workspace);
         
         new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, EMPTY_MAPPED_PATHS_MAP, ".", false, false).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
         
@@ -331,7 +331,7 @@ public class CheckoutActionTest {
         verify(workspaces, times(2)).exists("workspace");
         verify(workspaces).getWorkspace("workspace");
         verify(workspaces).deleteWorkspace(workspace);
-        verify(workspaces).newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class));
+        verify(workspaces).newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), eq(EMPTY_MAPPED_PATHS_MAP), isA(String.class));
         verify(workspaces).getWorkspaceMapping(anyString());
         verifyNoMoreInteractions(workspaces);
     }
@@ -373,14 +373,14 @@ public class CheckoutActionTest {
     public void assertCheckoutDoesNotDeleteWorkspaceIfNotUsingUpdateAndThereIsNoWorkspace() throws Exception {
         prepareCommonMocks();
         when(workspaces.exists("workspace")).thenReturn(false).thenReturn(false);
-        when(workspaces.newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class))).thenReturn(workspace);
+        when(workspaces.newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), eq(EMPTY_MAPPED_PATHS_MAP), isA(String.class))).thenReturn(workspace);
         when(project.getProjectPath()).thenReturn("project");
 
         new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, EMPTY_MAPPED_PATHS_MAP, ".", false, false).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
         
         verify(server).getWorkspaces();
         verify(workspaces, times(2)).exists("workspace");
-        verify(workspaces).newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class));
+        verify(workspaces).newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), eq(EMPTY_MAPPED_PATHS_MAP), isA(String.class));
         verify(workspaces).getWorkspaceMapping(anyString());
         verifyNoMoreInteractions(workspaces);
     }
@@ -390,14 +390,14 @@ public class CheckoutActionTest {
     public void assertCheckoutBySingleVersionSpecDoesNotDeleteWorkspaceIfNotUsingUpdateAndThereIsNoWorkspace() throws Exception {
         prepareCommonMocks();
         when(workspaces.exists("workspace")).thenReturn(false).thenReturn(false);
-        when(workspaces.newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class))).thenReturn(workspace);
+        when(workspaces.newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), eq(EMPTY_MAPPED_PATHS_MAP), isA(String.class))).thenReturn(workspace);
         when(project.getProjectPath()).thenReturn("project");
 
         new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, EMPTY_MAPPED_PATHS_MAP, ".", false, false).checkoutBySingleVersionSpec(server, hudsonWs, MY_LABEL);
         
         verify(server).getWorkspaces();
         verify(workspaces, times(2)).exists("workspace");
-        verify(workspaces).newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class));
+        verify(workspaces).newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), eq(EMPTY_MAPPED_PATHS_MAP), isA(String.class));
         verify(workspaces).getWorkspaceMapping(anyString());
         verifyNoMoreInteractions(workspaces);
     }

--- a/tfs/src/test/java/hudson/plugins/tfs/actions/CheckoutActionTest.java
+++ b/tfs/src/test/java/hudson/plugins/tfs/actions/CheckoutActionTest.java
@@ -8,6 +8,9 @@ import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
 
 import com.microsoft.tfs.core.clients.versioncontrol.specs.version.DateVersionSpec;
 import com.microsoft.tfs.core.clients.versioncontrol.specs.version.VersionSpec;
@@ -33,6 +36,10 @@ import org.mockito.MockitoAnnotations;
 public class CheckoutActionTest {
 
     private static final List<String> EMPTY_CLOAKED_PATHS_LIST = Collections.emptyList();
+
+    private static final Map<String, String> EMPTY_MAPPED_PATHS_MAP = new TreeMap<String, String>();
+    private static final Set<String> EMPTY_MAPPED_PATHS_LIST = EMPTY_MAPPED_PATHS_MAP.keySet();
+
     private static final String MY_LABEL = "MyLabel";
     private FilePath hudsonWs;
     private @Mock Server server;
@@ -69,7 +76,7 @@ public class CheckoutActionTest {
         when(workspaces.newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class))).thenReturn(workspace);
     	when(workspaces.getWorkspace("workspace")).thenReturn(workspace);
     	
-        new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, ".", false, false).checkoutBySingleVersionSpec(server, hudsonWs, MY_LABEL);
+        new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, EMPTY_MAPPED_PATHS_MAP, ".", false, false).checkoutBySingleVersionSpec(server, hudsonWs, MY_LABEL);
 
         verify(workspaces).newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class));
     	verify(project).getFiles(isA(String.class), eq(MY_LABEL), eq(false));
@@ -84,7 +91,7 @@ public class CheckoutActionTest {
         when(workspaces.newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class))).thenReturn(workspace);
         when(workspaces.getWorkspace("workspace")).thenReturn(workspace);
         
-        new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, ".", false, false).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
+        new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, EMPTY_MAPPED_PATHS_MAP, ".", false, false).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
         
         verify(workspaces).newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class));
         verify(project).getFiles(isA(String.class), eq("D2009-09-24T00:00:00Z"), eq(false));
@@ -98,7 +105,7 @@ public class CheckoutActionTest {
         when(workspaces.exists(new Workspace("workspace"))).thenReturn(false);
         when(workspaces.newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class))).thenReturn(workspace);
         
-        new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, ".", true, false).checkoutBySingleVersionSpec(server, hudsonWs, MY_LABEL);
+        new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, EMPTY_MAPPED_PATHS_MAP, ".", true, false).checkoutBySingleVersionSpec(server, hudsonWs, MY_LABEL);
         
         verify(workspaces).newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class));
         verify(project).getFiles(isA(String.class), eq(MY_LABEL), eq(false));
@@ -112,7 +119,7 @@ public class CheckoutActionTest {
     	when(workspaces.exists(new Workspace("workspace"))).thenReturn(false);
         when(workspaces.newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class))).thenReturn(workspace);
     	
-        new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, ".", true, false).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
+        new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, EMPTY_MAPPED_PATHS_MAP, ".", true, false).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
     	
         verify(workspaces).newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class));
     	verify(project).getFiles(isA(String.class), eq("D2009-09-24T00:00:00Z"), eq(false));
@@ -126,7 +133,7 @@ public class CheckoutActionTest {
         when(workspaces.getWorkspace("workspace")).thenReturn(workspace);
         when(workspace.getComputer()).thenReturn("LocalComputer");
         
-        new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, ".", true, false).checkoutBySingleVersionSpec(server, hudsonWs, MY_LABEL);
+        new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, EMPTY_MAPPED_PATHS_MAP, ".", true, false).checkoutBySingleVersionSpec(server, hudsonWs, MY_LABEL);
 
         verify(project).getFiles(isA(String.class), eq(MY_LABEL), eq(false));
         verify(workspaces, never()).newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class));
@@ -140,7 +147,7 @@ public class CheckoutActionTest {
         when(workspaces.getWorkspace("workspace")).thenReturn(workspace);
         when(workspace.getComputer()).thenReturn("LocalComputer");
         
-        new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, ".", true, false).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
+        new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, EMPTY_MAPPED_PATHS_MAP, ".", true, false).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
 
         verify(project).getFiles(isA(String.class), eq("D2009-09-24T00:00:00Z"), eq(false));
         verify(workspaces, never()).newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class));
@@ -155,7 +162,7 @@ public class CheckoutActionTest {
         when(workspaces.newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class))).thenReturn(workspace);
         when(workspaces.getWorkspace("workspace")).thenReturn(workspace);
         
-        new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, ".", false, false).checkoutBySingleVersionSpec(server, hudsonWs, MY_LABEL);
+        new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, EMPTY_MAPPED_PATHS_MAP, ".", false, false).checkoutBySingleVersionSpec(server, hudsonWs, MY_LABEL);
 
         verify(workspaces).newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class));
         verify(project).getFiles(isA(String.class), eq(MY_LABEL), eq(false));
@@ -170,7 +177,7 @@ public class CheckoutActionTest {
         when(workspaces.newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class))).thenReturn(workspace);
         when(workspaces.getWorkspace("workspace")).thenReturn(workspace);
         
-        new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, ".", false, false).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
+        new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, EMPTY_MAPPED_PATHS_MAP, ".", false, false).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
 
         verify(workspaces).newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class));
         verify(project).getFiles(isA(String.class), eq("D2009-09-24T00:00:00Z"), eq(false));
@@ -184,7 +191,7 @@ public class CheckoutActionTest {
         when(workspaces.getWorkspace("workspace")).thenReturn(workspace);
         when(workspace.getComputer()).thenReturn("LocalComputer");
         
-        new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, ".", true, false).checkoutBySingleVersionSpec(server, hudsonWs, MY_LABEL);
+        new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, EMPTY_MAPPED_PATHS_MAP, ".", true, false).checkoutBySingleVersionSpec(server, hudsonWs, MY_LABEL);
         
         verify(project, never()).getDetailedHistory(isA(Calendar.class), isA(Calendar.class));
     }
@@ -196,7 +203,7 @@ public class CheckoutActionTest {
         when(workspaces.getWorkspace("workspace")).thenReturn(workspace);
         when(workspace.getComputer()).thenReturn("LocalComputer");
         
-        new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, ".", true, false).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
+        new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, EMPTY_MAPPED_PATHS_MAP, ".", true, false).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
         
         verify(project, never()).getDetailedHistory(isA(Calendar.class), isA(Calendar.class));
     }
@@ -210,7 +217,7 @@ public class CheckoutActionTest {
         when(workspace.getComputer()).thenReturn("LocalComputer");
         when(project.getDetailedHistory(isA(String.class))).thenReturn(list);
         
-        CheckoutAction action = new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, ".", true, false);
+        CheckoutAction action = new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, EMPTY_MAPPED_PATHS_MAP, ".", true, false);
         List<ChangeSet> actualList = action.checkoutBySingleVersionSpec(server, hudsonWs, MY_LABEL);
         assertSame("The list from the detailed history, was not the same as returned from checkout", list, actualList);
         
@@ -224,16 +231,16 @@ public class CheckoutActionTest {
         when(workspaces.exists("workspace")).thenReturn(true);
         when(workspaces.getWorkspace("workspace")).thenReturn(workspace);
         when(workspace.getComputer()).thenReturn("LocalComputer");
-        when(project.getDetailedHistoryWithoutCloakedPaths(isA(VersionSpec.class), isA(VersionSpec.class), anyCollection())).thenReturn(list);
+        when(project.getDetailedHistoryWithoutCloakedPaths(isA(VersionSpec.class), isA(VersionSpec.class), anyCollection(), anyCollection())).thenReturn(list);
 
-        CheckoutAction action = new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, ".", true, false);
+        CheckoutAction action = new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, EMPTY_MAPPED_PATHS_MAP, ".", true, false);
         final Calendar startDate = Util.getCalendar(2008, 9, 24);
         final Calendar endDate = Util.getCalendar(2008, 10, 24);
         List<ChangeSet> actualList = action.checkout(server, hudsonWs, startDate, endDate);
         assertEquals("The list from the detailed history, was not the same as returned from checkout", list, actualList);
         
         final DateVersionSpec startDateVersionSpec = new DateVersionSpec(startDate);
-        verify(project).getDetailedHistoryWithoutCloakedPaths(argThat(new DateVersionSpecMatcher(startDateVersionSpec)), isA(VersionSpec.class), eq(EMPTY_CLOAKED_PATHS_LIST));
+        verify(project).getDetailedHistoryWithoutCloakedPaths(argThat(new DateVersionSpecMatcher(startDateVersionSpec)), isA(VersionSpec.class), eq(EMPTY_CLOAKED_PATHS_LIST), eq(EMPTY_MAPPED_PATHS_LIST));
     }
     
     @Test
@@ -247,7 +254,7 @@ public class CheckoutActionTest {
         when(workspaces.exists(new Workspace("workspace"))).thenReturn(false);
         when(workspaces.newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class))).thenReturn(workspace);
         
-        new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, "tfs-ws", false, false).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
+        new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, EMPTY_MAPPED_PATHS_MAP, "tfs-ws", false, false).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
         
         assertTrue("The local folder was removed", tfsWs.exists());
         assertEquals("The local TFS folder was not cleaned", 0, tfsWs.list((FileFilter)null).size());
@@ -265,7 +272,7 @@ public class CheckoutActionTest {
         when(workspaces.exists(new Workspace("workspace"))).thenReturn(false);
         when(workspaces.newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class))).thenReturn(workspace);
         
-        new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, "tfs-ws", false, false).checkoutBySingleVersionSpec(server, hudsonWs, MY_LABEL);
+        new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, EMPTY_MAPPED_PATHS_MAP, "tfs-ws", false, false).checkoutBySingleVersionSpec(server, hudsonWs, MY_LABEL);
         
         assertTrue("The local folder was removed", tfsWs.exists());
         assertEquals("The local TFS folder was not cleaned", 0, tfsWs.list((FileFilter)null).size());
@@ -283,7 +290,7 @@ public class CheckoutActionTest {
         when(workspaces.getWorkspace("workspace")).thenReturn(workspace);
         when(workspace.getComputer()).thenReturn("LocalComputer");
         
-        new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, "tfs-ws", true, false).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
+        new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, EMPTY_MAPPED_PATHS_MAP, "tfs-ws", true, false).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
 
         assertTrue("The local folder was removed", tfsWs.exists());
         assertEquals("The TFS workspace path was cleaned", 1, hudsonWs.list((FileFilter)null).size());
@@ -298,7 +305,7 @@ public class CheckoutActionTest {
         when(project.getProjectPath()).thenReturn("project");
         when(workspaces.newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class))).thenReturn(workspace);
         
-        new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, ".", false, false).checkoutBySingleVersionSpec(server, hudsonWs, MY_LABEL);
+        new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, EMPTY_MAPPED_PATHS_MAP, ".", false, false).checkoutBySingleVersionSpec(server, hudsonWs, MY_LABEL);
         
         verify(server).getWorkspaces();
         verify(workspaces, times(2)).exists("workspace");
@@ -318,7 +325,7 @@ public class CheckoutActionTest {
         when(project.getProjectPath()).thenReturn("project");
         when(workspaces.newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class))).thenReturn(workspace);
         
-        new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, ".", false, false).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
+        new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, EMPTY_MAPPED_PATHS_MAP, ".", false, false).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
         
         verify(server).getWorkspaces();
         verify(workspaces, times(2)).exists("workspace");
@@ -336,7 +343,7 @@ public class CheckoutActionTest {
         when(workspaces.exists("workspace")).thenReturn(true).thenReturn(true);
         when(workspaces.getWorkspace("workspace")).thenReturn(workspace);
         
-        new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, ".", true, false).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
+        new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, EMPTY_MAPPED_PATHS_MAP, ".", true, false).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
         
         verify(server).getWorkspaces();
         verify(workspaces, times(2)).exists("workspace");
@@ -352,7 +359,7 @@ public class CheckoutActionTest {
         when(workspaces.exists("workspace")).thenReturn(true).thenReturn(true);
         when(workspaces.getWorkspace("workspace")).thenReturn(workspace);
         
-        new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, ".", true, false).checkoutBySingleVersionSpec(server, hudsonWs, MY_LABEL);
+        new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, EMPTY_MAPPED_PATHS_MAP, ".", true, false).checkoutBySingleVersionSpec(server, hudsonWs, MY_LABEL);
         
         verify(server).getWorkspaces();
         verify(workspaces, times(2)).exists("workspace");
@@ -369,7 +376,7 @@ public class CheckoutActionTest {
         when(workspaces.newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class))).thenReturn(workspace);
         when(project.getProjectPath()).thenReturn("project");
 
-        new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, ".", false, false).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
+        new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, EMPTY_MAPPED_PATHS_MAP, ".", false, false).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
         
         verify(server).getWorkspaces();
         verify(workspaces, times(2)).exists("workspace");
@@ -386,7 +393,7 @@ public class CheckoutActionTest {
         when(workspaces.newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class))).thenReturn(workspace);
         when(project.getProjectPath()).thenReturn("project");
 
-        new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, ".", false, false).checkoutBySingleVersionSpec(server, hudsonWs, MY_LABEL);
+        new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, EMPTY_MAPPED_PATHS_MAP, ".", false, false).checkoutBySingleVersionSpec(server, hudsonWs, MY_LABEL);
         
         verify(server).getWorkspaces();
         verify(workspaces, times(2)).exists("workspace");
@@ -403,9 +410,9 @@ public class CheckoutActionTest {
         when(workspaces.exists("workspace")).thenReturn(true);
         when(workspaces.getWorkspace("workspace")).thenReturn(workspace);
         when(workspace.getComputer()).thenReturn("LocalComputer");
-        when(project.getDetailedHistoryWithoutCloakedPaths(isA(VersionSpec.class), isA(VersionSpec.class), anyCollection())).thenReturn(list);
+        when(project.getDetailedHistoryWithoutCloakedPaths(isA(VersionSpec.class), isA(VersionSpec.class), anyCollection(), anyCollection())).thenReturn(list);
         
-        CheckoutAction action = new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, ".", true, false);
+        CheckoutAction action = new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, EMPTY_MAPPED_PATHS_MAP, ".", true, false);
         final Calendar startDate = Util.getCalendar(2008, 9, 24);
         final Calendar endDate = Util.getCalendar(2009, 9, 24);
         List<ChangeSet> actualList = action.checkout(server, hudsonWs, startDate, endDate);
@@ -416,7 +423,8 @@ public class CheckoutActionTest {
         verify(project).getDetailedHistoryWithoutCloakedPaths(
                 argThat(new DateVersionSpecMatcher(startDateVersionSpec)),
                 argThat(new DateVersionSpecMatcher(endDateVersionSpec)),
-                eq(EMPTY_CLOAKED_PATHS_LIST));
+                eq(EMPTY_CLOAKED_PATHS_LIST),
+                eq(EMPTY_MAPPED_PATHS_LIST));
         verify(project).getFiles(isA(String.class), eq("D2009-09-24T00:00:00Z"), eq(false));
     }
 

--- a/tfs/src/test/java/hudson/plugins/tfs/commands/NewWorkspaceCommandTest.java
+++ b/tfs/src/test/java/hudson/plugins/tfs/commands/NewWorkspaceCommandTest.java
@@ -14,10 +14,13 @@ import static org.mockito.Mockito.when;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
 
 public class NewWorkspaceCommandTest extends AbstractCallableCommandTest {
 
     private static final List<String> EMPTY_CLOAKED_PATHS = Collections.emptyList();
+    private static final Map<String, String> EMPTY_MAPPED_PATHS_MAP = new TreeMap<String, String>();
 
     @Test public void assertLogging() throws Exception {
         when(server.getUserName()).thenReturn("snd\\user_cp");
@@ -28,7 +31,7 @@ public class NewWorkspaceCommandTest extends AbstractCallableCommandTest {
                 isA(String.class),
                 isA(WorkspaceLocation.class),
                 isA(WorkspaceOptions.class))).thenReturn(null);
-        final NewWorkspaceCommand command = new NewWorkspaceCommand(server, "TheWorkspaceName", null, EMPTY_CLOAKED_PATHS, null) {
+        final NewWorkspaceCommand command = new NewWorkspaceCommand(server, "TheWorkspaceName", null, EMPTY_CLOAKED_PATHS, EMPTY_MAPPED_PATHS_MAP, null) {
             @Override
             public Server createServer() {
                 return server;
@@ -51,6 +54,7 @@ public class NewWorkspaceCommandTest extends AbstractCallableCommandTest {
 
     @Test public void assertLoggingWhenAlsoMapping() throws Exception {
         final List<String> cloakedPaths = Collections.singletonList("$/Stuff/Hide");
+        final Map<String, String> mappedPaths = new TreeMap<String, String>();
 
         when(server.getUserName()).thenReturn("snd\\user_cp");
         when(vcc.createWorkspace(aryEq((WorkingFolder[]) null),
@@ -60,7 +64,7 @@ public class NewWorkspaceCommandTest extends AbstractCallableCommandTest {
                 isA(String.class),
                 isA(WorkspaceLocation.class),
                 isA(WorkspaceOptions.class))).thenReturn(null);
-        final NewWorkspaceCommand command = new NewWorkspaceCommand(server, "TheWorkspaceName", "$/Stuff", cloakedPaths, "/home/jenkins/jobs/stuff/workspace") {
+        final NewWorkspaceCommand command = new NewWorkspaceCommand(server, "TheWorkspaceName", "$/Stuff", cloakedPaths, mappedPaths, "/home/jenkins/jobs/stuff/workspace") {
             @Override
             public Server createServer() {
                 return server;
@@ -83,7 +87,118 @@ public class NewWorkspaceCommandTest extends AbstractCallableCommandTest {
         );
     }
 
+    @Test public void assertLoggingWhenAlsoMappingAtSubLevelWithoutMapFolder() throws Exception {
+        final List<String> cloakedPaths = Collections.singletonList("$/Stuff/Hide");
+        final Map<String, String> mappedPaths = new TreeMap<String, String>();
+        mappedPaths.put("$/Stuff/Hide/DoNotHide", null);
+
+        when(server.getUserName()).thenReturn("snd\\user_cp");
+        when(vcc.createWorkspace(aryEq((WorkingFolder[]) null),
+                isA(String.class),
+                isA(String.class),
+                isA(String.class),
+                isA(String.class),
+                isA(WorkspaceLocation.class),
+                isA(WorkspaceOptions.class))).thenReturn(null);
+        final NewWorkspaceCommand command = new NewWorkspaceCommand(server, "TheWorkspaceName", "$/Stuff", cloakedPaths, mappedPaths, "/home/jenkins/jobs/stuff/workspace") {
+            @Override
+            public Server createServer() {
+                return server;
+            }
+
+            @Override
+            protected void updateCache(final TFSTeamProjectCollection connection) {
+                // no-op for tests
+            }
+        };
+        final Callable<Void, Exception> callable = command.getCallable();
+
+        callable.call();
+
+        assertLog(
+                "Creating workspace 'TheWorkspaceName' owned by 'snd\\user_cp'...",
+                "Mapping '$/Stuff' to local folder '/home/jenkins/jobs/stuff/workspace' in workspace 'TheWorkspaceName'...",
+                "Cloaking '$/Stuff/Hide' in workspace 'TheWorkspaceName'...",
+                "Mapping '$/Stuff/Hide/DoNotHide' to local folder '/home/jenkins/jobs/stuff/workspace/Hide/DoNotHide' in workspace 'TheWorkspaceName'...",
+                "Created workspace 'TheWorkspaceName'."
+        );
+    }
+
+    @Test public void assertLoggingWhenAlsoMappingAtSubLevelWithMapFolder() throws Exception {
+        final List<String> cloakedPaths = Collections.singletonList("$/Stuff/Hide");
+        final Map<String, String> mappedPaths = new TreeMap<String, String>();
+        mappedPaths.put("$/Stuff/Hide/DoNotHide", "Stuff/Hide/DoNotHide");
+
+        when(server.getUserName()).thenReturn("snd\\user_cp");
+        when(vcc.createWorkspace(aryEq((WorkingFolder[]) null),
+                isA(String.class),
+                isA(String.class),
+                isA(String.class),
+                isA(String.class),
+                isA(WorkspaceLocation.class),
+                isA(WorkspaceOptions.class))).thenReturn(null);
+        final NewWorkspaceCommand command = new NewWorkspaceCommand(server, "TheWorkspaceName", "$/Stuff", cloakedPaths, mappedPaths, "/home/jenkins/jobs/stuff/workspace") {
+            @Override
+            public Server createServer() {
+                return server;
+            }
+
+            @Override
+            protected void updateCache(final TFSTeamProjectCollection connection) {
+                // no-op for tests
+            }
+        };
+        final Callable<Void, Exception> callable = command.getCallable();
+
+        callable.call();
+
+        assertLog(
+                "Creating workspace 'TheWorkspaceName' owned by 'snd\\user_cp'...",
+                "Mapping '$/Stuff' to local folder '/home/jenkins/jobs/stuff/workspace' in workspace 'TheWorkspaceName'...",
+                "Cloaking '$/Stuff/Hide' in workspace 'TheWorkspaceName'...",
+                "Mapping '$/Stuff/Hide/DoNotHide' to local folder '/home/jenkins/jobs/stuff/workspace/Stuff/Hide/DoNotHide' in workspace 'TheWorkspaceName'...",
+                "Created workspace 'TheWorkspaceName'."
+        );
+    }
+
+    @Test public void assertLoggingWhenAlsoMappingAtSubLevelWithRedirectMapFolder() throws Exception {
+        final List<String> cloakedPaths = Collections.singletonList("$/Stuff/Hide");
+        final Map<String, String> mappedPaths = new TreeMap<String, String>();
+        mappedPaths.put("$/Stuff/Hide/DoNotHide", "AnotherFolder");
+
+        when(server.getUserName()).thenReturn("snd\\user_cp");
+        when(vcc.createWorkspace(aryEq((WorkingFolder[]) null),
+                isA(String.class),
+                isA(String.class),
+                isA(String.class),
+                isA(String.class),
+                isA(WorkspaceLocation.class),
+                isA(WorkspaceOptions.class))).thenReturn(null);
+        final NewWorkspaceCommand command = new NewWorkspaceCommand(server, "TheWorkspaceName", "$/Stuff", cloakedPaths, mappedPaths, "/home/jenkins/jobs/stuff/workspace") {
+            @Override
+            public Server createServer() {
+                return server;
+            }
+
+            @Override
+            protected void updateCache(final TFSTeamProjectCollection connection) {
+                // no-op for tests
+            }
+        };
+        final Callable<Void, Exception> callable = command.getCallable();
+
+        callable.call();
+
+        assertLog(
+                "Creating workspace 'TheWorkspaceName' owned by 'snd\\user_cp'...",
+                "Mapping '$/Stuff' to local folder '/home/jenkins/jobs/stuff/workspace' in workspace 'TheWorkspaceName'...",
+                "Cloaking '$/Stuff/Hide' in workspace 'TheWorkspaceName'...",
+                "Mapping '$/Stuff/Hide/DoNotHide' to local folder '/home/jenkins/jobs/stuff/workspace/AnotherFolder' in workspace 'TheWorkspaceName'...",
+                "Created workspace 'TheWorkspaceName'."
+        );
+    }
+
     @Override protected AbstractCallableCommand createCommand(final ServerConfigurationProvider serverConfig) {
-        return new NewWorkspaceCommand(serverConfig, "workspaceName", "$/serverPath", EMPTY_CLOAKED_PATHS, "local/path");
+        return new NewWorkspaceCommand(serverConfig, "workspaceName", "$/serverPath", EMPTY_CLOAKED_PATHS, EMPTY_MAPPED_PATHS_MAP, "local/path");
     }
 }

--- a/tfs/src/test/java/hudson/plugins/tfs/model/ProjectTest.java
+++ b/tfs/src/test/java/hudson/plugins/tfs/model/ProjectTest.java
@@ -112,7 +112,41 @@ public class ProjectTest extends SwedishLocaleTestCase {
         final ChangeSet changeSet44 = createChangeSet(44, "$/MyProject/A/foo");
         final List<ChangeSet> changeSets = Arrays.asList(changeSet44, changeSet43, changeSet42);
 
-        final ChangeSet actual = Project.findLatestUncloakedChangeset(cloakedPaths, changeSets);
+        final ChangeSet actual = Project.findLatestUncloakedChangeset(cloakedPaths, null, changeSets);
+
+        Assert.assertEquals("44", actual.getVersion());
+    }
+
+    @Test
+    public void findLatestUncloakedChangeset_latestIsUncloakedBelowACloakedFolder() {
+        final List<String> cloakedPaths = Arrays.asList("$/MyProject/A/2", "$/MyProject/B");
+        final List<String> mappedPaths = Arrays.asList("$/MyProject/A/2/foo", "$/MyProject/B/bar");
+        final ChangeSet changeSet42 = createChangeSet(42, "$/MyProject/A/foo", "$/MyProject/A/bar");
+        final ChangeSet changeSet43 = createChangeSet(43, "$/MyProject/A/bar");
+        final ChangeSet changeSet44 = createChangeSet(44, "$/MyProject/A/foo");
+        final List<ChangeSet> changeSets = Arrays.asList(changeSet44, changeSet43, changeSet42);
+
+        final ChangeSet actual = Project.findLatestUncloakedChangeset(cloakedPaths, mappedPaths, changeSets);
+
+        Assert.assertEquals("44", actual.getVersion());
+    }
+
+    @Test
+    public void findLatestUncloakedChangeset_latestIsUncloakedBelowSeveralCloakedFolders() {
+        final List<String> cloakedPaths = Arrays.asList(
+            "$/MyProject/A/2",
+            "$/MyProject/A/2/foo/bar",
+            "$/MyProject/B");
+        final List<String> mappedPaths = Arrays.asList(
+            "$/MyProject/A/2/foo",
+            "$/MyProject/A/2/foo/bar/baz",
+            "$/MyProject/B/bar");
+        final ChangeSet changeSet42 = createChangeSet(42, "$/MyProject/A/foo", "$/MyProject/A/bar");
+        final ChangeSet changeSet43 = createChangeSet(43, "$/MyProject/A/bar");
+        final ChangeSet changeSet44 = createChangeSet(44, "$/MyProject/A/foo/bar/baz/foo");
+        final List<ChangeSet> changeSets = Arrays.asList(changeSet44, changeSet43, changeSet42);
+
+        final ChangeSet actual = Project.findLatestUncloakedChangeset(cloakedPaths, mappedPaths, changeSets);
 
         Assert.assertEquals("44", actual.getVersion());
     }
@@ -125,7 +159,46 @@ public class ProjectTest extends SwedishLocaleTestCase {
         final ChangeSet changeSet44 = createChangeSet(44, "$/MyProject/A/2/foo");
         final List<ChangeSet> changeSets = Arrays.asList(changeSet44, changeSet43, changeSet42);
 
-        final ChangeSet actual = Project.findLatestUncloakedChangeset(cloakedPaths, changeSets);
+        final ChangeSet actual = Project.findLatestUncloakedChangeset(cloakedPaths, null, changeSets);
+
+        Assert.assertEquals("43", actual.getVersion());
+    }
+
+    @Test
+    public void findLatestUncloakedChangeset_latestIsCloakedWithMappedFolders() {
+        final List<String> cloakedPaths = Arrays.asList(
+            "$/MyProject/A/1",
+            "$/MyProject/A/2",
+            "$/MyProject/B");
+        final List<String> mappedPaths = Arrays.asList(
+            "$/MyProject/A/1/foo",
+            "$/MyProject/B/bar");
+        final ChangeSet changeSet42 = createChangeSet(42, "$/MyProject/A/foo", "$/MyProject/A/bar");
+        final ChangeSet changeSet43 = createChangeSet(43, "$/MyProject/A/bar");
+        final ChangeSet changeSet44 = createChangeSet(44, "$/MyProject/A/2/foo");
+        final List<ChangeSet> changeSets = Arrays.asList(changeSet44, changeSet43, changeSet42);
+
+        final ChangeSet actual = Project.findLatestUncloakedChangeset(cloakedPaths, null, changeSets);
+
+        Assert.assertEquals("43", actual.getVersion());
+    }
+
+    @Test
+    public void findLatestUncloakedChangeset_latestIsCloakedBelowSeveralMappedFolders() {
+        final List<String> cloakedPaths = Arrays.asList(
+            "$/MyProject/A/2",
+            "$/MyProject/A/2/foo/bar",
+            "$/MyProject/B");
+        final List<String> mappedPaths = Arrays.asList(
+            "$/MyProject/A/2/foo",
+            "$/MyProject/A/2/foo/bar/baz",
+            "$/MyProject/B/bar");
+        final ChangeSet changeSet42 = createChangeSet(42, "$/MyProject/A/foo", "$/MyProject/A/bar");
+        final ChangeSet changeSet43 = createChangeSet(43, "$/MyProject/A/bar");
+        final ChangeSet changeSet44 = createChangeSet(44, "$/MyProject/A/2/foo/bar/foo");
+        final List<ChangeSet> changeSets = Arrays.asList(changeSet44, changeSet43, changeSet42);
+
+        final ChangeSet actual = Project.findLatestUncloakedChangeset(cloakedPaths, mappedPaths, changeSets);
 
         Assert.assertEquals("43", actual.getVersion());
     }
@@ -138,7 +211,7 @@ public class ProjectTest extends SwedishLocaleTestCase {
         final ChangeSet changeSet44 = createChangeSet(44, "$/MyProject/A/2/foo");
         final List<ChangeSet> changeSets = Arrays.asList(changeSet44, changeSet43, changeSet42);
 
-        final ChangeSet actual = Project.findLatestUncloakedChangeset(cloakedPaths, changeSets);
+        final ChangeSet actual = Project.findLatestUncloakedChangeset(cloakedPaths, null, changeSets);
 
         Assert.assertEquals(null, actual);
     }
@@ -161,7 +234,7 @@ public class ProjectTest extends SwedishLocaleTestCase {
     public void isChangesetFullyCloaked_nullCloakedPaths() {
         final List<String> changesetPaths = Arrays.asList("$/foo", "$/foo/bar.baz");
 
-        final boolean actual = Project.isChangesetFullyCloaked(changesetPaths, null);
+        final boolean actual = Project.isChangesetFullyCloaked(changesetPaths, null, null);
 
         Assert.assertEquals(false, actual);
     }
@@ -172,7 +245,7 @@ public class ProjectTest extends SwedishLocaleTestCase {
         final List<String> changesetPaths = Arrays.asList("$/foo", "$/foo/bar.baz");
         final List<String> cloakedPaths = Arrays.asList("$/fizz", "$/fizz/FizzBuzz.java");
 
-        final boolean actual = Project.isChangesetFullyCloaked(changesetPaths, cloakedPaths);
+        final boolean actual = Project.isChangesetFullyCloaked(changesetPaths, cloakedPaths, null);
 
         Assert.assertEquals(false, actual);
     }
@@ -182,9 +255,20 @@ public class ProjectTest extends SwedishLocaleTestCase {
         final List<String> changesetPaths = Arrays.asList("$/foo/bar/test.baz");
         final List<String> cloakedPaths = Arrays.asList("$/fOo/bAr/");
 
-        final boolean actual = Project.isChangesetFullyCloaked(changesetPaths, cloakedPaths);
+        final boolean actual = Project.isChangesetFullyCloaked(changesetPaths, cloakedPaths, null);
 
         Assert.assertEquals(true, actual);
+    }
+
+    @Test
+    public void isChangesetFullyCloaked_caseInsensitiveMappedPaths() {
+        final List<String> changesetPaths = Arrays.asList("$/foo/bar/baz/test.baz");
+        final List<String> cloakedPaths = Arrays.asList("$/fOo/bAr/");
+        final List<String> mappedPaths = Arrays.asList("$/fOo/bAr/BaZ");
+
+        final boolean actual = Project.isChangesetFullyCloaked(changesetPaths, cloakedPaths, mappedPaths);
+
+        Assert.assertEquals(false, actual);
     }
 
     @Test
@@ -192,7 +276,18 @@ public class ProjectTest extends SwedishLocaleTestCase {
         final List<String> changesetPaths = Arrays.asList("$/foo", "$/foo/bar.baz");
         final List<String> cloakedPaths = Collections.singletonList("$/foo/bar.baz");
 
-        final boolean actual = Project.isChangesetFullyCloaked(changesetPaths, cloakedPaths);
+        final boolean actual = Project.isChangesetFullyCloaked(changesetPaths, cloakedPaths, null);
+
+        Assert.assertEquals(false, actual);
+    }
+
+    @Test
+    public void isChangesetFullyCloaked_mappingChild() {
+        final List<String> changesetPaths = Arrays.asList("$/foo/bar", "$/foo/bar/baz/fizz.buzz");
+        final List<String> cloakedPaths = Collections.singletonList("$/foo/bar");
+        final List<String> mappedPaths = Arrays.asList("$/foo/bar/baz");
+
+        final boolean actual = Project.isChangesetFullyCloaked(changesetPaths, cloakedPaths, mappedPaths);
 
         Assert.assertEquals(false, actual);
     }
@@ -202,7 +297,7 @@ public class ProjectTest extends SwedishLocaleTestCase {
         final List<String> changesetPaths = Arrays.asList("$/foo", "$/bar");
         final List<String> cloakedPaths = Collections.singletonList("$/foo");
 
-        final boolean actual = Project.isChangesetFullyCloaked(changesetPaths, cloakedPaths);
+        final boolean actual = Project.isChangesetFullyCloaked(changesetPaths, cloakedPaths, null);
 
         Assert.assertEquals(false, actual);
     }
@@ -212,7 +307,23 @@ public class ProjectTest extends SwedishLocaleTestCase {
         final List<String> changesetPaths = Arrays.asList("$/foo", "$/foo/bar.baz");
         final List<String> cloakedPaths = Collections.singletonList("$/foo");
 
-        final boolean actual = Project.isChangesetFullyCloaked(changesetPaths, cloakedPaths);
+        final boolean actual = Project.isChangesetFullyCloaked(changesetPaths, cloakedPaths, null);
+
+        Assert.assertEquals(true, actual);
+    }
+
+    @Test
+    public void isChangesetFullyCloaked_fullyCloakedPathWithMappedPaths() {
+        final List<String> changesetPaths = Arrays.asList(
+            "$/foo",
+             "$/foo/bar/baz",
+             "$/foo/bar/baz/fizz");
+        final List<String> cloakedPaths = Arrays.asList(
+            "$/foo",
+            "$/foo/bar/baz");
+        final List<String> mappedPaths = Arrays.asList("$/foo/bar");
+
+        final boolean actual = Project.isChangesetFullyCloaked(changesetPaths, cloakedPaths, mappedPaths);
 
         Assert.assertEquals(true, actual);
     }
@@ -222,7 +333,7 @@ public class ProjectTest extends SwedishLocaleTestCase {
         final List<String> changesetPaths = Collections.singletonList("$/foo/bar.baz");
         final List<String> cloakedPaths = Arrays.asList("$/foo", "$/bar");
 
-        final boolean actual = Project.isChangesetFullyCloaked(changesetPaths, cloakedPaths);
+        final boolean actual = Project.isChangesetFullyCloaked(changesetPaths, cloakedPaths, null);
 
         Assert.assertEquals(true, actual);
     }
@@ -232,7 +343,7 @@ public class ProjectTest extends SwedishLocaleTestCase {
         final List<String> changesetPaths = Arrays.asList("$/foo/bar.baz", "$/bar/foo.baz");
         final List<String> cloakedPaths = Arrays.asList("$/foo", "$/bar");
 
-        final boolean actual = Project.isChangesetFullyCloaked(changesetPaths, cloakedPaths);
+        final boolean actual = Project.isChangesetFullyCloaked(changesetPaths, cloakedPaths, null);
 
         Assert.assertEquals(true, actual);
     }

--- a/tfs/src/test/java/hudson/plugins/tfs/model/WorkspaceConfigurationTest.java
+++ b/tfs/src/test/java/hudson/plugins/tfs/model/WorkspaceConfigurationTest.java
@@ -5,25 +5,44 @@ import static org.junit.Assert.*;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
 
 import org.junit.Test;
 
 public class WorkspaceConfigurationTest {
 
     private static final List<String> EMPTY_CLOAKED_PATHS_LIST = Collections.emptyList();
+    private static final Map<String, String> EMPTY_MAPPING_PATHS_LIST = new TreeMap<String, String>();
 
     @Test public void assertConfigurationsEquals() {
         final List<String> cloakList = Collections.singletonList("cloak");
+        final Map<String, String> mappings = new TreeMap<String, String>();
+        mappings.put("$/foo/", "foo");
+        mappings.put("$/bar/", "bar");
+        mappings.put("$/baz/", "baz");
 
-        WorkspaceConfiguration one = new WorkspaceConfiguration("server", "workspace", "project", cloakList, "workfolder");
-        WorkspaceConfiguration two = new WorkspaceConfiguration("server", "workspace", "project", cloakList, "workfolder");
+        final Map<String, String> almostSimilarMappings = new TreeMap<String, String>();
+        mappings.put("$/foo/", "foo/");
+        mappings.put("$/bar/", "bar");
+        mappings.put("$/baz/", "baz");
+
+        WorkspaceConfiguration one = new WorkspaceConfiguration("server", "workspace", "project", cloakList, mappings, "workfolder");
+        WorkspaceConfiguration two = new WorkspaceConfiguration("server", "workspace", "project", cloakList, mappings, "workfolder");
         assertThat(one, is(two));
         assertThat(two, is(one));
         assertThat(one, is(one));
-        assertThat(one, not(new WorkspaceConfiguration("aserver", "workspace", "project", cloakList, "workfolder")));
-        assertThat(one, not(new WorkspaceConfiguration("server", "aworkspace", "project", cloakList, "workfolder")));
-        assertThat(one, not(new WorkspaceConfiguration("server", "workspace", "aproject", cloakList, "workfolder")));
-        assertThat(one, not(new WorkspaceConfiguration("server", "workspace", "project", cloakList, "aworkfolder")));
-        assertThat(one, not(new WorkspaceConfiguration("server", "workspace", "project", EMPTY_CLOAKED_PATHS_LIST, "workfolder")));
+        
+        assertThat(one, not(new WorkspaceConfiguration("aserver", "workspace", "project", cloakList, mappings, "workfolder")));
+        assertThat(one, not(new WorkspaceConfiguration("server", "aworkspace", "project", cloakList, mappings, "workfolder")));
+        assertThat(one, not(new WorkspaceConfiguration("server", "workspace", "aproject", cloakList, mappings, "workfolder")));
+        assertThat(one, not(new WorkspaceConfiguration("server", "workspace", "project", cloakList, mappings, "aworkfolder")));
+
+        assertThat(one, not(new WorkspaceConfiguration("server", "workspace", "project", null, mappings, "workfolder")));
+        assertThat(one, not(new WorkspaceConfiguration("server", "workspace", "project", EMPTY_CLOAKED_PATHS_LIST, mappings, "workfolder")));
+
+        assertThat(one, not(new WorkspaceConfiguration("server", "workspace", "project", cloakList, null, "workfolder")));
+        assertThat(one, not(new WorkspaceConfiguration("server", "workspace", "project", cloakList, EMPTY_MAPPING_PATHS_LIST, "workfolder")));
+        assertThat(one, not(new WorkspaceConfiguration("server", "workspace", "project", cloakList, almostSimilarMappings, "workfolder")));
     }
 }

--- a/tfs/src/test/java/hudson/plugins/tfs/model/WorkspaceConfigurationTest.java
+++ b/tfs/src/test/java/hudson/plugins/tfs/model/WorkspaceConfigurationTest.java
@@ -27,11 +27,25 @@ public class WorkspaceConfigurationTest {
         mappings.put("$/bar/", "bar");
         mappings.put("$/baz/", "baz");
 
+        final Map<String, String> nullMappings = new TreeMap<String, String>();
+        mappings.put("$/foo/", null);
+        mappings.put("$/bar/", null);
+        mappings.put("$/baz/", null);
+
         WorkspaceConfiguration one = new WorkspaceConfiguration("server", "workspace", "project", cloakList, mappings, "workfolder");
         WorkspaceConfiguration two = new WorkspaceConfiguration("server", "workspace", "project", cloakList, mappings, "workfolder");
+        WorkspaceConfiguration three = new WorkspaceConfiguration("server", "workspace", "project", cloakList, almostSimilarMappings, "workfolder");
+        WorkspaceConfiguration four = new WorkspaceConfiguration("server", "workspace", "project", cloakList, nullMappings, "workfolder");
+        
         assertThat(one, is(two));
         assertThat(two, is(one));
         assertThat(one, is(one));
+
+        assertThat(one, not(three));
+        assertThat(one, not(four));
+
+        assertThat(three, is(three));
+        assertThat(four, is(four));
         
         assertThat(one, not(new WorkspaceConfiguration("aserver", "workspace", "project", cloakList, mappings, "workfolder")));
         assertThat(one, not(new WorkspaceConfiguration("server", "aworkspace", "project", cloakList, mappings, "workfolder")));
@@ -43,6 +57,5 @@ public class WorkspaceConfigurationTest {
 
         assertThat(one, not(new WorkspaceConfiguration("server", "workspace", "project", cloakList, null, "workfolder")));
         assertThat(one, not(new WorkspaceConfiguration("server", "workspace", "project", cloakList, EMPTY_MAPPING_PATHS_LIST, "workfolder")));
-        assertThat(one, not(new WorkspaceConfiguration("server", "workspace", "project", cloakList, almostSimilarMappings, "workfolder")));
     }
 }

--- a/tfs/src/test/java/hudson/plugins/tfs/model/WorkspacesTest.java
+++ b/tfs/src/test/java/hudson/plugins/tfs/model/WorkspacesTest.java
@@ -5,6 +5,8 @@ import java.io.Reader;
 import java.io.StringReader;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
 
 import hudson.plugins.tfs.commands.ListWorkspacesCommand;
 
@@ -21,6 +23,7 @@ import org.mockito.MockitoAnnotations;
 public class WorkspacesTest {
 
     private static final List<String> EMPTY_CLOAKED_PATHS_LIST = Collections.emptyList();
+    private static final Map<String, String> EMPTY_MAPPED_PATHS_MAP = new TreeMap<String, String>();
 
     @Mock private Server server;
     private ListWorkspacesCommand parser;
@@ -91,7 +94,7 @@ public class WorkspacesTest {
         when(server.execute(isA(Callable.class))).thenReturn(null);
         
         Workspaces workspaces = new Workspaces(server);
-        Workspace workspace = workspaces.newWorkspace("name1", null, EMPTY_CLOAKED_PATHS_LIST, null);
+        Workspace workspace = workspaces.newWorkspace("name1", null, EMPTY_CLOAKED_PATHS_LIST, EMPTY_MAPPED_PATHS_MAP, null);
         assertNotNull("The new workspace was null", workspace);
         assertTrue("The workspace was reported as non existant", workspaces.exists(workspace));
     }
@@ -101,7 +104,7 @@ public class WorkspacesTest {
         when(server.execute(isA(Callable.class))).thenReturn(null);
         
         Workspaces workspaces = new Workspaces(server);
-        workspaces.newWorkspace("name1", null, EMPTY_CLOAKED_PATHS_LIST, null);
+        workspaces.newWorkspace("name1", null, EMPTY_CLOAKED_PATHS_LIST, EMPTY_MAPPED_PATHS_MAP, null);
         assertNotNull("The get new workspace returned null", workspaces.getWorkspace("name1"));
         verify(server, times(1)).execute(isA(Callable.class));
     }
@@ -111,7 +114,7 @@ public class WorkspacesTest {
         when(server.execute(isA(Callable.class))).thenReturn(null);
         
         Workspaces workspaces = new Workspaces(server);
-        Workspace workspace = workspaces.newWorkspace("name1", null, EMPTY_CLOAKED_PATHS_LIST, null);
+        Workspace workspace = workspaces.newWorkspace("name1", null, EMPTY_CLOAKED_PATHS_LIST, EMPTY_MAPPED_PATHS_MAP, null);
         assertTrue("The get new workspace did not exists", workspaces.exists(workspace));
         verify(server, times(1)).execute(isA(Callable.class));
     }
@@ -122,7 +125,7 @@ public class WorkspacesTest {
         Workspaces workspaces = new Workspaces(server);
         // Populate the map in test object
         assertFalse("The workspace was reported as existant", workspaces.exists(new Workspace("name")));
-        Workspace workspace = workspaces.newWorkspace("name", null, EMPTY_CLOAKED_PATHS_LIST, null);
+        Workspace workspace = workspaces.newWorkspace("name", null, EMPTY_CLOAKED_PATHS_LIST, EMPTY_MAPPED_PATHS_MAP, null);
         assertTrue("The workspace was reported as non existant", workspaces.exists(new Workspace("name")));
         workspaces.deleteWorkspace(workspace);
         assertFalse("The workspace was reported as existant", workspaces.exists(workspace));

--- a/tfs/src/test/java/hudson/plugins/tfs/util/BuildWorkspaceConfigurationRetrieverTest.java
+++ b/tfs/src/test/java/hudson/plugins/tfs/util/BuildWorkspaceConfigurationRetrieverTest.java
@@ -7,6 +7,8 @@ import static org.mockito.Mockito.*;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
 
 import hudson.model.AbstractBuild;
 import hudson.model.Node;
@@ -21,13 +23,14 @@ import org.jvnet.hudson.test.Bug;
 public class BuildWorkspaceConfigurationRetrieverTest {
 
     private static final List<String> EMPTY_CLOAKED_PATHS_LIST = Collections.emptyList();
+    private static final Map<String, String> EMPTY_MAPPING_PATHS_LIST = new TreeMap<String, String>();
 
     @Test
     public void assertGetLatestConfgiurationOnNode() {
         AbstractBuild build = mock(AbstractBuild.class);
         Node node = mock(Node.class);
         Node needleNode = mock(Node.class);
-        WorkspaceConfiguration configuration = new WorkspaceConfiguration("serverUrl", "workspaceName", "projectPath", EMPTY_CLOAKED_PATHS_LIST, "workfolder");
+        WorkspaceConfiguration configuration = new WorkspaceConfiguration("serverUrl", "workspaceName", "projectPath", EMPTY_CLOAKED_PATHS_LIST, EMPTY_MAPPING_PATHS_LIST, "workfolder");
         when(build.getPreviousBuild()).thenReturn(build).thenReturn(null);
         when(build.getBuiltOn()).thenReturn(node, node, null);
         when(node.getNodeName()).thenReturn("node1", "needleNode");
@@ -98,7 +101,7 @@ public class BuildWorkspaceConfigurationRetrieverTest {
         when(build.getPreviousBuild()).thenReturn(build);
         when(build.getBuiltOn()).thenReturn(node);
         when(node.getNodeName()).thenReturn("needleNode");
-        when(build.getAction(WorkspaceConfiguration.class)).thenReturn(new WorkspaceConfiguration("serverUrl", "workspaceName", "projectPath", EMPTY_CLOAKED_PATHS_LIST, "workfolder"));
+        when(build.getAction(WorkspaceConfiguration.class)).thenReturn(new WorkspaceConfiguration("serverUrl", "workspaceName", "projectPath", EMPTY_CLOAKED_PATHS_LIST, EMPTY_MAPPING_PATHS_LIST, "workfolder"));
         
         BuildWorkspaceConfiguration configuration = new BuildWorkspaceConfigurationRetriever().getLatestForNode(node, build);
         assertThat( configuration.getWorkspaceName(), is("workspaceName"));
@@ -113,7 +116,7 @@ public class BuildWorkspaceConfigurationRetrieverTest {
         AbstractBuild build = mock(AbstractBuild.class);
         Node node = mock(Node.class);
         Node needleNode = mock(Node.class);
-        WorkspaceConfiguration configuration = new WorkspaceConfiguration("serverUrl", "workspaceName", "projectPath", EMPTY_CLOAKED_PATHS_LIST, "workfolder");
+        WorkspaceConfiguration configuration = new WorkspaceConfiguration("serverUrl", "workspaceName", "projectPath", EMPTY_CLOAKED_PATHS_LIST, EMPTY_MAPPING_PATHS_LIST, "workfolder");
         when(build.getPreviousBuild()).thenReturn(build).thenReturn(null);
         when(build.getBuiltOn()).thenReturn(null);
 


### PR DESCRIPTION
This pull request adds the ability to cloak a folder and then explicitly map a sub folder, so that the cloaked folder will not be included in the checkout but the sub folder will be

This capability is useful in cases (like ours) where a TFS repository contains a large amount of code and each build only needs a 'small' amount of that code. For instance if the TFS repository looks like

    $/
        product-1
            folder-1
            folder-2
        product-2
            folder-1
            folder-2
        shared-1
            folder-1
                folder-1
                folder-2
            folder-2
                folder-1
                folder-2
        shared-2
            folder-1
                folder-1
                folder-2
            folder-2
                folder-1
                folder-2

To build `product-1` the following folders are required

    $/
        product-1
            folder-1
            folder-2
        shared-1
            folder-1
                folder-1
                folder-2
        shared-2
            folder-1

To build `product-2` the following folders are required

    $/
        product-2
            folder-1
            folder-2
        shared-1
            folder-1
                folder-2
            folder-2
                folder-1
                folder-2
        shared-2
            folder-2
                folder-1
                folder-2

The build configuration for `product-1` would ideally only checkout the folders it needs, however the
`project path` has to be `$/` (i.e. the repository root). It is then possible to cloak the folders that shouldn't be included. However that means that if new folders are added the build configuration needs to be updated to cloak the new folder.

By adding the mapping ability it is possible to cloak all [top level folders](teamfoundation.blogspot.co.nz/2008/06/advanced-workspace-cloaking-in-tfs-2008.html) and explicitly map those folders that we need. That way it is unlikely that the addition of new folders will require updates to the build configuration.

Additionally this code allows mapping a folder to a different location in the workspace which enables
a reduce the path length, especially when dealing with nested branches like this:

    $/
        Branches
            1.0
                product-1
                    ...
                product-2
                    ...
            2.0
                product-1
                    ...
                product-2
                    ...
            3.0
                product-1
                    ...
                product-2
                    ...
