### PR TITLE
BuildCommand: abort a build only if it was caused by the same PR

### DIFF
--- a/tfs/src/main/java/hudson/plugins/tfs/model/BuildCommand.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/model/BuildCommand.java
@@ -226,7 +226,8 @@ public class BuildCommand extends AbstractCommand {
         for (Run run : allBuilds) {
             TeamPullRequestMergedDetailsAction cause = run.getAction(TeamPullRequestMergedDetailsAction.class);
             if (cause != null && run.isBuilding()) {
-                if (pullReqeuestMergedDetails instanceof TeamPullRequestMergedDetailsAction) {
+                if (cause instanceof TeamPullRequestMergedDetailsAction &&
+                        cause.gitPullRequest.getPullRequestId() == pullReqeuestMergedDetails.gitPullRequest.getPullRequestId()) {
                     LOGGER.info("Canceling previously triggered Job: " + run.getFullDisplayName());
 
                     Executor executor = run.getExecutor();


### PR DESCRIPTION
There was a bug that caused a running job, triggered by a merge-commit Webhook,
being canceled regardless of what the running job's build cause was.

This fixes the misbehavior by just canceling builds that have the same
Pullrequest as a build cause.