### PR TITLE
Don't add empty parent to the name in TFS StausAPI requests

### DIFF
--- a/tfs/src/main/java/hudson/plugins/tfs/model/TeamGitStatus.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/model/TeamGitStatus.java
@@ -62,7 +62,7 @@ public class TeamGitStatus {
         final String instanceUrl = StringUtils.stripEnd(Jenkins.getInstance().getRootUrl(), "/");
         final String parent = job.getParent().getFullName(); 
         String projectDisplayName = job.getDisplayName();
-        if(parent != null && parent.isEmpty()){
+        if(parent != null && !parent.isEmpty()){
             projectDisplayName = parent + "/" + job.getDisplayName();
         }
         return new GitStatusContext(projectDisplayName, instanceUrl);

--- a/tfs/src/main/java/hudson/plugins/tfs/model/TeamGitStatus.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/model/TeamGitStatus.java
@@ -27,6 +27,7 @@ public class TeamGitStatus {
         RESULT_TO_STATE = Collections.unmodifiableMap(resultToStatus);
     }
 
+    public Integer iterationId;
     public GitStatusState state;
     public String description;
     public String targetUrl;
@@ -55,6 +56,7 @@ public class TeamGitStatus {
         status.description = "Jenkins Job " + job.getDisplayName() + " queued";
         status.targetUrl = job.getAbsoluteUrl();
         status.context = getStatusContext(job);
+        status.iterationId = 9;
         return status;
     }
 

--- a/tfs/src/main/java/hudson/plugins/tfs/model/TeamGitStatus.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/model/TeamGitStatus.java
@@ -60,9 +60,9 @@ public class TeamGitStatus {
 
     private static GitStatusContext getStatusContext(@Nonnull final Job job) {
         final String instanceUrl = StringUtils.stripEnd(Jenkins.getInstance().getRootUrl(), "/");
-        final Boolean parent = job.getParent().getFullName(); 
+        final String parent = job.getParent().getFullName(); 
         String projectDisplayName = job.getDisplayName();
-        if(parent != ""){
+        if(parent != null && parent.isEmpty()){
             projectDisplayName = parent + "/" + job.getDisplayName();
         }
         return new GitStatusContext(projectDisplayName, instanceUrl);

--- a/tfs/src/main/java/hudson/plugins/tfs/model/TeamGitStatus.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/model/TeamGitStatus.java
@@ -47,7 +47,7 @@ public class TeamGitStatus {
         status.description = job.getDisplayName() + run.getDisplayName() + ": " + status.description;
         status.targetUrl = run.getAbsoluteUrl();
         status.context = getStatusContext(job);
-        status.iterationId = 9;
+        status.iterationId = 1;
         return status;
     }
 
@@ -57,7 +57,7 @@ public class TeamGitStatus {
         status.description = "Jenkins Job " + job.getDisplayName() + " queued";
         status.targetUrl = job.getAbsoluteUrl();
         status.context = getStatusContext(job);
-        status.iterationId = 9;
+        status.iterationId = 1;
         return status;
     }
 

--- a/tfs/src/main/java/hudson/plugins/tfs/model/TeamGitStatus.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/model/TeamGitStatus.java
@@ -47,6 +47,7 @@ public class TeamGitStatus {
         status.description = job.getDisplayName() + run.getDisplayName() + ": " + status.description;
         status.targetUrl = run.getAbsoluteUrl();
         status.context = getStatusContext(job);
+        status.iterationId = 9;
         return status;
     }
 

--- a/tfs/src/main/java/hudson/plugins/tfs/model/TeamGitStatus.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/model/TeamGitStatus.java
@@ -60,9 +60,13 @@ public class TeamGitStatus {
 
     private static GitStatusContext getStatusContext(@Nonnull final Job job) {
         final String instanceUrl = StringUtils.stripEnd(Jenkins.getInstance().getRootUrl(), "/");
-        final String projectDisplayName = job.getParent().getFullName() + "/" + job.getDisplayName();
+        final Boolean parent = job.getParent().getFullName(); 
+        String projectDisplayName = job.getDisplayName();
+        if(parent != ""){
+            projectDisplayName = parent + "/" + job.getDisplayName();
+        }
         return new GitStatusContext(projectDisplayName, instanceUrl);
-    }
+     }
 
     public String toJson() {
         final JSONObject jsonObject = JSONObject.fromObject(this);

--- a/tfs/src/test/java/hudson/plugins/tfs/model/TeamGitStatusTest.java
+++ b/tfs/src/test/java/hudson/plugins/tfs/model/TeamGitStatusTest.java
@@ -20,6 +20,7 @@ public class TeamGitStatusTest {
 
         final String expected =
             "{" +
+                "\"iterationId\":0," +
                 "\"state\":\"Pending\"," +
                 "\"description\":\"The build is in progress\"," +
                 "\"targetUrl\":\"https://ci.fabrikam.com/my-project/build/124\"," +


### PR DESCRIPTION
Don't add parent if it is empty in order to get away from situations where genre/name is http://<JenkinsUrl>//<ProjectName>