### PR TITLE
doc: remove wrong environment replacement

### DIFF
--- a/tfs/src/main/resources/hudson/plugins/tfs/TeamFoundationServerScm/help-workspaceName.html
+++ b/tfs/src/main/resources/hudson/plugins/tfs/TeamFoundationServerScm/help-workspaceName.html
@@ -14,7 +14,6 @@
 	    <li><tt>${USER_NAME}</tt> - The user name that the Hudson server or slave is running as.</li>
 	    <li><tt>${NODE_NAME}</tt> - The name of the node/slave that the plugin currently is executed on. 
 	    Note that this is not the hostname, this value is Hudson configured name of the slave/node.</li>
-	    <li><tt>${ENV}</tt> - The environment variable that is set on the master or slave.</li>
     </ul>
   </p>
 </div>


### PR DESCRIPTION
The documentation in here states that ${ENV} will be replaced with the corresponding environment variable. This is not true, no such replacement takes place:

    Creating workspace '${TFS_ID}-tfstest' owned by ...

 This is consistent with the documentation of the TFS Plugin itself (https://github.com/jenkinsci/tfs-plugin/blob/master/README.md) which mentions  only ${JOB_NAME}, ${USER_NAME}, and ${NODE_NAME}.