### PR TITLE
Restore Support for TFS 2017/2018 in Build Status

### DIFF
--- a/tfs/src/main/java/hudson/plugins/tfs/util/TeamRestClient.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/util/TeamRestClient.java
@@ -280,7 +280,7 @@ public class TeamRestClient {
 
     public TeamGitStatus addPullRequestStatus(final PullRequestMergeCommitCreatedEventArgs args, final TeamGitStatus status) throws IOException {
 
-        final QueryString qs = new QueryString(API_VERSION, "4.1-preview");
+        final QueryString qs = new QueryString(API_VERSION, "3.0-preview.1");
         final URI requestUri = UriHelper.join(
             collectionUri, args.projectId,
             "_apis", "git",
@@ -294,7 +294,7 @@ public class TeamRestClient {
 
     public TeamGitStatus addPullRequestIterationStatus(final PullRequestMergeCommitCreatedEventArgs args, final TeamGitStatus status) throws IOException {
 
-        final QueryString qs = new QueryString(API_VERSION, "4.1-preview");
+        final QueryString qs = new QueryString(API_VERSION, "3.0-preview.1");
         final URI requestUri = UriHelper.join(
             collectionUri, args.projectId,
             "_apis", "git",


### PR DESCRIPTION
Use REST API version "3.0-preview.1" when posting commit or PR status
back to TFS, because version "4.1-preview" is not supported by TFS 2017
or 2018.

Resolves JENKINS-51579.