### PR TITLE
Dev/adelcast/fix author

### DIFF
--- a/tfs/src/main/java/hudson/plugins/tfs/commands/RemoteChangesetVersionCommand.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/commands/RemoteChangesetVersionCommand.java
@@ -83,7 +83,7 @@ public class RemoteChangesetVersionCommand extends AbstractCallableCommand<Integ
             final Changeset serverChangeset = serverChangeSets[0];
             changeSetNumber = serverChangeset.getChangesetID();
             final Date changeSetDate = serverChangeset.getDate().getTime();
-            final String author = serverChangeset.getCommitter();
+            final String author = serverChangeset.getOwner();
             final SimpleDateFormat simpleDateFormat = DateUtil.TFS_DATETIME_FORMATTER.get();
             simpleDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
             final String changeSetDateIso8601 = simpleDateFormat.format(changeSetDate);

--- a/tfs/src/main/java/hudson/plugins/tfs/model/Project.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/model/Project.java
@@ -56,7 +56,7 @@ public class Project {
         (com.microsoft.tfs.core.clients.versioncontrol.soapextensions.Changeset serverChangeset, UserLookup userLookup) {
         final String version = Integer.toString(serverChangeset.getChangesetID(), 10);
         final Date date = serverChangeset.getDate().getTime();
-        final String author = serverChangeset.getCommitter();
+        final String author = serverChangeset.getOwner();
         final User authorUser = userLookup.find(author);
         final String comment = serverChangeset.getComment();
 

--- a/tfs/src/main/java/hudson/plugins/tfs/model/TfsUserLookup.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/model/TfsUserLookup.java
@@ -34,11 +34,11 @@ public class TfsUserLookup implements UserLookup {
      */
     public User find(final String accountName) {
         final String mappedAccountName = userAccountMapper.mapUserAccount(accountName);
-        logger.log(Level.FINE, "Looking up Jenkins user for account '%s'.", mappedAccountName);
+        logger.log(Level.FINE, String.format("Looking up Jenkins user for account '%s'.", mappedAccountName));
         final User jenkinsUser = User.get(mappedAccountName);
         Mailer.UserProperty mailerProperty = jenkinsUser.getProperty(Mailer.UserProperty.class);
         if (mailerProperty == null || mailerProperty.getAddress() == null || mailerProperty.getAddress().length() == 0) {
-            logger.log(Level.FINE, "No Mailer.UserProperty defined for '%s', looking in TFS", mappedAccountName);
+            logger.log(Level.FINE, String.format("No Mailer.UserProperty defined for '%s', looking in TFS", mappedAccountName));
             final TeamFoundationIdentity tfsUser = ims.readIdentity(
                 IdentitySearchFactor.ACCOUNT_NAME,
                 accountName,


### PR DESCRIPTION
Use owner instead of committer as author, since automated processes often use non-user accounts to commit.