### PR TITLE
Improve VSTS Service Hook integration

### DIFF
--- a/tfs/src/main/java/hudson/plugins/tfs/JenkinsEventNotifier.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/JenkinsEventNotifier.java
@@ -1,11 +1,7 @@
 package hudson.plugins.tfs;
 
 import hudson.plugins.tfs.model.ConnectionParameters;
-import hudson.plugins.tfs.model.GitStatusContext;
-import hudson.plugins.tfs.model.GitStatusState;
 import hudson.plugins.tfs.model.JobCompletionEventArgs;
-import hudson.plugins.tfs.model.PullRequestMergeCommitCreatedEventArgs;
-import hudson.plugins.tfs.model.TeamGitStatus;
 import hudson.plugins.tfs.util.TeamRestClient;
 import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
@@ -19,11 +15,9 @@ import org.apache.http.impl.client.HttpClientBuilder;
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
 import java.io.BufferedReader;
-import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.UnsupportedEncodingException;
 import java.net.HttpURLConnection;
-import java.net.MalformedURLException;
 import java.net.URI;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
@@ -66,46 +60,6 @@ public final class JenkinsEventNotifier {
                 log.warning("ERROR: sendJobCompletionEvent: (collection=" + c.getCollectionUrl() + ") " + e.getMessage());
             }
         }
-    }
-
-    /**
-     * Send the build status of VSTS pull request back to connected TFS/VSTS servers only for those jobs kicked off by PRs.
-     */
-    public static void sendPullRequestBuildStatusEvent(final CommitParameterAction commitParameter, final GitStatusState buildState, final String buildDescription, final String targetUrl, final String jobFullPath) {
-        try {
-            if (commitParameter != null) {
-                if (commitParameter instanceof PullRequestParameterAction) {
-                    final PullRequestParameterAction prpa = (PullRequestParameterAction) commitParameter;
-                    final PullRequestMergeCommitCreatedEventArgs pullRequestMergeCommitCreatedEventArgs = prpa.getPullRequestMergeCommitCreatedEventArgs();
-                    sendPullRequestBuildStatusEvent(pullRequestMergeCommitCreatedEventArgs, buildState, buildDescription, targetUrl, jobFullPath);
-                }
-            }
-        } catch (final Exception e) {
-            log.warning("ERROR: sendPullRequestBuildStatusEvent fails due to exception: " + e.getMessage());
-        }
-        return;
-    }
-
-    /**
-     * Send the build status of VSTS pull request back to connected TFS/VSTS servers.
-     */
-    public static void sendPullRequestBuildStatusEvent(final PullRequestMergeCommitCreatedEventArgs gitCodePushedEventArgs, final GitStatusState buildState, final String buildDescription, final String targetUrl, final String jobFullPath) {
-        try {
-            final TeamGitStatus status = new TeamGitStatus();
-            status.state = buildState;
-            status.description = buildDescription;
-            status.targetUrl = targetUrl;
-            status.context = new GitStatusContext(" ", StringUtils.stripEnd(jobFullPath, "/"));
-
-            final URI collectionUri = gitCodePushedEventArgs.collectionUri;
-            final TeamRestClient client = new TeamRestClient(collectionUri);
-            client.addPullRequestStatus(gitCodePushedEventArgs, status);
-        } catch (MalformedURLException e) {
-            log.warning("ERROR: sendPullRequestBuildStatusEvent fails due to MalformedURLException: " + e.getMessage());
-        } catch (IOException e) {
-            log.warning("ERROR: sendPullRequestBuildStatusEvent fails due to IOException: " + e.getMessage());
-        }
-        return;
     }
 
     /**
@@ -195,6 +149,4 @@ public final class JenkinsEventNotifier {
 
         return formatter.toString();
     }
-
-
 }

--- a/tfs/src/main/java/hudson/plugins/tfs/listeners/JenkinsRunListener.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/listeners/JenkinsRunListener.java
@@ -1,33 +1,24 @@
 package hudson.plugins.tfs.listeners;
 
 import hudson.Extension;
-import hudson.model.Action;
-import hudson.model.Cause;
-import hudson.model.CauseAction;
-import hudson.model.Job;
-import hudson.model.Result;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.model.listeners.RunListener;
-import hudson.plugins.tfs.CommitParameterAction;
-import hudson.plugins.tfs.JenkinsEventNotifier;
-import hudson.plugins.tfs.TeamPushCause;
+
+import hudson.plugins.tfs.TeamCompletedStatusPostBuildAction;
+import hudson.plugins.tfs.TeamPendingStatusBuildStep;
 import hudson.plugins.tfs.UnsupportedIntegrationAction;
-import hudson.plugins.tfs.model.GitStatusState;
-import java.util.List;
-import net.sf.json.JSONObject;
 
 import javax.annotation.Nonnull;
 import java.util.logging.Logger;
 
+
 /**
  * This class listens to the events of every Jenkins run instance.
- * Completed runs fire an event back to the JenkinsEventNotifier.
  */
 @Extension
 public class JenkinsRunListener extends RunListener<Run> {
     protected static final Logger log = Logger.getLogger(JenkinsRunListener.class.getName());
-    private static final String DEFAULT_RUN_CONTEXT = "Jenkins PR build";
 
     public JenkinsRunListener() {
         log.fine("JenkinsRunListener: constructor");
@@ -40,11 +31,8 @@ public class JenkinsRunListener extends RunListener<Run> {
     @Override
     public void onStarted(final Run run, final TaskListener listener) {
         if (UnsupportedIntegrationAction.isSupported(run, listener)) {
-            Job currJob = run.getParent();
-            final String targetUrl = currJob.getAbsoluteUrl() + (currJob.getNextBuildNumber() - 1);
-            final CommitParameterAction commitParameter = run.getAction(CommitParameterAction.class);
-            final String context = getRunContext(run) + " started";
-            JenkinsEventNotifier.sendPullRequestBuildStatusEvent(commitParameter, GitStatusState.Pending, context, targetUrl, currJob.getAbsoluteUrl());
+            final TeamPendingStatusBuildStep step = new TeamPendingStatusBuildStep();
+            step.perform(run, listener);
         }
     }
 
@@ -55,60 +43,9 @@ public class JenkinsRunListener extends RunListener<Run> {
     @Override
     public void onCompleted(final Run run, @Nonnull final TaskListener listener) {
         log.info("onCompleted: " + run.toString());
-
-        GitStatusState runGitState;
-        final Result runResult = run.getResult();
-        if (runResult != null && runResult.isBetterOrEqualTo(Result.SUCCESS)) {
-            runGitState = GitStatusState.Succeeded;
-        } else {
-            runGitState = GitStatusState.Failed;
-        }
-
         if (UnsupportedIntegrationAction.isSupported(run, listener)) {
-            Job currJob = run.getParent();
-            final String runDescription = run.getDescription();
-            final String targetUrl = currJob.getAbsoluteUrl() + (currJob.getNextBuildNumber() - 1);
-            final CommitParameterAction commitParameter = run.getAction(CommitParameterAction.class);
-            final String context = getRunContext(run) + " completed";
-            JenkinsEventNotifier.sendPullRequestBuildStatusEvent(commitParameter, runGitState, context, targetUrl, currJob.getAbsoluteUrl());
+            final TeamCompletedStatusPostBuildAction step = new TeamCompletedStatusPostBuildAction();
+            step.perform(run, listener);
         }
-
-        JSONObject json = createJsonFromRun(run);
-        final String payload = JenkinsEventNotifier.getApiJson(run.getUrl());
-        if (payload != null) {
-            json = JSONObject.fromObject(payload);
-        }
-
-        json.put("name", run.getParent().getDisplayName());
-        json.put("startedBy", getStartedBy(run));
-
-        JenkinsEventNotifier.sendJobCompletionEvent(json);
-    }
-
-    private String getStartedBy(final Run run) {
-        final Cause.UserIdCause cause = (Cause.UserIdCause) run.getCause(Cause.UserIdCause.class);
-        String startedBy = "";
-        if (cause != null && cause.getUserId() != null) {
-            startedBy = cause.getUserId();
-        }
-        return startedBy;
-    }
-
-    private JSONObject createJsonFromRun(final Run run) {
-        return new JSONObject();
-    }
-
-    private String getRunContext(final Run run) {
-        List<? extends Action> actionList = run.getAllActions();
-        for (final Action currAction : actionList) {
-            if (currAction instanceof CauseAction) {
-                for (final Cause currCause : ((CauseAction) currAction).getCauses()) {
-                    if (currCause instanceof TeamPushCause) {
-                        return ((TeamPushCause) currCause).getRunContext();
-                    }
-                }
-            }
-        }
-        return DEFAULT_RUN_CONTEXT;
     }
 }

--- a/tfs/src/main/java/hudson/plugins/tfs/model/BuildCommand.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/model/BuildCommand.java
@@ -7,12 +7,14 @@ import hudson.model.Action;
 import hudson.model.BuildableItem;
 import hudson.model.Cause;
 import hudson.model.CauseAction;
+import hudson.model.Executor;
 import hudson.model.Job;
 import hudson.model.ParameterDefinition;
 import hudson.model.ParameterValue;
 import hudson.model.ParametersAction;
 import hudson.model.ParametersDefinitionProperty;
 import hudson.model.Queue;
+import hudson.model.Run;
 import hudson.model.SimpleParameterDefinition;
 import hudson.model.queue.ScheduleResult;
 import hudson.plugins.tfs.CommitParameterAction;
@@ -25,6 +27,7 @@ import hudson.plugins.tfs.UnsupportedIntegrationAction;
 import hudson.plugins.tfs.model.servicehooks.Event;
 import hudson.plugins.tfs.util.ActionHelper;
 import hudson.plugins.tfs.util.MediaType;
+import hudson.util.RunList;
 import jenkins.model.Jenkins;
 import jenkins.util.TimeDuration;
 import net.sf.json.JSONArray;
@@ -83,7 +86,7 @@ public class BuildCommand extends AbstractCommand {
         }
     }
 
-    protected JSONObject innerPerform(final BuildableItem buildableItem, final TimeDuration delay, final List<Action> extraActions) {
+    protected JSONObject innerPerform(final Job job, final BuildableItem buildableItem, final TimeDuration delay, final List<Action> extraActions) {
         final JSONObject result = new JSONObject();
 
         final Jenkins jenkins = Jenkins.getActiveInstance();
@@ -91,6 +94,11 @@ public class BuildCommand extends AbstractCommand {
         final Cause cause = new Cause.UserIdCause();
         final CauseAction causeAction = new CauseAction(cause);
         final Action[] actionArray = ActionHelper.create(extraActions, causeAction);
+        for (Action a : extraActions) {
+            if (a instanceof TeamPullRequestMergedDetailsAction) {
+                cancelPreviousPullRequestBuilds(job, (TeamPullRequestMergedDetailsAction) a, queue);
+            }
+        }
         final ScheduleResult scheduleResult = queue.schedule2(buildableItem, delay.getTime(), actionArray);
         final Queue.Item item = scheduleResult.getItem();
         if (item != null) {
@@ -209,7 +217,28 @@ public class BuildCommand extends AbstractCommand {
             actions.add(action);
         }
 
-        return innerPerform(buildableItem, delay, actions);
+        return innerPerform(job, buildableItem, delay, actions);
+    }
+
+    private void cancelPreviousPullRequestBuilds(Job job, TeamPullRequestMergedDetailsAction pullReqeuestMergedDetails, Queue queue) {
+        RunList<?> allBuilds = job.getBuilds();
+
+        for (Run run : allBuilds) {
+            TeamPullRequestMergedDetailsAction cause = run.getAction(TeamPullRequestMergedDetailsAction.class);
+            if (cause != null && run.isBuilding()) {
+                if (pullReqeuestMergedDetails instanceof TeamPullRequestMergedDetailsAction) {
+                    LOGGER.info("Canceling previously triggered Job: " + run.getFullDisplayName());
+
+                    Executor executor = run.getExecutor();
+                    if (executor != null)
+                        executor.doStop();
+
+                    Queue.Item item = queue.getItem(run.getQueueId());
+                    if (item != null)
+                        queue.cancel(item);
+                }
+            }
+        }
     }
 
     static void contributeTeamBuildParameterActions(final Map<String, String> teamBuildParameters, final List<Action> actions) {


### PR DESCRIPTION
Deduplicate code paths used for feeding back status to VSTS/TFS.

Further, set the "name" and "genre" fields to sane values:

VSTS uses these fiels for configuration of branch policies. Empty
strings are not permitted, thus this feature was broken on the part of
tfs-plugin.

Use the Jenkins root-URL as 'genre' and the job-name as 'name'.