### PR TITLE
tell if branch is missing

### DIFF
--- a/tfs/src/main/java/hudson/plugins/tfs/TeamBuildEndpoint.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/TeamBuildEndpoint.java
@@ -262,6 +262,10 @@ public class TeamBuildEndpoint implements UnprotectedRootAction {
                         break;
                     }
                 }
+
+                if (job == null) {
+                    throw new IllegalArgumentException("Job " + jobName + " found but branch " + sourceBranch + " is missing");
+                }
             }
         }
 


### PR DESCRIPTION
Improve the error message if the job can be found but the source branch is missing