### PR TITLE
Users/kej/update changeset url

### DIFF
--- a/tfs/src/main/java/hudson/plugins/tfs/browsers/TeamSystemWebAccessBrowser.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/browsers/TeamSystemWebAccessBrowser.java
@@ -1,4 +1,3 @@
-//CHECKSTYLE:OFF
 package hudson.plugins.tfs.browsers;
 
 import hudson.Extension;
@@ -11,14 +10,15 @@ import hudson.plugins.tfs.util.QueryString;
 import hudson.scm.EditType;
 import hudson.scm.RepositoryBrowser;
 import hudson.scm.SCM;
+import org.kohsuke.stapler.DataBoundConstructor;
 
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
 
-import org.apache.commons.io.FilenameUtils;
-import org.kohsuke.stapler.DataBoundConstructor;
-
+/**
+ *  Provides information and links back to the TFS/VSTS repository for the current change set.
+ */
 public class TeamSystemWebAccessBrowser extends TeamFoundationServerRepositoryBrowser {
 
     private static final long serialVersionUID = 1L;
@@ -26,7 +26,7 @@ public class TeamSystemWebAccessBrowser extends TeamFoundationServerRepositoryBr
     private final String url;
 
     @DataBoundConstructor
-    public TeamSystemWebAccessBrowser(String urlExample) {
+    public TeamSystemWebAccessBrowser(final String urlExample) {
         this.url = Util.fixEmpty(urlExample);
     }
 
@@ -34,7 +34,7 @@ public class TeamSystemWebAccessBrowser extends TeamFoundationServerRepositoryBr
         return url;
     }
 
-    private String getServerConfiguration(ChangeSet changeset) {
+    private String getServerConfiguration(final ChangeSet changeset) {
         AbstractProject<?, ?> project = changeset.getParent().build.getProject();
         SCM scm = project.getScm();
         if (scm instanceof TeamFoundationServerScm) {
@@ -46,7 +46,7 @@ public class TeamSystemWebAccessBrowser extends TeamFoundationServerRepositoryBr
         }
     }
 
-    private String getBaseUrlString(ChangeSet changeSet) throws MalformedURLException {
+    private String getBaseUrlString(final ChangeSet changeSet) throws MalformedURLException {
         String baseUrl = url;
         if (baseUrl == null) {
             baseUrl = getServerConfiguration(changeSet);
@@ -62,13 +62,12 @@ public class TeamSystemWebAccessBrowser extends TeamFoundationServerRepositoryBr
     public URL getChangeSetLink(final ChangeSet changeSet) throws IOException {
         final String baseUrlString = getBaseUrlString(changeSet);
         final URL baseUrl = new URL(baseUrlString);
-        final QueryString qs = new QueryString();
-        qs.put("id", changeSet.getVersion());
-        final URL changeSetUrl = new URL(baseUrl, "_versionControl/changeset?" + qs.toString());
-        return changeSetUrl;
+        //final QueryString qs = new QueryString();
+        //qs.put("id", changeSet.getVersion());
+        return new URL(baseUrl, "_versionControl/changeset/" + changeSet.getVersion());
     }
 
-    URL createChangeSetItemLink(final ChangeSet.Item item, final String action) throws IOException {
+    private URL createChangeSetItemLink(final ChangeSet.Item item, final String action) throws IOException {
         final ChangeSet changeSet = item.getParent();
         final URL changeSetUrl = getChangeSetLink(changeSet);
         final QueryString qs = new QueryString();
@@ -95,6 +94,9 @@ public class TeamSystemWebAccessBrowser extends TeamFoundationServerRepositoryBr
         return createChangeSetItemLink(item, "compare");
     }
 
+    /**
+     * Gets the descriptor for the repository.
+     */
     @Extension
     public static final class DescriptorImpl extends Descriptor<RepositoryBrowser<?>> {
 

--- a/tfs/src/main/java/hudson/plugins/tfs/browsers/TeamSystemWebAccessBrowser.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/browsers/TeamSystemWebAccessBrowser.java
@@ -62,8 +62,6 @@ public class TeamSystemWebAccessBrowser extends TeamFoundationServerRepositoryBr
     public URL getChangeSetLink(final ChangeSet changeSet) throws IOException {
         final String baseUrlString = getBaseUrlString(changeSet);
         final URL baseUrl = new URL(baseUrlString);
-        //final QueryString qs = new QueryString();
-        //qs.put("id", changeSet.getVersion());
         return new URL(baseUrl, "_versionControl/changeset/" + changeSet.getVersion());
     }
 

--- a/tfs/src/test/java/hudson/plugins/tfs/browsers/TeamSystemWebAccessBrowserTest.java
+++ b/tfs/src/test/java/hudson/plugins/tfs/browsers/TeamSystemWebAccessBrowserTest.java
@@ -23,21 +23,21 @@ public class TeamSystemWebAccessBrowserTest {
         TeamSystemWebAccessBrowser browser = new TeamSystemWebAccessBrowser("http://tfs:8080/");
         ChangeSet changeSet = new ChangeSet("99", null, "user", "comment");
         URL actual = browser.getChangeSetLink(changeSet);
-        assertEquals("The change set link was incorrect", "http://tfs:8080/_versionControl/changeset?id=99", actual.toString());
+        assertEquals("The change set link was incorrect", "http://tfs:8080/_versionControl/changeset/99", actual.toString());
     }
 
     @Test public void assertChangeSetLinkWithRealisticServerUrlWithPort() throws Exception {
         TeamSystemWebAccessBrowser browser = new TeamSystemWebAccessBrowser("http://tfs:8080/tfs/coll");
         ChangeSet changeSet = new ChangeSet("99", null, "user", "comment");
         URL actual = browser.getChangeSetLink(changeSet);
-        assertEquals("The change set link was incorrect", "http://tfs:8080/tfs/coll/_versionControl/changeset?id=99", actual.toString());
+        assertEquals("The change set link was incorrect", "http://tfs:8080/tfs/coll/_versionControl/changeset/99", actual.toString());
     }
 
     @Test public void assertChangeSetLinkWithRealisticServerUrl() throws Exception {
         TeamSystemWebAccessBrowser browser = new TeamSystemWebAccessBrowser("http://tfs/tfs/coll");
         ChangeSet changeSet = new ChangeSet("99", null, "user", "comment");
         URL actual = browser.getChangeSetLink(changeSet);
-        assertEquals("The change set link was incorrect", "http://tfs/tfs/coll/_versionControl/changeset?id=99", actual.toString());
+        assertEquals("The change set link was incorrect", "http://tfs/tfs/coll/_versionControl/changeset/99", actual.toString());
     }
 
 	@Bug(7394)
@@ -46,7 +46,7 @@ public class TeamSystemWebAccessBrowserTest {
 		TeamSystemWebAccessBrowser browser = new TeamSystemWebAccessBrowser("http://tfs");
 		ChangeSet changeSet = new ChangeSet("99", null, "user", "comment");
 		URL actual = browser.getChangeSetLink(changeSet);
-		assertEquals("The change set link was incorrect", "http://tfs/_versionControl/changeset?id=99", actual.toString());
+		assertEquals("The change set link was incorrect", "http://tfs/_versionControl/changeset/99", actual.toString());
 	}
 
 	@Bug(7394)
@@ -55,7 +55,7 @@ public class TeamSystemWebAccessBrowserTest {
 		TeamSystemWebAccessBrowser browser = new TeamSystemWebAccessBrowser("http://tfs/");
 		ChangeSet changeSet = new ChangeSet("99", null, "user", "comment");
 		URL actual = browser.getChangeSetLink(changeSet);
-		assertEquals("The change set link was incorrect","http://tfs/_versionControl/changeset?id=99", actual.toString());
+		assertEquals("The change set link was incorrect","http://tfs/_versionControl/changeset/99", actual.toString());
 	}
     
     private static TeamFoundationServerScm createTestScm(String serverUrl) {
@@ -83,7 +83,7 @@ public class TeamSystemWebAccessBrowserTest {
         TeamSystemWebAccessBrowser browser = new TeamSystemWebAccessBrowser(""); // configured but no URL specified
 
         URL actual = browser.getChangeSetLink(changeset);
-        assertEquals("The change set link was incorrect", "http://server:80/tfs/collection/_versionControl/changeset?id=62643", actual.toString());
+        assertEquals("The change set link was incorrect", "http://server:80/tfs/collection/_versionControl/changeset/62643", actual.toString());
     }
 
     @Test public void assertChangeSetLinkUsesScmConfigurationNoSlash() throws Exception {
@@ -99,7 +99,7 @@ public class TeamSystemWebAccessBrowserTest {
       TeamSystemWebAccessBrowser browser = new TeamSystemWebAccessBrowser(""); // configured but no URL specified
 
       URL actual = browser.getChangeSetLink(changeset);
-      assertEquals("The change set link was incorrect", "http://server:80/tfs/collection/_versionControl/changeset?id=62643", actual.toString());
+      assertEquals("The change set link was incorrect", "http://server:80/tfs/collection/_versionControl/changeset/62643", actual.toString());
     }
 
     @Test public void assertFileLinkUsesScmConfiguration() throws Exception {
@@ -116,7 +116,7 @@ public class TeamSystemWebAccessBrowserTest {
       TeamSystemWebAccessBrowser browser = new TeamSystemWebAccessBrowser(""); // configured but no URL specified
 
       URL actual = browser.getFileLink(item);
-      assertEquals("The file link was incorrect", "http://server:80/tfs/collection/_versionControl/changeset?id=62643#path=%24%2Fproject%2Ffolder%2Ffolder%2Fbranch%2Fsome%2Fpath%2Fto%2Fsome%2Ffile.txt&version=62643&_a=contents", actual.toString());
+      assertEquals("The file link was incorrect", "http://server:80/tfs/collection/_versionControl/changeset/62643#path=%24%2Fproject%2Ffolder%2Ffolder%2Fbranch%2Fsome%2Fpath%2Fto%2Fsome%2Ffile.txt&version=62643&_a=contents", actual.toString());
     }
 
     @Test public void assertDiffLinkUsesScmConfiguration() throws Exception {
@@ -133,7 +133,7 @@ public class TeamSystemWebAccessBrowserTest {
 
       TeamSystemWebAccessBrowser browser = new TeamSystemWebAccessBrowser(""); // configured but no URL specified
       URL actual = browser.getDiffLink(item);
-      assertEquals("The diff link was incorrect", "http://server:80/tfs/collection/_versionControl/changeset?id=62643#path=%24%2Fproject%2Ffolder%2Ffolder%2Fbranch%2Fsome%2Fpath%2Fto%2Fsome%2Ffile.txt&version=62643&_a=compare", actual.toString());
+      assertEquals("The diff link was incorrect", "http://server:80/tfs/collection/_versionControl/changeset/62643#path=%24%2Fproject%2Ffolder%2Ffolder%2Fbranch%2Fsome%2Fpath%2Fto%2Fsome%2Ffile.txt&version=62643&_a=compare", actual.toString());
     }
 
     @Test public void assertFileLink() throws Exception {
@@ -142,7 +142,7 @@ public class TeamSystemWebAccessBrowserTest {
         ChangeSet.Item item = new ChangeSet.Item("$/Project/Folder/file.cs", "add");
         changeSet.add(item);
         URL actual = browser.getFileLink(item);
-        assertEquals("The file link was incorrect", "http://tfs:8080/_versionControl/changeset?id=99#path=%24%2FProject%2FFolder%2Ffile.cs&version=99&_a=contents", actual.toString());
+        assertEquals("The file link was incorrect", "http://tfs:8080/_versionControl/changeset/99#path=%24%2FProject%2FFolder%2Ffile.cs&version=99&_a=contents", actual.toString());
     }
 
     @Test public void assertFileLinkWithRealisticServerUrl() throws Exception {
@@ -151,7 +151,7 @@ public class TeamSystemWebAccessBrowserTest {
         ChangeSet.Item item = new ChangeSet.Item("$/Project/Folder/file.cs", "add");
         changeSet.add(item);
         URL actual = browser.getFileLink(item);
-        assertEquals("The file link was incorrect", "http://tfs:8080/tfs/coll/_versionControl/changeset?id=99#path=%24%2FProject%2FFolder%2Ffile.cs&version=99&_a=contents", actual.toString());
+        assertEquals("The file link was incorrect", "http://tfs:8080/tfs/coll/_versionControl/changeset/99#path=%24%2FProject%2FFolder%2Ffile.cs&version=99&_a=contents", actual.toString());
     }
 
     @Test public void assertDiffLink() throws Exception {
@@ -160,7 +160,7 @@ public class TeamSystemWebAccessBrowserTest {
         ChangeSet.Item item = new ChangeSet.Item("$/Project/Folder/file.cs", "edit");
         changeSet.add(item);
         URL actual = browser.getDiffLink(item);
-        assertEquals("The diff link was incorrect", "http://tfs:8080/_versionControl/changeset?id=99#path=%24%2FProject%2FFolder%2Ffile.cs&version=99&_a=compare", actual.toString());
+        assertEquals("The diff link was incorrect", "http://tfs:8080/_versionControl/changeset/99#path=%24%2FProject%2FFolder%2Ffile.cs&version=99&_a=compare", actual.toString());
     }
 
     @Test public void assertDiffLinkWithRealisticServerUrl() throws Exception {
@@ -169,7 +169,7 @@ public class TeamSystemWebAccessBrowserTest {
         ChangeSet.Item item = new ChangeSet.Item("$/Project/Folder/file.cs", "edit");
         changeSet.add(item);
         URL actual = browser.getDiffLink(item);
-        assertEquals("The diff link was incorrect", "http://tfs:8080/tfs/coll/_versionControl/changeset?id=99#path=%24%2FProject%2FFolder%2Ffile.cs&version=99&_a=compare", actual.toString());
+        assertEquals("The diff link was incorrect", "http://tfs:8080/tfs/coll/_versionControl/changeset/99#path=%24%2FProject%2FFolder%2Ffile.cs&version=99&_a=compare", actual.toString());
     }
 
     @Test public void assertNullDiffLinkForAddedFile() throws Exception {


### PR DESCRIPTION
I updated the URL we craft to point back to a changeset in TFS/VSTS to use the valid format of `projectname/_versionControl/changeset/10210 ` instead of `projectname/_versionControl/changeset?id=10210`. This fixes [JENKINS-48341](https://issues.jenkins-ci.org/browse/JENKINS-48341)

I also removed the `//CHECKSTYLE:OFF` annotation and made the necessary code changes to get it to pass.