### PR TITLE
Allow users to map sub-folders of cloaked paths, part II

### DIFF
--- a/tfs/src/main/java/hudson/plugins/tfs/TeamFoundationServerScm.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/TeamFoundationServerScm.java
@@ -1,3 +1,4 @@
+//CHECKSTYLE:OFF
 package hudson.plugins.tfs;
 
 import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
@@ -57,8 +58,12 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Collection;
+import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.TreeMap;
+import java.util.Map.Entry;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
@@ -85,6 +90,7 @@ public class TeamFoundationServerScm extends SCM {
     private final String serverUrl;
     private final String projectPath;
     private Collection<String> cloakedPaths;
+    private Map<String, String> mappedPaths;
     private String localPath;
     private final String workspaceName;
     @Deprecated private String userPassword;
@@ -230,13 +236,48 @@ public class TeamFoundationServerScm extends SCM {
 
     @DataBoundSetter
     public void setCloakedPaths(final String cloakedPaths) {
-        this.cloakedPaths = splitCloakedPaths(cloakedPaths);
+        this.cloakedPaths = deserializeCloakedPathCollectionFromString(cloakedPaths);
+    }
+
+    public String getMappedPaths() {
+        return serializeMappedPathCollectionToString(this.mappedPaths);
+    }
+
+    @DataBoundSetter
+    public void setMappedPaths(final String mappedPaths) {
+        this.mappedPaths = deserializeMappedPathCollectionFromString(mappedPaths);
     }
 
     // Bean properties END
 
     static String serializeCloakedPathCollectionToString(final Collection<String> cloakedPaths) {
         return cloakedPaths == null ? StringUtils.EMPTY : StringUtils.join(cloakedPaths, "\n");
+    }
+
+    static String serializeMappedPathCollectionToString(final Map<String, String> mappedPaths) {
+        if (mappedPaths == null) {
+            return StringUtils.EMPTY;
+        }
+
+        Map<String, String> sortedPaths = new TreeMap<String, String>(mappedPaths);
+        Iterator<Entry<String, String>> iter = sortedPaths.entrySet().iterator();
+
+        StringBuilder sb = new StringBuilder();
+        while (iter.hasNext()) {
+            Entry<String, String> entry = iter.next();
+            sb.append(entry.getKey());
+            
+            final String mappedPath = entry.getValue();
+            if (mappedPath != null) {
+                sb.append(' ').append(':').append(' ');
+                sb.append(entry.getValue());
+            }
+            if (iter.hasNext()) {
+                sb.append('\n');
+            }
+        }
+
+        return sb.toString();
     }
 
     String getWorkspaceName(final Run<?, ?> build, final Computer computer) {
@@ -274,6 +315,29 @@ public class TeamFoundationServerScm extends SCM {
         return paths;
     }
 
+    Map<String, String> getMappedPaths(final Run<?, ?> run) {
+        final Map<String, String> paths = new TreeMap<String, String>();
+        if (mappedPaths != null) {
+            final BuildVariableResolver resolver = new BuildVariableResolver(run.getParent());
+            
+            Iterator<Entry<String, String>> iter = mappedPaths.entrySet().iterator();
+            while (iter.hasNext()) {
+                Entry<String, String> entry = iter.next();
+                final String serverPath = Util.replaceMacro(substituteBuildParameter(run, entry.getKey()), resolver);
+
+                String localPath = null;
+                String storedLocalPath = entry.getValue();
+                if (storedLocalPath != null) {
+                    localPath = Util.replaceMacro(substituteBuildParameter(run, storedLocalPath), resolver);
+                }
+
+                paths.put(serverPath, localPath);
+            }
+        }
+
+        return paths;
+    }
+
     private String substituteBuildParameter(final Run<?, ?> run, final String text) {
         if (run instanceof AbstractBuild<?, ?>) {
             AbstractBuild<?, ?> build = (AbstractBuild<?, ?>) run;
@@ -284,7 +348,7 @@ public class TeamFoundationServerScm extends SCM {
         return text;
     }
 
-    static Collection<String> splitCloakedPaths(final String cloakedPaths) {
+    static Collection<String> deserializeCloakedPathCollectionFromString(final String cloakedPaths) {
         final List<String> cloakedPathsList = new ArrayList<String>();
         if (cloakedPaths != null && cloakedPaths.length() > 0) {
             final StringBuilder cloakedPath = new StringBuilder(cloakedPaths.length());
@@ -308,11 +372,53 @@ public class TeamFoundationServerScm extends SCM {
         return cloakedPathsList;
     }
 
+    static Map<String, String> deserializeMappedPathCollectionFromString(final String mappedPaths){
+        final Map<String, String> mappedPathsCollection = new HashMap<String, String>();
+        if (mappedPaths != null && mappedPaths.length() > 0) {
+            final StringBuilder path = new StringBuilder(mappedPaths.length());
+            for (final char character : mappedPaths.toCharArray()) {
+                switch (character) {
+                    case '\n':
+                        if (path.length() > 0) {
+                            String[] combinedPaths = splitMappedPath(path.toString());
+                            String localPath = null;
+                            if (combinedPaths.length > 1) {
+                                localPath = combinedPaths[1].trim();
+                            }
+                            mappedPathsCollection.put(combinedPaths[0].trim(), localPath);
+
+                            path.setLength(0);
+                        }
+                        break;
+                    default:
+                        path.append(character);
+                        break;
+                }
+            }
+
+            if (path.length() > 0) {
+                String[] combinedPaths = splitMappedPath(path.toString());
+
+                final String serverPath = combinedPaths[0].trim();
+                String localPath = null;
+                if (combinedPaths.length > 1) {
+                    localPath = combinedPaths[1].trim();
+                }
+                mappedPathsCollection.put(serverPath, localPath);
+            }
+        }
+        return mappedPathsCollection;
+    }
+
+    static String[] splitMappedPath(final String mappedPath) {
+        return mappedPath.split(":", 2);
+    }
+
     @Override
     public void checkout(final Run<?, ?> build, final Launcher launcher, final FilePath workspaceFilePath, final TaskListener listener, final File changelogFile, final SCMRevisionState baseline) throws IOException, InterruptedException {
         Server server = createServer(launcher, listener, build);
         try {
-            WorkspaceConfiguration workspaceConfiguration = new WorkspaceConfiguration(server.getUrl(), getWorkspaceName(build, workspaceFilePath.toComputer()), getProjectPath(build), getCloakedPaths(build), getLocalPath());
+            WorkspaceConfiguration workspaceConfiguration = new WorkspaceConfiguration(server.getUrl(), getWorkspaceName(build, workspaceFilePath.toComputer()), getProjectPath(build), getCloakedPaths(build), getMappedPaths(build), getLocalPath());
             final Run<?, ?> previousBuild = build.getPreviousBuild();
             // Check if the configuration has changed
             if (previousBuild != null) {
@@ -342,7 +448,7 @@ public class TeamFoundationServerScm extends SCM {
             final Project project = server.getProject(projPath);
             final int changeSet = recordWorkspaceChangesetVersion(build, listener, project, projPath, singleVersionSpec);
 
-            CheckoutAction action = new CheckoutAction(workspaceConfiguration.getWorkspaceName(), workspaceConfiguration.getProjectPath(), workspaceConfiguration.getCloakedPaths(), workspaceConfiguration.getWorkfolder(), isUseUpdate(), isUseOverwrite());
+            CheckoutAction action = new CheckoutAction(workspaceConfiguration.getWorkspaceName(), workspaceConfiguration.getProjectPath(), workspaceConfiguration.getCloakedPaths(), workspaceConfiguration.getMappedPaths(), workspaceConfiguration.getWorkfolder(), isUseUpdate(), isUseOverwrite());
             List<ChangeSet> list;
             if (StringUtils.isNotEmpty(singleVersionSpec)) {
                 list = action.checkoutBySingleVersionSpec(server, workspaceFilePath, singleVersionSpec);
@@ -415,7 +521,8 @@ public class TeamFoundationServerScm extends SCM {
                 return (server.getProject(getProjectPath(lastRun)).getDetailedHistoryWithoutCloakedPaths(
                             lastRun.getTimestamp(),
                             Calendar.getInstance(),
-                            getCloakedPaths(lastRun)
+                            getCloakedPaths(lastRun),
+                            getMappedPaths(lastRun).keySet()
                         ).size() > 0);
             } finally {
                 server.close();
@@ -580,6 +687,7 @@ public class TeamFoundationServerScm extends SCM {
         public static final Pattern WORKSPACE_NAME_REGEX = Pattern.compile("[^\"/:<>\\|\\*\\?]+[^\\s\\.\"/:<>\\|\\*\\?]$", Pattern.CASE_INSENSITIVE);
         public static final Pattern PROJECT_PATH_REGEX = Pattern.compile("^\\$\\/.*", Pattern.CASE_INSENSITIVE);
         public static final Pattern CLOAKED_PATHS_REGEX = Pattern.compile("\\s*\\$[^\\n;]+(\\s*[\\n]\\s*\\$[^\\n;]+){0,}\\s*", Pattern.CASE_INSENSITIVE);
+        public static final Pattern MAPPED_PATHS_REGEX = Pattern.compile("\\s*\\$[^\\n;]+(\\s*[\\n]\\s*\\$[^\\n;]+){0,}\\s*", Pattern.CASE_INSENSITIVE);
 
         @Override
         public boolean isApplicable(final Job project) {
@@ -654,6 +762,12 @@ public class TeamFoundationServerScm extends SCM {
         public FormValidation doCloakedPathsCheck(@QueryParameter final String value) {
             return doRegexCheck(new Pattern[]{CLOAKED_PATHS_REGEX},
                     "Each cloaked path must begin with '$/'. Multiple paths must be separated by blank lines.",
+                    null, value );
+        }
+
+        public FormValidation doMappedPathsCheck(@QueryParameter final String value) {
+            return doRegexCheck(new Pattern[]{MAPPED_PATHS_REGEX},
+                    "Each mapped path must begin with '$/'. Multiple paths must be separated by blank lines.",
                     null, value);
         }
 
@@ -714,7 +828,8 @@ public class TeamFoundationServerScm extends SCM {
                         return (server.getProject(getProjectPath(build)).getDetailedHistoryWithoutCloakedPaths(
                                 build.getTimestamp(),
                                 Calendar.getInstance(),
-                                getCloakedPaths(build)
+                                getCloakedPaths(build),
+                                getMappedPaths(build).keySet()
                         ).size() > 0) ? PollingResult.BUILD_NOW : PollingResult.NO_CHANGES;
                     } finally {
                         server.close();
@@ -729,7 +844,7 @@ public class TeamFoundationServerScm extends SCM {
         }
         final Project tfsProject = server.getProject(projectPath);
         try {
-            final ChangeSet latest = tfsProject.getLatestUncloakedChangeset(tfsBaseline.changesetVersion, cloakedPaths);
+            final ChangeSet latest = tfsProject.getLatestUncloakedChangeset(tfsBaseline.changesetVersion, cloakedPaths, mappedPaths.keySet());
             final TFSRevisionState tfsRemote =
                     (latest != null)
                     ? new TFSRevisionState(latest.getVersion(), projectPath)

--- a/tfs/src/main/java/hudson/plugins/tfs/actions/CheckoutAction.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/actions/CheckoutAction.java
@@ -20,20 +20,23 @@ import java.util.Calendar;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 
 public class CheckoutAction {
 
     private final String workspaceName;
     private final String projectPath;
     private final Collection<String> cloakedPaths;
+    private final Map<String, String> mappedPaths;
     private final String localFolder;
     private final boolean useUpdate;
     private final boolean useOverwrite;
 
-    public CheckoutAction(String workspaceName, String projectPath, Collection<String> cloakedPaths, String localFolder, boolean useUpdate, boolean useOverwrite) {
+    public CheckoutAction(String workspaceName, String projectPath, Collection<String> cloakedPaths, Map<String, String> mappedPaths, String localFolder, boolean useUpdate, boolean useOverwrite) {
         this.workspaceName = workspaceName;
         this.projectPath = projectPath;
         this.cloakedPaths = cloakedPaths;
+        this.mappedPaths = mappedPaths;
         this.localFolder = localFolder;
         this.useUpdate = useUpdate;
         this.useOverwrite = useOverwrite;
@@ -63,7 +66,7 @@ public class CheckoutAction {
         project.getFiles(normalizedFolder, versionSpecString, useOverwrite);
 
         if (lastBuildVersionSpec != null) {
-            return project.getDetailedHistoryWithoutCloakedPaths(lastBuildVersionSpec, currentBuildVersionSpec, cloakedPaths);
+            return project.getDetailedHistoryWithoutCloakedPaths(lastBuildVersionSpec, currentBuildVersionSpec, cloakedPaths, mappedPaths.keySet());
         }
 
         return new ArrayList<ChangeSet>();
@@ -141,7 +144,7 @@ public class CheckoutAction {
                 localFolderPath.deleteContents();
             }
             final String serverPath = project.getProjectPath();
-            workspace = workspaces.newWorkspace(workspaceName, serverPath, cloakedPaths, localPath);
+            workspace = workspaces.newWorkspace(workspaceName, serverPath, cloakedPaths, mappedPaths, localPath);
         } else {
             workspace = workspaces.getWorkspace(workspaceName);
         }

--- a/tfs/src/main/java/hudson/plugins/tfs/commands/NewWorkspaceCommand.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/commands/NewWorkspaceCommand.java
@@ -14,11 +14,17 @@ import hudson.plugins.tfs.model.MockableVersionControlClient;
 import hudson.plugins.tfs.model.Server;
 import hudson.remoting.Callable;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.regex.Matcher;
 
 
 public class NewWorkspaceCommand extends AbstractCallableCommand<Void, Exception> {
@@ -32,13 +38,15 @@ public class NewWorkspaceCommand extends AbstractCallableCommand<Void, Exception
     private final String workspaceName;
     private final String serverPath;
     private final Collection<String> cloakedPaths;
+    private final Map<String, String> mappedPaths;
     private final String localPath;
 
-    public NewWorkspaceCommand(final ServerConfigurationProvider server, final String workspaceName, final String serverPath, Collection<String> cloakedPaths, final String localPath) {
+    public NewWorkspaceCommand(final ServerConfigurationProvider server, final String workspaceName, final String serverPath, Collection<String> cloakedPaths, Map<String, String> mappedPaths, final String localPath) {
         super(server);
         this.workspaceName = workspaceName;
         this.serverPath = serverPath;
         this.cloakedPaths = cloakedPaths;
+        this.mappedPaths = mappedPaths;
         this.localPath = localPath;
     }
 
@@ -59,7 +67,7 @@ public class NewWorkspaceCommand extends AbstractCallableCommand<Void, Exception
         
         WorkingFolder[] foldersToMap = null;
         if (serverPath != null && localPath != null) {
-            final String mappingMessage = String.format(MappingTemplate, serverPath, localPath, workspaceName);
+            String mappingMessage = String.format(MappingTemplate, serverPath, localPath, workspaceName);
             logger.println(mappingMessage);
 
             final List<WorkingFolder> folderList = new ArrayList<WorkingFolder>();
@@ -72,6 +80,26 @@ public class NewWorkspaceCommand extends AbstractCallableCommand<Void, Exception
                 logger.println(cloakingMessage);
 
                 folderList.add(new WorkingFolder(cloakedPath, null, WorkingFolderType.CLOAK));
+            }
+
+            Iterator<Entry<String, String>> iter = mappedPaths.entrySet().iterator();
+            while (iter.hasNext()) {
+                Entry<String, String> entry = iter.next();
+                final String mappedServerPath = entry.getKey();
+                final String storedMappedLocalPath = entry.getValue();
+                String mappedLocalPath = null;
+                if (storedMappedLocalPath != null) {
+                    mappedLocalPath = Paths.get(localPath, storedMappedLocalPath).toString().replaceAll(Matcher.quoteReplacement(File.separator), "/");
+                }
+                else {
+                    final String relativePath = mappedServerPath.substring(serverPath.length());
+                    mappedLocalPath = Paths.get(localPath, relativePath).toString().replaceAll(Matcher.quoteReplacement(File.separator), "/");
+                }
+                
+                mappingMessage = String.format(MappingTemplate, mappedServerPath, mappedLocalPath, workspaceName);
+                logger.println(mappingMessage);
+
+                folderList.add(new WorkingFolder(mappedServerPath, LocalPath.canonicalize(mappedLocalPath), WorkingFolderType.MAP, RecursionType.FULL));
             }
             foldersToMap = folderList.toArray(EMPTY_WORKING_FOLDER_ARRAY);
         }

--- a/tfs/src/main/java/hudson/plugins/tfs/model/Project.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/model/Project.java
@@ -175,16 +175,17 @@ public class Project {
      * Gets the latest changeset that isn't in a cloaked path.
      * @param fromChangeset the changeset that was last seen, as a point of reference
      * @param cloakedPaths the list of cloaked paths in the project
+     * @param mappedPaths the list of server paths that are explicitly mapped in the project
      * @return the {@link ChangeSet} instance representing the last entry in the history for the path
      */
-    public ChangeSet getLatestUncloakedChangeset(final int fromChangeset, final Collection<String> cloakedPaths) {
+    public ChangeSet getLatestUncloakedChangeset(final int fromChangeset, final Collection<String> cloakedPaths, final Collection<String> mappedPaths) {
         final ChangesetVersionSpec fromVersion = new ChangesetVersionSpec(fromChangeset);
         final List<ChangeSet> changeSets = getVCCHistory(fromVersion, LatestVersionSpec.INSTANCE, true, Integer.MAX_VALUE);
-        final ChangeSet result = findLatestUncloakedChangeset(cloakedPaths, changeSets);
+        final ChangeSet result = findLatestUncloakedChangeset(cloakedPaths, mappedPaths, changeSets);
         return result;
     }
 
-    static ChangeSet findLatestUncloakedChangeset(final Collection<String> cloakedPaths, final List<ChangeSet> changeSets) {
+    static ChangeSet findLatestUncloakedChangeset(final Collection<String> cloakedPaths, final Collection<String> mappedPaths, final List<ChangeSet> changeSets) {
         ChangeSet result = null;
 
         // We need to search from latest to earliest, otherwise an incorrect result is produced
@@ -198,7 +199,7 @@ public class Project {
             lastChangeSetNumber = changeSetNumber;
             final Collection<String> changes = s.getAffectedPaths();
 
-            final boolean fullyCloaked = isChangesetFullyCloaked(changes, cloakedPaths);
+            final boolean fullyCloaked = isChangesetFullyCloaked(changes, cloakedPaths, mappedPaths);
             if (!fullyCloaked) {
                 result = s;
                 break;
@@ -215,18 +216,18 @@ public class Project {
      *                     changesets that are fully covered by one or more of these paths
      * @return a list of change sets
      */
-    public List<ChangeSet> getDetailedHistoryWithoutCloakedPaths(final Calendar fromTimestamp, final Calendar toTimestamp, final Collection<String> cloakedPaths) {
+    public List<ChangeSet> getDetailedHistoryWithoutCloakedPaths(final Calendar fromTimestamp, final Calendar toTimestamp, final Collection<String> cloakedPaths, final Collection<String> mappedPaths) {
         final DateVersionSpec fromVersion = new DateVersionSpec(fromTimestamp);
         final DateVersionSpec toVersion = new DateVersionSpec(toTimestamp);
-        return getDetailedHistoryWithoutCloakedPaths(fromVersion, toVersion, cloakedPaths);
+        return getDetailedHistoryWithoutCloakedPaths(fromVersion, toVersion, cloakedPaths, mappedPaths);
     }
 
-    public List<ChangeSet> getDetailedHistoryWithoutCloakedPaths(final VersionSpec fromVersion, final VersionSpec toVersion, final Collection<String> cloakedPaths) {
+    public List<ChangeSet> getDetailedHistoryWithoutCloakedPaths(final VersionSpec fromVersion, final VersionSpec toVersion, final Collection<String> cloakedPaths, final Collection<String> mappedPaths) {
         final List<ChangeSet> changeSets = getVCCHistory(fromVersion, toVersion, true, Integer.MAX_VALUE);
         final ArrayList<ChangeSet> changeSetNoCloaked = new ArrayList<ChangeSet>();
         for (final ChangeSet changeset : changeSets) {
             final Collection<String> affectedPaths = changeset.getAffectedPaths();
-            final boolean fullyCloaked = isChangesetFullyCloaked(affectedPaths, cloakedPaths);
+            final boolean fullyCloaked = isChangesetFullyCloaked(affectedPaths, cloakedPaths, mappedPaths);
             if (!fullyCloaked) {
                 changeSetNoCloaked.add(changeset);
             }
@@ -234,19 +235,32 @@ public class Project {
         return changeSetNoCloaked;
     }
 
-    static boolean isChangesetFullyCloaked(final Collection<String> changesetPaths, final Collection<String> cloakedPaths) {
+    static boolean isChangesetFullyCloaked(final Collection<String> changesetPaths, final Collection<String> cloakedPaths, final Collection<String> mappedPaths) {
         if (cloakedPaths == null) {
             return false;
         }
         for (final String tfsPath : changesetPaths) {
-            boolean isPathCloaked = false;
+            String mostSpecificCloakedPath = null;
             for (final String cloakedPath : cloakedPaths) {
                 if (tfsPath.regionMatches(true, 0, cloakedPath, 0, cloakedPath.length())) {
-                    isPathCloaked = true;
-                    break;
+                    
+                    if ((mostSpecificCloakedPath == null) || (mostSpecificCloakedPath.length() < cloakedPath.length())) {
+                        mostSpecificCloakedPath = cloakedPath;
+                    }
                 }
             }
-            if (!isPathCloaked) {
+
+            if (mostSpecificCloakedPath != null) {
+                if (mappedPaths != null) {
+                    for (final String mappedPath : mappedPaths) {
+                        if ((mappedPath.regionMatches(true, 0, mostSpecificCloakedPath, 0, mostSpecificCloakedPath.length())) &&
+                            (tfsPath.regionMatches(true, 0, mappedPath, 0, mappedPath.length()))) {
+                            return false;
+                        }
+                    }
+                }
+            }
+            else {
                 return false;
             }
         }

--- a/tfs/src/main/java/hudson/plugins/tfs/model/WorkspaceConfiguration.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/model/WorkspaceConfiguration.java
@@ -3,6 +3,9 @@ package hudson.plugins.tfs.model;
 
 import java.io.Serializable;
 import java.util.Collection;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Map.Entry;
 
 import hudson.model.InvisibleAction;
 
@@ -21,14 +24,16 @@ public class WorkspaceConfiguration extends InvisibleAction implements Serializa
     private final String serverUrl;
     private boolean workspaceExists;
     private Collection<String> cloakedPaths;
+    private Map<String, String> mappedPaths;
 
-    public WorkspaceConfiguration(String serverUrl, String workspaceName, String projectPath, Collection<String> cloakedPaths, String workfolder) {
+    public WorkspaceConfiguration(String serverUrl, String workspaceName, String projectPath, Collection<String> cloakedPaths, Map<String, String> mappedPaths, String workfolder) {
         this.workspaceName = workspaceName;
         this.workfolder = workfolder;
         this.projectPath = projectPath;
         this.serverUrl = serverUrl;
         this.workspaceExists = true;
         this.cloakedPaths = cloakedPaths;
+        this.mappedPaths = mappedPaths;
     }
 
     public WorkspaceConfiguration(WorkspaceConfiguration configuration) {
@@ -38,6 +43,7 @@ public class WorkspaceConfiguration extends InvisibleAction implements Serializa
         this.serverUrl = configuration.serverUrl;
         this.workspaceExists = configuration.workspaceExists;
         this.cloakedPaths = configuration.cloakedPaths;
+        this.mappedPaths = configuration.mappedPaths;
     }
 
     public String getWorkspaceName() {
@@ -68,6 +74,10 @@ public class WorkspaceConfiguration extends InvisibleAction implements Serializa
         return cloakedPaths;
     }
 
+    public Map<String, String> getMappedPaths() {
+        return mappedPaths;
+    }
+
     @Override
     public int hashCode() {
         final int prime = 31;
@@ -78,6 +88,7 @@ public class WorkspaceConfiguration extends InvisibleAction implements Serializa
         result = prime * result + (workspaceExists ? 1231 : 1237);
         result = prime * result + ((workspaceName == null) ? 0 : workspaceName.hashCode());
         result = prime * result + ((cloakedPaths == null) ? 0 : cloakedPaths.hashCode());
+        result = prime * result + ((mappedPaths == null) ? 0 : mappedPaths.hashCode());
         return result;
     }
 
@@ -121,6 +132,35 @@ public class WorkspaceConfiguration extends InvisibleAction implements Serializa
             return false;
         else if (!cloakedPaths.containsAll(other.cloakedPaths))
             return false;
+        if (mappedPaths == null) {
+            if (other.mappedPaths != null)
+                return false;
+        } else if (other.mappedPaths == null)
+            return false;
+        else if (mappedPaths.size() != other.mappedPaths.size())
+            return false;
+        else {
+            final Iterator<Entry<String, String>> localPaths = mappedPaths.entrySet().iterator();
+            while (localPaths.hasNext()) {
+                final Entry<String, String> actualItem = localPaths.next();
+                String key = actualItem.getKey();
+                if (!other.mappedPaths.containsKey(key)) {
+                    return false;
+                }
+
+                final String expectedItem = other.mappedPaths.get(key);
+                final String actualMappedPath = actualItem.getValue();
+                if (actualMappedPath == null) {
+                    if (expectedItem != null)
+                        return false;
+                }
+                else {
+                    if (!actualMappedPath.equals(expectedItem)) {
+                        return false;
+                    }
+                }
+            }
+        }
         return true;
     }
 

--- a/tfs/src/main/java/hudson/plugins/tfs/model/Workspaces.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/model/Workspaces.java
@@ -104,8 +104,8 @@ public class Workspaces implements ListWorkspacesCommand.WorkspaceFactory {
      * @param localPath the path in the local filesystem to map
      * @return a workspace
      */
-    public Workspace newWorkspace(final String workspaceName, final String serverPath, Collection<String> cloakedPaths, final String localPath) {
-        NewWorkspaceCommand command = new NewWorkspaceCommand(server, workspaceName, serverPath, cloakedPaths, localPath);
+    public Workspace newWorkspace(final String workspaceName, final String serverPath, Collection<String> cloakedPaths, Map<String, String> mappedPaths, final String localPath) {
+        NewWorkspaceCommand command = new NewWorkspaceCommand(server, workspaceName, serverPath, cloakedPaths, mappedPaths, localPath);
         server.execute(command.getCallable());
         Workspace workspace = new Workspace(workspaceName);
         workspaces.put(workspaceName, workspace);

--- a/tfs/src/main/java/hudson/plugins/tfs/util/KeyValueTextReader.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/util/KeyValueTextReader.java
@@ -14,7 +14,7 @@ import java.util.regex.Pattern;
  * This is used when reading text files that contains keys and value pairs where the
  * value can be in one or several rows. First used when doing some more intelligent parsing
  * of the output from the tfs history command.
- *
+ * 
  * @author redsolo
  */
 public class KeyValueTextReader {

--- a/tfs/src/main/resources/hudson/plugins/tfs/TeamFoundationServerScm/config.jelly
+++ b/tfs/src/main/resources/hudson/plugins/tfs/TeamFoundationServerScm/config.jelly
@@ -38,6 +38,10 @@
         <f:entry field="cloakedPaths" title="Cloaked paths" description="A collection of server paths to cloak to exclude from the workspace and from the build trigger.  Multiple entries must be placed onto separate lines.">
             <f:textarea checkUrl="'${rootURL}/scm/TeamFoundationServerScm/cloakedPathsCheck?value='+escape(this.value)"/>
         </f:entry>
+
+        <f:entry field="mappedPaths" title="Mapped paths" description="A collection of server paths that should be mapped even if their parent paths are cloaked.  Multiple entries must be placed onto separate lines.">
+            <f:textarea checkUrl="'${rootURL}/scm/TeamFoundationServerScm/mappedPathsCheck?value='+escape(this.value)"/>
+        </f:entry>
     </f:advanced>
     
     <t:listScmBrowsers name="tfs.browser" />

--- a/tfs/src/main/resources/hudson/plugins/tfs/TeamFoundationServerScm/help-mappedPaths.html
+++ b/tfs/src/main/resources/hudson/plugins/tfs/TeamFoundationServerScm/help-mappedPaths.html
@@ -1,0 +1,56 @@
+<div>
+    <p>
+      Mapped paths will be pulled into the local workspace during a GET
+      from the TFVC repository even if the parent folder is cloaked.
+      <br />
+      Check-ins that contain files only in mapped folders will trigger a build,
+      whereas a check-in containing any path that is in a sub-folder of a cloaked folder
+      will not trigger a build.
+    </p>
+    <p>
+      For example, suppose the <b>Project path</b> is <tt>$/Example/project/path</tt>,
+      and the repository contains the following subfolders:
+      <blockquote>
+        $/Example/project/path/A <br />
+        $/Example/project/path/A/1 <br />
+        $/Example/project/path/A/2 <br />
+        $/Example/project/path/B <br />
+        $/Example/project/path/B/1 <br />
+        $/Example/project/path/B/2 <br />
+        $/Example/project/path/C <br />
+      </blockquote>
+      Now, suppose the following paths were entered as <b>Cloaked Paths</b>:
+      <blockquote>
+        $/Example/project/path/A/2 <br />
+        $/Example/project/path/B <br />
+      </blockquote>
+      And the following paths were <b>Mapped Paths</b>:
+      <blockquote>
+          $/Example/project/path/B/1 : project/path/B1/1 <br />
+      </blockquote>
+      ...then the resulting workspace on the Jenkins server would only have the following folders:
+      <blockquote>
+        [Workspace_Directory]/Example/project/path/A <br />
+        [Workspace_Directory]/Example/project/path/A/1 <br />
+        [Workspace_Directory]/Example/project/path/C <br />
+        [Workspace_Directory]/project/path/B/1 <br />
+      </blockquote>
+    </p>
+    <p>
+      To continue with the example,
+      the following check-in <em>will not</em> trigger a build,
+      because it only contains changes under cloaked paths:
+      <blockquote>
+        $/Example/project/path/A/2/alpha.txt <br />
+        $/Example/project/path/A/2/second.txt <br />
+        $/Example/project/path/B/bravo.txt <br />
+      </blockquote>
+      ...whereas this check-in <em>will</em> trigger a build,
+      because it contains at least one path that isn't cloaked:
+      <blockquote>
+        $/Example/project/path/A/2/second.txt <br />
+        $/Example/project/path/B/bravo.txt <br />
+        $/Example/project/path/B/2/other.txt <br />
+      </blockquote>
+    </p>
+  </div>

--- a/tfs/src/test/java/hudson/plugins/tfs/actions/CheckoutActionTest.java
+++ b/tfs/src/test/java/hudson/plugins/tfs/actions/CheckoutActionTest.java
@@ -8,6 +8,9 @@ import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
 
 import com.microsoft.tfs.core.clients.versioncontrol.specs.version.DateVersionSpec;
 import com.microsoft.tfs.core.clients.versioncontrol.specs.version.VersionSpec;
@@ -33,6 +36,10 @@ import org.mockito.MockitoAnnotations;
 public class CheckoutActionTest {
 
     private static final List<String> EMPTY_CLOAKED_PATHS_LIST = Collections.emptyList();
+
+    private static final Map<String, String> EMPTY_MAPPED_PATHS_MAP = new TreeMap<String, String>();
+    private static final Set<String> EMPTY_MAPPED_PATHS_LIST = EMPTY_MAPPED_PATHS_MAP.keySet();
+
     private static final String MY_LABEL = "MyLabel";
     private FilePath hudsonWs;
     private @Mock Server server;
@@ -66,12 +73,12 @@ public class CheckoutActionTest {
         prepareCommonMocks();
         when(project.getProjectPath()).thenReturn("project");
     	when(workspaces.exists("workspace")).thenReturn(true).thenReturn(false);
-        when(workspaces.newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class))).thenReturn(workspace);
+        when(workspaces.newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), eq(EMPTY_MAPPED_PATHS_MAP), isA(String.class))).thenReturn(workspace);
     	when(workspaces.getWorkspace("workspace")).thenReturn(workspace);
     	
-        new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, ".", false, false).checkoutBySingleVersionSpec(server, hudsonWs, MY_LABEL);
+        new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, EMPTY_MAPPED_PATHS_MAP, ".", false, false).checkoutBySingleVersionSpec(server, hudsonWs, MY_LABEL);
 
-        verify(workspaces).newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class));
+        verify(workspaces).newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), eq(EMPTY_MAPPED_PATHS_MAP), isA(String.class));
     	verify(project).getFiles(isA(String.class), eq(MY_LABEL), eq(false));
     	verify(workspaces).deleteWorkspace(workspace);    	
     }
@@ -81,12 +88,12 @@ public class CheckoutActionTest {
         prepareCommonMocks();
         when(project.getProjectPath()).thenReturn("project");
         when(workspaces.exists("workspace")).thenReturn(true).thenReturn(false);
-        when(workspaces.newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class))).thenReturn(workspace);
+        when(workspaces.newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), eq(EMPTY_MAPPED_PATHS_MAP), isA(String.class))).thenReturn(workspace);
         when(workspaces.getWorkspace("workspace")).thenReturn(workspace);
         
-        new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, ".", false, false).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
+        new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, EMPTY_MAPPED_PATHS_MAP, ".", false, false).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
         
-        verify(workspaces).newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class));
+        verify(workspaces).newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), eq(EMPTY_MAPPED_PATHS_MAP), isA(String.class));
         verify(project).getFiles(isA(String.class), eq("D2009-09-24T00:00:00Z"), eq(false));
         verify(workspaces).deleteWorkspace(workspace);
     }
@@ -96,11 +103,11 @@ public class CheckoutActionTest {
         prepareCommonMocks();
         when(project.getProjectPath()).thenReturn("project");
         when(workspaces.exists(new Workspace("workspace"))).thenReturn(false);
-        when(workspaces.newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class))).thenReturn(workspace);
+        when(workspaces.newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), eq(EMPTY_MAPPED_PATHS_MAP), isA(String.class))).thenReturn(workspace);
         
-        new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, ".", true, false).checkoutBySingleVersionSpec(server, hudsonWs, MY_LABEL);
+        new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, EMPTY_MAPPED_PATHS_MAP, ".", true, false).checkoutBySingleVersionSpec(server, hudsonWs, MY_LABEL);
         
-        verify(workspaces).newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class));
+        verify(workspaces).newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), eq(EMPTY_MAPPED_PATHS_MAP), isA(String.class));
         verify(project).getFiles(isA(String.class), eq(MY_LABEL), eq(false));
         verify(workspaces, never()).deleteWorkspace(isA(Workspace.class));
     }
@@ -110,11 +117,11 @@ public class CheckoutActionTest {
         prepareCommonMocks();
         when(project.getProjectPath()).thenReturn("project");
     	when(workspaces.exists(new Workspace("workspace"))).thenReturn(false);
-        when(workspaces.newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class))).thenReturn(workspace);
+        when(workspaces.newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), eq(EMPTY_MAPPED_PATHS_MAP), isA(String.class))).thenReturn(workspace);
     	
-        new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, ".", true, false).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
+        new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, EMPTY_MAPPED_PATHS_MAP, ".", true, false).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
     	
-        verify(workspaces).newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class));
+        verify(workspaces).newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), eq(EMPTY_MAPPED_PATHS_MAP), isA(String.class));
     	verify(project).getFiles(isA(String.class), eq("D2009-09-24T00:00:00Z"), eq(false));
     	verify(workspaces, never()).deleteWorkspace(isA(Workspace.class));
     }
@@ -126,10 +133,10 @@ public class CheckoutActionTest {
         when(workspaces.getWorkspace("workspace")).thenReturn(workspace);
         when(workspace.getComputer()).thenReturn("LocalComputer");
         
-        new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, ".", true, false).checkoutBySingleVersionSpec(server, hudsonWs, MY_LABEL);
+        new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, EMPTY_MAPPED_PATHS_MAP, ".", true, false).checkoutBySingleVersionSpec(server, hudsonWs, MY_LABEL);
 
         verify(project).getFiles(isA(String.class), eq(MY_LABEL), eq(false));
-        verify(workspaces, never()).newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class));
+        verify(workspaces, never()).newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), eq(EMPTY_MAPPED_PATHS_MAP), isA(String.class));
         verify(workspaces, never()).deleteWorkspace(isA(Workspace.class));
     }
     
@@ -140,10 +147,10 @@ public class CheckoutActionTest {
         when(workspaces.getWorkspace("workspace")).thenReturn(workspace);
         when(workspace.getComputer()).thenReturn("LocalComputer");
         
-        new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, ".", true, false).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
+        new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, EMPTY_MAPPED_PATHS_MAP, ".", true, false).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
 
         verify(project).getFiles(isA(String.class), eq("D2009-09-24T00:00:00Z"), eq(false));
-        verify(workspaces, never()).newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class));
+        verify(workspaces, never()).newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), eq(EMPTY_MAPPED_PATHS_MAP), isA(String.class));
         verify(workspaces, never()).deleteWorkspace(isA(Workspace.class));
     }
 
@@ -152,12 +159,12 @@ public class CheckoutActionTest {
         prepareCommonMocks();
         when(project.getProjectPath()).thenReturn("project");
         when(workspaces.exists("workspace")).thenReturn(true).thenReturn(false);
-        when(workspaces.newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class))).thenReturn(workspace);
+        when(workspaces.newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), eq(EMPTY_MAPPED_PATHS_MAP), isA(String.class))).thenReturn(workspace);
         when(workspaces.getWorkspace("workspace")).thenReturn(workspace);
         
-        new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, ".", false, false).checkoutBySingleVersionSpec(server, hudsonWs, MY_LABEL);
+        new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, EMPTY_MAPPED_PATHS_MAP, ".", false, false).checkoutBySingleVersionSpec(server, hudsonWs, MY_LABEL);
 
-        verify(workspaces).newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class));
+        verify(workspaces).newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), eq(EMPTY_MAPPED_PATHS_MAP), isA(String.class));
         verify(project).getFiles(isA(String.class), eq(MY_LABEL), eq(false));
         verify(workspaces).deleteWorkspace(workspace);
     }
@@ -167,12 +174,12 @@ public class CheckoutActionTest {
         prepareCommonMocks();
         when(project.getProjectPath()).thenReturn("project");
         when(workspaces.exists("workspace")).thenReturn(true).thenReturn(false);
-        when(workspaces.newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class))).thenReturn(workspace);
+        when(workspaces.newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), eq(EMPTY_MAPPED_PATHS_MAP), isA(String.class))).thenReturn(workspace);
         when(workspaces.getWorkspace("workspace")).thenReturn(workspace);
         
-        new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, ".", false, false).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
+        new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, EMPTY_MAPPED_PATHS_MAP, ".", false, false).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
 
-        verify(workspaces).newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class));
+        verify(workspaces).newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), eq(EMPTY_MAPPED_PATHS_MAP), isA(String.class));
         verify(project).getFiles(isA(String.class), eq("D2009-09-24T00:00:00Z"), eq(false));
         verify(workspaces).deleteWorkspace(workspace);
     }
@@ -184,7 +191,7 @@ public class CheckoutActionTest {
         when(workspaces.getWorkspace("workspace")).thenReturn(workspace);
         when(workspace.getComputer()).thenReturn("LocalComputer");
         
-        new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, ".", true, false).checkoutBySingleVersionSpec(server, hudsonWs, MY_LABEL);
+        new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, EMPTY_MAPPED_PATHS_MAP, ".", true, false).checkoutBySingleVersionSpec(server, hudsonWs, MY_LABEL);
         
         verify(project, never()).getDetailedHistory(isA(Calendar.class), isA(Calendar.class));
     }
@@ -196,7 +203,7 @@ public class CheckoutActionTest {
         when(workspaces.getWorkspace("workspace")).thenReturn(workspace);
         when(workspace.getComputer()).thenReturn("LocalComputer");
         
-        new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, ".", true, false).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
+        new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, EMPTY_MAPPED_PATHS_MAP, ".", true, false).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
         
         verify(project, never()).getDetailedHistory(isA(Calendar.class), isA(Calendar.class));
     }
@@ -210,7 +217,7 @@ public class CheckoutActionTest {
         when(workspace.getComputer()).thenReturn("LocalComputer");
         when(project.getDetailedHistory(isA(String.class))).thenReturn(list);
         
-        CheckoutAction action = new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, ".", true, false);
+        CheckoutAction action = new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, EMPTY_MAPPED_PATHS_MAP, ".", true, false);
         List<ChangeSet> actualList = action.checkoutBySingleVersionSpec(server, hudsonWs, MY_LABEL);
         assertSame("The list from the detailed history, was not the same as returned from checkout", list, actualList);
         
@@ -224,16 +231,16 @@ public class CheckoutActionTest {
         when(workspaces.exists("workspace")).thenReturn(true);
         when(workspaces.getWorkspace("workspace")).thenReturn(workspace);
         when(workspace.getComputer()).thenReturn("LocalComputer");
-        when(project.getDetailedHistoryWithoutCloakedPaths(isA(VersionSpec.class), isA(VersionSpec.class), anyCollection())).thenReturn(list);
+        when(project.getDetailedHistoryWithoutCloakedPaths(isA(VersionSpec.class), isA(VersionSpec.class), anyCollection(), anyCollection())).thenReturn(list);
 
-        CheckoutAction action = new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, ".", true, false);
+        CheckoutAction action = new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, EMPTY_MAPPED_PATHS_MAP, ".", true, false);
         final Calendar startDate = Util.getCalendar(2008, 9, 24);
         final Calendar endDate = Util.getCalendar(2008, 10, 24);
         List<ChangeSet> actualList = action.checkout(server, hudsonWs, startDate, endDate);
         assertEquals("The list from the detailed history, was not the same as returned from checkout", list, actualList);
         
         final DateVersionSpec startDateVersionSpec = new DateVersionSpec(startDate);
-        verify(project).getDetailedHistoryWithoutCloakedPaths(argThat(new DateVersionSpecMatcher(startDateVersionSpec)), isA(VersionSpec.class), eq(EMPTY_CLOAKED_PATHS_LIST));
+        verify(project).getDetailedHistoryWithoutCloakedPaths(argThat(new DateVersionSpecMatcher(startDateVersionSpec)), isA(VersionSpec.class), eq(EMPTY_CLOAKED_PATHS_LIST), eq(EMPTY_MAPPED_PATHS_LIST));
     }
     
     @Test
@@ -245,9 +252,9 @@ public class CheckoutActionTest {
         
         prepareCommonMocks();
         when(workspaces.exists(new Workspace("workspace"))).thenReturn(false);
-        when(workspaces.newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class))).thenReturn(workspace);
+        when(workspaces.newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), eq(EMPTY_MAPPED_PATHS_MAP), isA(String.class))).thenReturn(workspace);
         
-        new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, "tfs-ws", false, false).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
+        new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, EMPTY_MAPPED_PATHS_MAP, "tfs-ws", false, false).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
         
         assertTrue("The local folder was removed", tfsWs.exists());
         assertEquals("The local TFS folder was not cleaned", 0, tfsWs.list((FileFilter)null).size());
@@ -263,9 +270,9 @@ public class CheckoutActionTest {
         
         prepareCommonMocks();
         when(workspaces.exists(new Workspace("workspace"))).thenReturn(false);
-        when(workspaces.newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class))).thenReturn(workspace);
+        when(workspaces.newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), eq(EMPTY_MAPPED_PATHS_MAP), isA(String.class))).thenReturn(workspace);
         
-        new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, "tfs-ws", false, false).checkoutBySingleVersionSpec(server, hudsonWs, MY_LABEL);
+        new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, EMPTY_MAPPED_PATHS_MAP, "tfs-ws", false, false).checkoutBySingleVersionSpec(server, hudsonWs, MY_LABEL);
         
         assertTrue("The local folder was removed", tfsWs.exists());
         assertEquals("The local TFS folder was not cleaned", 0, tfsWs.list((FileFilter)null).size());
@@ -283,7 +290,7 @@ public class CheckoutActionTest {
         when(workspaces.getWorkspace("workspace")).thenReturn(workspace);
         when(workspace.getComputer()).thenReturn("LocalComputer");
         
-        new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, "tfs-ws", true, false).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
+        new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, EMPTY_MAPPED_PATHS_MAP, "tfs-ws", true, false).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
 
         assertTrue("The local folder was removed", tfsWs.exists());
         assertEquals("The TFS workspace path was cleaned", 1, hudsonWs.list((FileFilter)null).size());
@@ -296,15 +303,15 @@ public class CheckoutActionTest {
         when(workspaces.exists("workspace")).thenReturn(true).thenReturn(false);
         when(workspaces.getWorkspace("workspace")).thenReturn(workspace);
         when(project.getProjectPath()).thenReturn("project");
-        when(workspaces.newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class))).thenReturn(workspace);
+        when(workspaces.newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), eq(EMPTY_MAPPED_PATHS_MAP), isA(String.class))).thenReturn(workspace);
         
-        new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, ".", false, false).checkoutBySingleVersionSpec(server, hudsonWs, MY_LABEL);
+        new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, EMPTY_MAPPED_PATHS_MAP, ".", false, false).checkoutBySingleVersionSpec(server, hudsonWs, MY_LABEL);
         
         verify(server).getWorkspaces();
         verify(workspaces, times(2)).exists("workspace");
         verify(workspaces).getWorkspace("workspace");
         verify(workspaces).deleteWorkspace(workspace);
-        verify(workspaces).newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class));
+        verify(workspaces).newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), eq(EMPTY_MAPPED_PATHS_MAP), isA(String.class));
         verify(workspaces).getWorkspaceMapping(anyString());
         verifyNoMoreInteractions(workspaces);
     }
@@ -316,15 +323,15 @@ public class CheckoutActionTest {
         when(workspaces.exists("workspace")).thenReturn(true).thenReturn(false);
         when(workspaces.getWorkspace("workspace")).thenReturn(workspace);
         when(project.getProjectPath()).thenReturn("project");
-        when(workspaces.newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class))).thenReturn(workspace);
+        when(workspaces.newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), eq(EMPTY_MAPPED_PATHS_MAP), isA(String.class))).thenReturn(workspace);
         
-        new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, ".", false, false).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
+        new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, EMPTY_MAPPED_PATHS_MAP, ".", false, false).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
         
         verify(server).getWorkspaces();
         verify(workspaces, times(2)).exists("workspace");
         verify(workspaces).getWorkspace("workspace");
         verify(workspaces).deleteWorkspace(workspace);
-        verify(workspaces).newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class));
+        verify(workspaces).newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), eq(EMPTY_MAPPED_PATHS_MAP), isA(String.class));
         verify(workspaces).getWorkspaceMapping(anyString());
         verifyNoMoreInteractions(workspaces);
     }
@@ -336,7 +343,7 @@ public class CheckoutActionTest {
         when(workspaces.exists("workspace")).thenReturn(true).thenReturn(true);
         when(workspaces.getWorkspace("workspace")).thenReturn(workspace);
         
-        new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, ".", true, false).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
+        new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, EMPTY_MAPPED_PATHS_MAP, ".", true, false).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
         
         verify(server).getWorkspaces();
         verify(workspaces, times(2)).exists("workspace");
@@ -352,7 +359,7 @@ public class CheckoutActionTest {
         when(workspaces.exists("workspace")).thenReturn(true).thenReturn(true);
         when(workspaces.getWorkspace("workspace")).thenReturn(workspace);
         
-        new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, ".", true, false).checkoutBySingleVersionSpec(server, hudsonWs, MY_LABEL);
+        new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, EMPTY_MAPPED_PATHS_MAP, ".", true, false).checkoutBySingleVersionSpec(server, hudsonWs, MY_LABEL);
         
         verify(server).getWorkspaces();
         verify(workspaces, times(2)).exists("workspace");
@@ -366,14 +373,14 @@ public class CheckoutActionTest {
     public void assertCheckoutDoesNotDeleteWorkspaceIfNotUsingUpdateAndThereIsNoWorkspace() throws Exception {
         prepareCommonMocks();
         when(workspaces.exists("workspace")).thenReturn(false).thenReturn(false);
-        when(workspaces.newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class))).thenReturn(workspace);
+        when(workspaces.newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), eq(EMPTY_MAPPED_PATHS_MAP), isA(String.class))).thenReturn(workspace);
         when(project.getProjectPath()).thenReturn("project");
 
-        new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, ".", false, false).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
+        new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, EMPTY_MAPPED_PATHS_MAP, ".", false, false).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
         
         verify(server).getWorkspaces();
         verify(workspaces, times(2)).exists("workspace");
-        verify(workspaces).newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class));
+        verify(workspaces).newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), eq(EMPTY_MAPPED_PATHS_MAP), isA(String.class));
         verify(workspaces).getWorkspaceMapping(anyString());
         verifyNoMoreInteractions(workspaces);
     }
@@ -383,14 +390,14 @@ public class CheckoutActionTest {
     public void assertCheckoutBySingleVersionSpecDoesNotDeleteWorkspaceIfNotUsingUpdateAndThereIsNoWorkspace() throws Exception {
         prepareCommonMocks();
         when(workspaces.exists("workspace")).thenReturn(false).thenReturn(false);
-        when(workspaces.newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class))).thenReturn(workspace);
+        when(workspaces.newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), eq(EMPTY_MAPPED_PATHS_MAP), isA(String.class))).thenReturn(workspace);
         when(project.getProjectPath()).thenReturn("project");
 
-        new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, ".", false, false).checkoutBySingleVersionSpec(server, hudsonWs, MY_LABEL);
+        new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, EMPTY_MAPPED_PATHS_MAP, ".", false, false).checkoutBySingleVersionSpec(server, hudsonWs, MY_LABEL);
         
         verify(server).getWorkspaces();
         verify(workspaces, times(2)).exists("workspace");
-        verify(workspaces).newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class));
+        verify(workspaces).newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), eq(EMPTY_MAPPED_PATHS_MAP), isA(String.class));
         verify(workspaces).getWorkspaceMapping(anyString());
         verifyNoMoreInteractions(workspaces);
     }
@@ -403,9 +410,9 @@ public class CheckoutActionTest {
         when(workspaces.exists("workspace")).thenReturn(true);
         when(workspaces.getWorkspace("workspace")).thenReturn(workspace);
         when(workspace.getComputer()).thenReturn("LocalComputer");
-        when(project.getDetailedHistoryWithoutCloakedPaths(isA(VersionSpec.class), isA(VersionSpec.class), anyCollection())).thenReturn(list);
+        when(project.getDetailedHistoryWithoutCloakedPaths(isA(VersionSpec.class), isA(VersionSpec.class), anyCollection(), anyCollection())).thenReturn(list);
         
-        CheckoutAction action = new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, ".", true, false);
+        CheckoutAction action = new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, EMPTY_MAPPED_PATHS_MAP, ".", true, false);
         final Calendar startDate = Util.getCalendar(2008, 9, 24);
         final Calendar endDate = Util.getCalendar(2009, 9, 24);
         List<ChangeSet> actualList = action.checkout(server, hudsonWs, startDate, endDate);
@@ -416,7 +423,8 @@ public class CheckoutActionTest {
         verify(project).getDetailedHistoryWithoutCloakedPaths(
                 argThat(new DateVersionSpecMatcher(startDateVersionSpec)),
                 argThat(new DateVersionSpecMatcher(endDateVersionSpec)),
-                eq(EMPTY_CLOAKED_PATHS_LIST));
+                eq(EMPTY_CLOAKED_PATHS_LIST),
+                eq(EMPTY_MAPPED_PATHS_LIST));
         verify(project).getFiles(isA(String.class), eq("D2009-09-24T00:00:00Z"), eq(false));
     }
 

--- a/tfs/src/test/java/hudson/plugins/tfs/commands/NewWorkspaceCommandTest.java
+++ b/tfs/src/test/java/hudson/plugins/tfs/commands/NewWorkspaceCommandTest.java
@@ -14,10 +14,13 @@ import static org.mockito.Mockito.when;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
 
 public class NewWorkspaceCommandTest extends AbstractCallableCommandTest {
 
     private static final List<String> EMPTY_CLOAKED_PATHS = Collections.emptyList();
+    private static final Map<String, String> EMPTY_MAPPED_PATHS_MAP = new TreeMap<String, String>();
 
     @Test public void assertLogging() throws Exception {
         when(server.getUserName()).thenReturn("snd\\user_cp");
@@ -28,7 +31,7 @@ public class NewWorkspaceCommandTest extends AbstractCallableCommandTest {
                 isA(String.class),
                 isA(WorkspaceLocation.class),
                 isA(WorkspaceOptions.class))).thenReturn(null);
-        final NewWorkspaceCommand command = new NewWorkspaceCommand(server, "TheWorkspaceName", null, EMPTY_CLOAKED_PATHS, null) {
+        final NewWorkspaceCommand command = new NewWorkspaceCommand(server, "TheWorkspaceName", null, EMPTY_CLOAKED_PATHS, EMPTY_MAPPED_PATHS_MAP, null) {
             @Override
             public Server createServer() {
                 return server;
@@ -51,6 +54,7 @@ public class NewWorkspaceCommandTest extends AbstractCallableCommandTest {
 
     @Test public void assertLoggingWhenAlsoMapping() throws Exception {
         final List<String> cloakedPaths = Collections.singletonList("$/Stuff/Hide");
+        final Map<String, String> mappedPaths = new TreeMap<String, String>();
 
         when(server.getUserName()).thenReturn("snd\\user_cp");
         when(vcc.createWorkspace(aryEq((WorkingFolder[]) null),
@@ -60,7 +64,7 @@ public class NewWorkspaceCommandTest extends AbstractCallableCommandTest {
                 isA(String.class),
                 isA(WorkspaceLocation.class),
                 isA(WorkspaceOptions.class))).thenReturn(null);
-        final NewWorkspaceCommand command = new NewWorkspaceCommand(server, "TheWorkspaceName", "$/Stuff", cloakedPaths, "/home/jenkins/jobs/stuff/workspace") {
+        final NewWorkspaceCommand command = new NewWorkspaceCommand(server, "TheWorkspaceName", "$/Stuff", cloakedPaths, mappedPaths, "/home/jenkins/jobs/stuff/workspace") {
             @Override
             public Server createServer() {
                 return server;
@@ -83,7 +87,118 @@ public class NewWorkspaceCommandTest extends AbstractCallableCommandTest {
         );
     }
 
+    @Test public void assertLoggingWhenAlsoMappingAtSubLevelWithoutMapFolder() throws Exception {
+        final List<String> cloakedPaths = Collections.singletonList("$/Stuff/Hide");
+        final Map<String, String> mappedPaths = new TreeMap<String, String>();
+        mappedPaths.put("$/Stuff/Hide/DoNotHide", null);
+
+        when(server.getUserName()).thenReturn("snd\\user_cp");
+        when(vcc.createWorkspace(aryEq((WorkingFolder[]) null),
+                isA(String.class),
+                isA(String.class),
+                isA(String.class),
+                isA(String.class),
+                isA(WorkspaceLocation.class),
+                isA(WorkspaceOptions.class))).thenReturn(null);
+        final NewWorkspaceCommand command = new NewWorkspaceCommand(server, "TheWorkspaceName", "$/Stuff", cloakedPaths, mappedPaths, "/home/jenkins/jobs/stuff/workspace") {
+            @Override
+            public Server createServer() {
+                return server;
+            }
+
+            @Override
+            protected void updateCache(final TFSTeamProjectCollection connection) {
+                // no-op for tests
+            }
+        };
+        final Callable<Void, Exception> callable = command.getCallable();
+
+        callable.call();
+
+        assertLog(
+                "Creating workspace 'TheWorkspaceName' owned by 'snd\\user_cp'...",
+                "Mapping '$/Stuff' to local folder '/home/jenkins/jobs/stuff/workspace' in workspace 'TheWorkspaceName'...",
+                "Cloaking '$/Stuff/Hide' in workspace 'TheWorkspaceName'...",
+                "Mapping '$/Stuff/Hide/DoNotHide' to local folder '/home/jenkins/jobs/stuff/workspace/Hide/DoNotHide' in workspace 'TheWorkspaceName'...",
+                "Created workspace 'TheWorkspaceName'."
+        );
+    }
+
+    @Test public void assertLoggingWhenAlsoMappingAtSubLevelWithMapFolder() throws Exception {
+        final List<String> cloakedPaths = Collections.singletonList("$/Stuff/Hide");
+        final Map<String, String> mappedPaths = new TreeMap<String, String>();
+        mappedPaths.put("$/Stuff/Hide/DoNotHide", "Stuff/Hide/DoNotHide");
+
+        when(server.getUserName()).thenReturn("snd\\user_cp");
+        when(vcc.createWorkspace(aryEq((WorkingFolder[]) null),
+                isA(String.class),
+                isA(String.class),
+                isA(String.class),
+                isA(String.class),
+                isA(WorkspaceLocation.class),
+                isA(WorkspaceOptions.class))).thenReturn(null);
+        final NewWorkspaceCommand command = new NewWorkspaceCommand(server, "TheWorkspaceName", "$/Stuff", cloakedPaths, mappedPaths, "/home/jenkins/jobs/stuff/workspace") {
+            @Override
+            public Server createServer() {
+                return server;
+            }
+
+            @Override
+            protected void updateCache(final TFSTeamProjectCollection connection) {
+                // no-op for tests
+            }
+        };
+        final Callable<Void, Exception> callable = command.getCallable();
+
+        callable.call();
+
+        assertLog(
+                "Creating workspace 'TheWorkspaceName' owned by 'snd\\user_cp'...",
+                "Mapping '$/Stuff' to local folder '/home/jenkins/jobs/stuff/workspace' in workspace 'TheWorkspaceName'...",
+                "Cloaking '$/Stuff/Hide' in workspace 'TheWorkspaceName'...",
+                "Mapping '$/Stuff/Hide/DoNotHide' to local folder '/home/jenkins/jobs/stuff/workspace/Stuff/Hide/DoNotHide' in workspace 'TheWorkspaceName'...",
+                "Created workspace 'TheWorkspaceName'."
+        );
+    }
+
+    @Test public void assertLoggingWhenAlsoMappingAtSubLevelWithRedirectMapFolder() throws Exception {
+        final List<String> cloakedPaths = Collections.singletonList("$/Stuff/Hide");
+        final Map<String, String> mappedPaths = new TreeMap<String, String>();
+        mappedPaths.put("$/Stuff/Hide/DoNotHide", "AnotherFolder");
+
+        when(server.getUserName()).thenReturn("snd\\user_cp");
+        when(vcc.createWorkspace(aryEq((WorkingFolder[]) null),
+                isA(String.class),
+                isA(String.class),
+                isA(String.class),
+                isA(String.class),
+                isA(WorkspaceLocation.class),
+                isA(WorkspaceOptions.class))).thenReturn(null);
+        final NewWorkspaceCommand command = new NewWorkspaceCommand(server, "TheWorkspaceName", "$/Stuff", cloakedPaths, mappedPaths, "/home/jenkins/jobs/stuff/workspace") {
+            @Override
+            public Server createServer() {
+                return server;
+            }
+
+            @Override
+            protected void updateCache(final TFSTeamProjectCollection connection) {
+                // no-op for tests
+            }
+        };
+        final Callable<Void, Exception> callable = command.getCallable();
+
+        callable.call();
+
+        assertLog(
+                "Creating workspace 'TheWorkspaceName' owned by 'snd\\user_cp'...",
+                "Mapping '$/Stuff' to local folder '/home/jenkins/jobs/stuff/workspace' in workspace 'TheWorkspaceName'...",
+                "Cloaking '$/Stuff/Hide' in workspace 'TheWorkspaceName'...",
+                "Mapping '$/Stuff/Hide/DoNotHide' to local folder '/home/jenkins/jobs/stuff/workspace/AnotherFolder' in workspace 'TheWorkspaceName'...",
+                "Created workspace 'TheWorkspaceName'."
+        );
+    }
+
     @Override protected AbstractCallableCommand createCommand(final ServerConfigurationProvider serverConfig) {
-        return new NewWorkspaceCommand(serverConfig, "workspaceName", "$/serverPath", EMPTY_CLOAKED_PATHS, "local/path");
+        return new NewWorkspaceCommand(serverConfig, "workspaceName", "$/serverPath", EMPTY_CLOAKED_PATHS, EMPTY_MAPPED_PATHS_MAP, "local/path");
     }
 }

--- a/tfs/src/test/java/hudson/plugins/tfs/model/ProjectTest.java
+++ b/tfs/src/test/java/hudson/plugins/tfs/model/ProjectTest.java
@@ -112,7 +112,41 @@ public class ProjectTest extends SwedishLocaleTestCase {
         final ChangeSet changeSet44 = createChangeSet(44, "$/MyProject/A/foo");
         final List<ChangeSet> changeSets = Arrays.asList(changeSet44, changeSet43, changeSet42);
 
-        final ChangeSet actual = Project.findLatestUncloakedChangeset(cloakedPaths, changeSets);
+        final ChangeSet actual = Project.findLatestUncloakedChangeset(cloakedPaths, null, changeSets);
+
+        Assert.assertEquals("44", actual.getVersion());
+    }
+
+    @Test
+    public void findLatestUncloakedChangeset_latestIsUncloakedBelowACloakedFolder() {
+        final List<String> cloakedPaths = Arrays.asList("$/MyProject/A/2", "$/MyProject/B");
+        final List<String> mappedPaths = Arrays.asList("$/MyProject/A/2/foo", "$/MyProject/B/bar");
+        final ChangeSet changeSet42 = createChangeSet(42, "$/MyProject/A/foo", "$/MyProject/A/bar");
+        final ChangeSet changeSet43 = createChangeSet(43, "$/MyProject/A/bar");
+        final ChangeSet changeSet44 = createChangeSet(44, "$/MyProject/A/foo");
+        final List<ChangeSet> changeSets = Arrays.asList(changeSet44, changeSet43, changeSet42);
+
+        final ChangeSet actual = Project.findLatestUncloakedChangeset(cloakedPaths, mappedPaths, changeSets);
+
+        Assert.assertEquals("44", actual.getVersion());
+    }
+
+    @Test
+    public void findLatestUncloakedChangeset_latestIsUncloakedBelowSeveralCloakedFolders() {
+        final List<String> cloakedPaths = Arrays.asList(
+            "$/MyProject/A/2",
+            "$/MyProject/A/2/foo/bar",
+            "$/MyProject/B");
+        final List<String> mappedPaths = Arrays.asList(
+            "$/MyProject/A/2/foo",
+            "$/MyProject/A/2/foo/bar/baz",
+            "$/MyProject/B/bar");
+        final ChangeSet changeSet42 = createChangeSet(42, "$/MyProject/A/foo", "$/MyProject/A/bar");
+        final ChangeSet changeSet43 = createChangeSet(43, "$/MyProject/A/bar");
+        final ChangeSet changeSet44 = createChangeSet(44, "$/MyProject/A/foo/bar/baz/foo");
+        final List<ChangeSet> changeSets = Arrays.asList(changeSet44, changeSet43, changeSet42);
+
+        final ChangeSet actual = Project.findLatestUncloakedChangeset(cloakedPaths, mappedPaths, changeSets);
 
         Assert.assertEquals("44", actual.getVersion());
     }
@@ -125,7 +159,46 @@ public class ProjectTest extends SwedishLocaleTestCase {
         final ChangeSet changeSet44 = createChangeSet(44, "$/MyProject/A/2/foo");
         final List<ChangeSet> changeSets = Arrays.asList(changeSet44, changeSet43, changeSet42);
 
-        final ChangeSet actual = Project.findLatestUncloakedChangeset(cloakedPaths, changeSets);
+        final ChangeSet actual = Project.findLatestUncloakedChangeset(cloakedPaths, null, changeSets);
+
+        Assert.assertEquals("43", actual.getVersion());
+    }
+
+    @Test
+    public void findLatestUncloakedChangeset_latestIsCloakedWithMappedFolders() {
+        final List<String> cloakedPaths = Arrays.asList(
+            "$/MyProject/A/1",
+            "$/MyProject/A/2",
+            "$/MyProject/B");
+        final List<String> mappedPaths = Arrays.asList(
+            "$/MyProject/A/1/foo",
+            "$/MyProject/B/bar");
+        final ChangeSet changeSet42 = createChangeSet(42, "$/MyProject/A/foo", "$/MyProject/A/bar");
+        final ChangeSet changeSet43 = createChangeSet(43, "$/MyProject/A/bar");
+        final ChangeSet changeSet44 = createChangeSet(44, "$/MyProject/A/2/foo");
+        final List<ChangeSet> changeSets = Arrays.asList(changeSet44, changeSet43, changeSet42);
+
+        final ChangeSet actual = Project.findLatestUncloakedChangeset(cloakedPaths, null, changeSets);
+
+        Assert.assertEquals("43", actual.getVersion());
+    }
+
+    @Test
+    public void findLatestUncloakedChangeset_latestIsCloakedBelowSeveralMappedFolders() {
+        final List<String> cloakedPaths = Arrays.asList(
+            "$/MyProject/A/2",
+            "$/MyProject/A/2/foo/bar",
+            "$/MyProject/B");
+        final List<String> mappedPaths = Arrays.asList(
+            "$/MyProject/A/2/foo",
+            "$/MyProject/A/2/foo/bar/baz",
+            "$/MyProject/B/bar");
+        final ChangeSet changeSet42 = createChangeSet(42, "$/MyProject/A/foo", "$/MyProject/A/bar");
+        final ChangeSet changeSet43 = createChangeSet(43, "$/MyProject/A/bar");
+        final ChangeSet changeSet44 = createChangeSet(44, "$/MyProject/A/2/foo/bar/foo");
+        final List<ChangeSet> changeSets = Arrays.asList(changeSet44, changeSet43, changeSet42);
+
+        final ChangeSet actual = Project.findLatestUncloakedChangeset(cloakedPaths, mappedPaths, changeSets);
 
         Assert.assertEquals("43", actual.getVersion());
     }
@@ -138,7 +211,7 @@ public class ProjectTest extends SwedishLocaleTestCase {
         final ChangeSet changeSet44 = createChangeSet(44, "$/MyProject/A/2/foo");
         final List<ChangeSet> changeSets = Arrays.asList(changeSet44, changeSet43, changeSet42);
 
-        final ChangeSet actual = Project.findLatestUncloakedChangeset(cloakedPaths, changeSets);
+        final ChangeSet actual = Project.findLatestUncloakedChangeset(cloakedPaths, null, changeSets);
 
         Assert.assertEquals(null, actual);
     }
@@ -161,7 +234,7 @@ public class ProjectTest extends SwedishLocaleTestCase {
     public void isChangesetFullyCloaked_nullCloakedPaths() {
         final List<String> changesetPaths = Arrays.asList("$/foo", "$/foo/bar.baz");
 
-        final boolean actual = Project.isChangesetFullyCloaked(changesetPaths, null);
+        final boolean actual = Project.isChangesetFullyCloaked(changesetPaths, null, null);
 
         Assert.assertEquals(false, actual);
     }
@@ -172,7 +245,7 @@ public class ProjectTest extends SwedishLocaleTestCase {
         final List<String> changesetPaths = Arrays.asList("$/foo", "$/foo/bar.baz");
         final List<String> cloakedPaths = Arrays.asList("$/fizz", "$/fizz/FizzBuzz.java");
 
-        final boolean actual = Project.isChangesetFullyCloaked(changesetPaths, cloakedPaths);
+        final boolean actual = Project.isChangesetFullyCloaked(changesetPaths, cloakedPaths, null);
 
         Assert.assertEquals(false, actual);
     }
@@ -182,9 +255,20 @@ public class ProjectTest extends SwedishLocaleTestCase {
         final List<String> changesetPaths = Arrays.asList("$/foo/bar/test.baz");
         final List<String> cloakedPaths = Arrays.asList("$/fOo/bAr/");
 
-        final boolean actual = Project.isChangesetFullyCloaked(changesetPaths, cloakedPaths);
+        final boolean actual = Project.isChangesetFullyCloaked(changesetPaths, cloakedPaths, null);
 
         Assert.assertEquals(true, actual);
+    }
+
+    @Test
+    public void isChangesetFullyCloaked_caseInsensitiveMappedPaths() {
+        final List<String> changesetPaths = Arrays.asList("$/foo/bar/baz/test.baz");
+        final List<String> cloakedPaths = Arrays.asList("$/fOo/bAr/");
+        final List<String> mappedPaths = Arrays.asList("$/fOo/bAr/BaZ");
+
+        final boolean actual = Project.isChangesetFullyCloaked(changesetPaths, cloakedPaths, mappedPaths);
+
+        Assert.assertEquals(false, actual);
     }
 
     @Test
@@ -192,7 +276,18 @@ public class ProjectTest extends SwedishLocaleTestCase {
         final List<String> changesetPaths = Arrays.asList("$/foo", "$/foo/bar.baz");
         final List<String> cloakedPaths = Collections.singletonList("$/foo/bar.baz");
 
-        final boolean actual = Project.isChangesetFullyCloaked(changesetPaths, cloakedPaths);
+        final boolean actual = Project.isChangesetFullyCloaked(changesetPaths, cloakedPaths, null);
+
+        Assert.assertEquals(false, actual);
+    }
+
+    @Test
+    public void isChangesetFullyCloaked_mappingChild() {
+        final List<String> changesetPaths = Arrays.asList("$/foo/bar", "$/foo/bar/baz/fizz.buzz");
+        final List<String> cloakedPaths = Collections.singletonList("$/foo/bar");
+        final List<String> mappedPaths = Arrays.asList("$/foo/bar/baz");
+
+        final boolean actual = Project.isChangesetFullyCloaked(changesetPaths, cloakedPaths, mappedPaths);
 
         Assert.assertEquals(false, actual);
     }
@@ -202,7 +297,7 @@ public class ProjectTest extends SwedishLocaleTestCase {
         final List<String> changesetPaths = Arrays.asList("$/foo", "$/bar");
         final List<String> cloakedPaths = Collections.singletonList("$/foo");
 
-        final boolean actual = Project.isChangesetFullyCloaked(changesetPaths, cloakedPaths);
+        final boolean actual = Project.isChangesetFullyCloaked(changesetPaths, cloakedPaths, null);
 
         Assert.assertEquals(false, actual);
     }
@@ -212,7 +307,23 @@ public class ProjectTest extends SwedishLocaleTestCase {
         final List<String> changesetPaths = Arrays.asList("$/foo", "$/foo/bar.baz");
         final List<String> cloakedPaths = Collections.singletonList("$/foo");
 
-        final boolean actual = Project.isChangesetFullyCloaked(changesetPaths, cloakedPaths);
+        final boolean actual = Project.isChangesetFullyCloaked(changesetPaths, cloakedPaths, null);
+
+        Assert.assertEquals(true, actual);
+    }
+
+    @Test
+    public void isChangesetFullyCloaked_fullyCloakedPathWithMappedPaths() {
+        final List<String> changesetPaths = Arrays.asList(
+            "$/foo",
+             "$/foo/bar/baz",
+             "$/foo/bar/baz/fizz");
+        final List<String> cloakedPaths = Arrays.asList(
+            "$/foo",
+            "$/foo/bar/baz");
+        final List<String> mappedPaths = Arrays.asList("$/foo/bar");
+
+        final boolean actual = Project.isChangesetFullyCloaked(changesetPaths, cloakedPaths, mappedPaths);
 
         Assert.assertEquals(true, actual);
     }
@@ -222,7 +333,7 @@ public class ProjectTest extends SwedishLocaleTestCase {
         final List<String> changesetPaths = Collections.singletonList("$/foo/bar.baz");
         final List<String> cloakedPaths = Arrays.asList("$/foo", "$/bar");
 
-        final boolean actual = Project.isChangesetFullyCloaked(changesetPaths, cloakedPaths);
+        final boolean actual = Project.isChangesetFullyCloaked(changesetPaths, cloakedPaths, null);
 
         Assert.assertEquals(true, actual);
     }
@@ -232,7 +343,7 @@ public class ProjectTest extends SwedishLocaleTestCase {
         final List<String> changesetPaths = Arrays.asList("$/foo/bar.baz", "$/bar/foo.baz");
         final List<String> cloakedPaths = Arrays.asList("$/foo", "$/bar");
 
-        final boolean actual = Project.isChangesetFullyCloaked(changesetPaths, cloakedPaths);
+        final boolean actual = Project.isChangesetFullyCloaked(changesetPaths, cloakedPaths, null);
 
         Assert.assertEquals(true, actual);
     }

--- a/tfs/src/test/java/hudson/plugins/tfs/model/WorkspaceConfigurationTest.java
+++ b/tfs/src/test/java/hudson/plugins/tfs/model/WorkspaceConfigurationTest.java
@@ -5,25 +5,57 @@ import static org.junit.Assert.*;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
 
 import org.junit.Test;
 
 public class WorkspaceConfigurationTest {
 
     private static final List<String> EMPTY_CLOAKED_PATHS_LIST = Collections.emptyList();
+    private static final Map<String, String> EMPTY_MAPPING_PATHS_LIST = new TreeMap<String, String>();
 
     @Test public void assertConfigurationsEquals() {
         final List<String> cloakList = Collections.singletonList("cloak");
+        final Map<String, String> mappings = new TreeMap<String, String>();
+        mappings.put("$/foo/", "foo");
+        mappings.put("$/bar/", "bar");
+        mappings.put("$/baz/", "baz");
 
-        WorkspaceConfiguration one = new WorkspaceConfiguration("server", "workspace", "project", cloakList, "workfolder");
-        WorkspaceConfiguration two = new WorkspaceConfiguration("server", "workspace", "project", cloakList, "workfolder");
+        final Map<String, String> almostSimilarMappings = new TreeMap<String, String>();
+        mappings.put("$/foo/", "foo/");
+        mappings.put("$/bar/", "bar");
+        mappings.put("$/baz/", "baz");
+
+        final Map<String, String> nullMappings = new TreeMap<String, String>();
+        mappings.put("$/foo/", null);
+        mappings.put("$/bar/", null);
+        mappings.put("$/baz/", null);
+
+        WorkspaceConfiguration one = new WorkspaceConfiguration("server", "workspace", "project", cloakList, mappings, "workfolder");
+        WorkspaceConfiguration two = new WorkspaceConfiguration("server", "workspace", "project", cloakList, mappings, "workfolder");
+        WorkspaceConfiguration three = new WorkspaceConfiguration("server", "workspace", "project", cloakList, almostSimilarMappings, "workfolder");
+        WorkspaceConfiguration four = new WorkspaceConfiguration("server", "workspace", "project", cloakList, nullMappings, "workfolder");
+        
         assertThat(one, is(two));
         assertThat(two, is(one));
         assertThat(one, is(one));
-        assertThat(one, not(new WorkspaceConfiguration("aserver", "workspace", "project", cloakList, "workfolder")));
-        assertThat(one, not(new WorkspaceConfiguration("server", "aworkspace", "project", cloakList, "workfolder")));
-        assertThat(one, not(new WorkspaceConfiguration("server", "workspace", "aproject", cloakList, "workfolder")));
-        assertThat(one, not(new WorkspaceConfiguration("server", "workspace", "project", cloakList, "aworkfolder")));
-        assertThat(one, not(new WorkspaceConfiguration("server", "workspace", "project", EMPTY_CLOAKED_PATHS_LIST, "workfolder")));
+
+        assertThat(one, not(three));
+        assertThat(one, not(four));
+
+        assertThat(three, is(three));
+        assertThat(four, is(four));
+        
+        assertThat(one, not(new WorkspaceConfiguration("aserver", "workspace", "project", cloakList, mappings, "workfolder")));
+        assertThat(one, not(new WorkspaceConfiguration("server", "aworkspace", "project", cloakList, mappings, "workfolder")));
+        assertThat(one, not(new WorkspaceConfiguration("server", "workspace", "aproject", cloakList, mappings, "workfolder")));
+        assertThat(one, not(new WorkspaceConfiguration("server", "workspace", "project", cloakList, mappings, "aworkfolder")));
+
+        assertThat(one, not(new WorkspaceConfiguration("server", "workspace", "project", null, mappings, "workfolder")));
+        assertThat(one, not(new WorkspaceConfiguration("server", "workspace", "project", EMPTY_CLOAKED_PATHS_LIST, mappings, "workfolder")));
+
+        assertThat(one, not(new WorkspaceConfiguration("server", "workspace", "project", cloakList, null, "workfolder")));
+        assertThat(one, not(new WorkspaceConfiguration("server", "workspace", "project", cloakList, EMPTY_MAPPING_PATHS_LIST, "workfolder")));
     }
 }

--- a/tfs/src/test/java/hudson/plugins/tfs/model/WorkspacesTest.java
+++ b/tfs/src/test/java/hudson/plugins/tfs/model/WorkspacesTest.java
@@ -5,6 +5,8 @@ import java.io.Reader;
 import java.io.StringReader;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
 
 import hudson.plugins.tfs.commands.ListWorkspacesCommand;
 
@@ -21,6 +23,7 @@ import org.mockito.MockitoAnnotations;
 public class WorkspacesTest {
 
     private static final List<String> EMPTY_CLOAKED_PATHS_LIST = Collections.emptyList();
+    private static final Map<String, String> EMPTY_MAPPED_PATHS_MAP = new TreeMap<String, String>();
 
     @Mock private Server server;
     private ListWorkspacesCommand parser;
@@ -91,7 +94,7 @@ public class WorkspacesTest {
         when(server.execute(isA(Callable.class))).thenReturn(null);
         
         Workspaces workspaces = new Workspaces(server);
-        Workspace workspace = workspaces.newWorkspace("name1", null, EMPTY_CLOAKED_PATHS_LIST, null);
+        Workspace workspace = workspaces.newWorkspace("name1", null, EMPTY_CLOAKED_PATHS_LIST, EMPTY_MAPPED_PATHS_MAP, null);
         assertNotNull("The new workspace was null", workspace);
         assertTrue("The workspace was reported as non existant", workspaces.exists(workspace));
     }
@@ -101,7 +104,7 @@ public class WorkspacesTest {
         when(server.execute(isA(Callable.class))).thenReturn(null);
         
         Workspaces workspaces = new Workspaces(server);
-        workspaces.newWorkspace("name1", null, EMPTY_CLOAKED_PATHS_LIST, null);
+        workspaces.newWorkspace("name1", null, EMPTY_CLOAKED_PATHS_LIST, EMPTY_MAPPED_PATHS_MAP, null);
         assertNotNull("The get new workspace returned null", workspaces.getWorkspace("name1"));
         verify(server, times(1)).execute(isA(Callable.class));
     }
@@ -111,7 +114,7 @@ public class WorkspacesTest {
         when(server.execute(isA(Callable.class))).thenReturn(null);
         
         Workspaces workspaces = new Workspaces(server);
-        Workspace workspace = workspaces.newWorkspace("name1", null, EMPTY_CLOAKED_PATHS_LIST, null);
+        Workspace workspace = workspaces.newWorkspace("name1", null, EMPTY_CLOAKED_PATHS_LIST, EMPTY_MAPPED_PATHS_MAP, null);
         assertTrue("The get new workspace did not exists", workspaces.exists(workspace));
         verify(server, times(1)).execute(isA(Callable.class));
     }
@@ -122,7 +125,7 @@ public class WorkspacesTest {
         Workspaces workspaces = new Workspaces(server);
         // Populate the map in test object
         assertFalse("The workspace was reported as existant", workspaces.exists(new Workspace("name")));
-        Workspace workspace = workspaces.newWorkspace("name", null, EMPTY_CLOAKED_PATHS_LIST, null);
+        Workspace workspace = workspaces.newWorkspace("name", null, EMPTY_CLOAKED_PATHS_LIST, EMPTY_MAPPED_PATHS_MAP, null);
         assertTrue("The workspace was reported as non existant", workspaces.exists(new Workspace("name")));
         workspaces.deleteWorkspace(workspace);
         assertFalse("The workspace was reported as existant", workspaces.exists(workspace));

--- a/tfs/src/test/java/hudson/plugins/tfs/util/BuildWorkspaceConfigurationRetrieverTest.java
+++ b/tfs/src/test/java/hudson/plugins/tfs/util/BuildWorkspaceConfigurationRetrieverTest.java
@@ -7,6 +7,8 @@ import static org.mockito.Mockito.*;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
 
 import hudson.model.AbstractBuild;
 import hudson.model.Node;
@@ -21,13 +23,14 @@ import org.jvnet.hudson.test.Bug;
 public class BuildWorkspaceConfigurationRetrieverTest {
 
     private static final List<String> EMPTY_CLOAKED_PATHS_LIST = Collections.emptyList();
+    private static final Map<String, String> EMPTY_MAPPING_PATHS_LIST = new TreeMap<String, String>();
 
     @Test
     public void assertGetLatestConfgiurationOnNode() {
         AbstractBuild build = mock(AbstractBuild.class);
         Node node = mock(Node.class);
         Node needleNode = mock(Node.class);
-        WorkspaceConfiguration configuration = new WorkspaceConfiguration("serverUrl", "workspaceName", "projectPath", EMPTY_CLOAKED_PATHS_LIST, "workfolder");
+        WorkspaceConfiguration configuration = new WorkspaceConfiguration("serverUrl", "workspaceName", "projectPath", EMPTY_CLOAKED_PATHS_LIST, EMPTY_MAPPING_PATHS_LIST, "workfolder");
         when(build.getPreviousBuild()).thenReturn(build).thenReturn(null);
         when(build.getBuiltOn()).thenReturn(node, node, null);
         when(node.getNodeName()).thenReturn("node1", "needleNode");
@@ -98,7 +101,7 @@ public class BuildWorkspaceConfigurationRetrieverTest {
         when(build.getPreviousBuild()).thenReturn(build);
         when(build.getBuiltOn()).thenReturn(node);
         when(node.getNodeName()).thenReturn("needleNode");
-        when(build.getAction(WorkspaceConfiguration.class)).thenReturn(new WorkspaceConfiguration("serverUrl", "workspaceName", "projectPath", EMPTY_CLOAKED_PATHS_LIST, "workfolder"));
+        when(build.getAction(WorkspaceConfiguration.class)).thenReturn(new WorkspaceConfiguration("serverUrl", "workspaceName", "projectPath", EMPTY_CLOAKED_PATHS_LIST, EMPTY_MAPPING_PATHS_LIST, "workfolder"));
         
         BuildWorkspaceConfiguration configuration = new BuildWorkspaceConfigurationRetriever().getLatestForNode(node, build);
         assertThat( configuration.getWorkspaceName(), is("workspaceName"));
@@ -113,7 +116,7 @@ public class BuildWorkspaceConfigurationRetrieverTest {
         AbstractBuild build = mock(AbstractBuild.class);
         Node node = mock(Node.class);
         Node needleNode = mock(Node.class);
-        WorkspaceConfiguration configuration = new WorkspaceConfiguration("serverUrl", "workspaceName", "projectPath", EMPTY_CLOAKED_PATHS_LIST, "workfolder");
+        WorkspaceConfiguration configuration = new WorkspaceConfiguration("serverUrl", "workspaceName", "projectPath", EMPTY_CLOAKED_PATHS_LIST, EMPTY_MAPPING_PATHS_LIST, "workfolder");
         when(build.getPreviousBuild()).thenReturn(build).thenReturn(null);
         when(build.getBuiltOn()).thenReturn(null);
 


### PR DESCRIPTION
Reintroduce the code that allows mapping sub-folders of a cloaked path.

This PR is here because commit f6fe6de50a52e4c0fe3419b996bdc8204c912210 was reverted due to issues with the functional tests. Any changes to the code / tests will be applied to this PR.