### PR TITLE
Persist Pull-Request details

### DIFF
--- a/tfs/src/main/java/hudson/plugins/tfs/TeamCompletedStatusPostBuildAction.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/TeamCompletedStatusPostBuildAction.java
@@ -1,4 +1,3 @@
-//CHECKSTYLE:OFF
 package hudson.plugins.tfs;
 
 import hudson.Extension;
@@ -37,19 +36,20 @@ public class TeamCompletedStatusPostBuildAction extends Notifier implements Simp
             @Nonnull final Launcher launcher,
             @Nonnull final TaskListener listener
     ) throws InterruptedException, IOException {
-        if (!TeamGlobalStatusAction.isApplicable(run)){
+        if (!TeamGlobalStatusAction.isApplicable(run)) {
             perform(run, listener);
         }
     }
 
-    public void perform(final @Nonnull Run<?, ?> run, final @Nonnull TaskListener listener) {
+    /**
+     * Perform the build step.
+     */
+    public void perform(@Nonnull final Run<?, ?> run, @Nonnull final TaskListener listener) {
         try {
             TeamStatus.createFromRun(run, listener, getDisplayName());
-        }
-        catch (final IllegalArgumentException e) {
+        } catch (final IllegalArgumentException e) {
             listener.error(e.getMessage());
-        }
-        catch (final Exception e) {
+        } catch (final Exception e) {
             e.printStackTrace(listener.error("Error while trying to update completion status in TFS/Team Services"));
         }
     }
@@ -59,12 +59,17 @@ public class TeamCompletedStatusPostBuildAction extends Notifier implements Simp
         return descriptor.getDisplayName();
     }
 
+    /**
+     * We don't need the outcome of any previous builds for this step.
+     */
     @Override
     public BuildStepMonitor getRequiredMonitorService() {
-        // we don't need the outcome of any previous builds for this step
         return BuildStepMonitor.NONE;
     }
 
+    /**
+     * Class descriptor.
+     */
     @Extension
     public static class DescriptorImpl extends BuildStepDescriptor<Publisher> {
 

--- a/tfs/src/main/java/hudson/plugins/tfs/TeamPullRequestMergedDetailsAction.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/TeamPullRequestMergedDetailsAction.java
@@ -7,7 +7,8 @@ import com.microsoft.visualstudio.services.webapi.model.ResourceRef;
 import hudson.model.Action;
 import hudson.model.Run;
 import hudson.plugins.tfs.model.GitPullRequestEx;
-import hudson.plugins.tfs.model.GitPushEvent;
+import hudson.plugins.tfs.model.GitPullRequestWrapper;
+import hudson.plugins.tfs.model.GitRepositoryWrapper;
 import hudson.plugins.tfs.util.UriHelper;
 import org.kohsuke.stapler.export.Exported;
 import org.kohsuke.stapler.export.ExportedBean;
@@ -29,6 +30,7 @@ public class TeamPullRequestMergedDetailsAction implements Action, Serializable 
     public String message;
     public String detailedMessage;
     public String collectionUri;
+    public GitPullRequestWrapper gitPullRequestWrapper;
 
     public TeamPullRequestMergedDetailsAction() {
 
@@ -39,6 +41,7 @@ public class TeamPullRequestMergedDetailsAction implements Action, Serializable 
         this.message = message;
         this.detailedMessage = detailedMessage;
         this.collectionUri = collectionUri;
+        this.gitPullRequestWrapper = new GitPullRequestWrapper(gitPullRequest);
     }
 
     public static URI addWorkItemsForRun(final Run<?, ?> run, final List<ResourceRef> destination) {
@@ -81,6 +84,9 @@ public class TeamPullRequestMergedDetailsAction implements Action, Serializable 
 
     @Exported
     public ResourceRef[] getWorkItems() {
+        if (gitPullRequest == null)
+            return null;
+
         return gitPullRequest.getWorkItemRefs();
     }
 
@@ -92,15 +98,14 @@ public class TeamPullRequestMergedDetailsAction implements Action, Serializable 
 
     @Exported
     public String getPullRequestUrl() {
-        final GitRepository repository = gitPullRequest.getRepository();
+        final GitRepositoryWrapper repository = gitPullRequestWrapper.repository;
         final URI collectionUri = URI.create(this.collectionUri);
-        final TeamProjectReference project = repository.getProject();
         final URI pullRequestUrl = UriHelper.join(collectionUri,
-                project.getName(),
+                repository.projectName,
                 "_git",
-                repository.getName(),
+                repository.name,
                 "pullrequest",
-                gitPullRequest.getPullRequestId()
+                gitPullRequestWrapper.pullRequestId
         );
         final String result = pullRequestUrl.toString();
         return result;

--- a/tfs/src/main/java/hudson/plugins/tfs/TeamUpdateWorkItemPostBuildAction.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/TeamUpdateWorkItemPostBuildAction.java
@@ -40,6 +40,13 @@ public class TeamUpdateWorkItemPostBuildAction extends Notifier implements Simpl
             @Nonnull final Launcher launcher,
             @Nonnull final TaskListener listener
     ) throws InterruptedException, IOException {
+        perform(run, listener);
+    }
+
+    /**
+     * Perform the build step.
+     */
+    public void perform(@Nonnull final Run<?, ?> run, final TaskListener listener) {
         try {
             final String absoluteUrl = run.getAbsoluteUrl();
             final ArrayList<ResourceRef> workItems = new ArrayList<ResourceRef>();

--- a/tfs/src/main/java/hudson/plugins/tfs/listeners/JenkinsRunListener.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/listeners/JenkinsRunListener.java
@@ -7,6 +7,7 @@ import hudson.model.listeners.RunListener;
 
 import hudson.plugins.tfs.TeamCompletedStatusPostBuildAction;
 import hudson.plugins.tfs.TeamPendingStatusBuildStep;
+import hudson.plugins.tfs.TeamUpdateWorkItemPostBuildAction;
 import hudson.plugins.tfs.UnsupportedIntegrationAction;
 
 import javax.annotation.Nonnull;
@@ -44,8 +45,10 @@ public class JenkinsRunListener extends RunListener<Run> {
     public void onCompleted(final Run run, @Nonnull final TaskListener listener) {
         log.info("onCompleted: " + run.toString());
         if (UnsupportedIntegrationAction.isSupported(run, listener)) {
-            final TeamCompletedStatusPostBuildAction step = new TeamCompletedStatusPostBuildAction();
-            step.perform(run, listener);
+            final TeamUpdateWorkItemPostBuildAction updateWorkItemStep = new TeamUpdateWorkItemPostBuildAction();
+            updateWorkItemStep.perform(run, listener);
+            final TeamCompletedStatusPostBuildAction completedStep = new TeamCompletedStatusPostBuildAction();
+            completedStep.perform(run, listener);
         }
     }
 }

--- a/tfs/src/main/java/hudson/plugins/tfs/model/GitPullRequestWrapper.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/model/GitPullRequestWrapper.java
@@ -1,0 +1,44 @@
+//CHECKSTYLE:OFF
+package hudson.plugins.tfs.model;
+
+import org.kohsuke.stapler.export.ExportedBean;
+
+import java.io.Serializable;
+import java.util.Date;
+
+@ExportedBean(defaultVisibility = 999)
+public class GitPullRequestWrapper implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    public String createdBy;
+    public Date creationDate;
+    public String description;
+    public int pullRequestId;
+    public String sourceRefName;
+    public String targetRefName;
+    public String title;
+    public String url;
+    public ResourceRefWrapper[] workItemRefs;
+    public GitRepositoryWrapper repository;
+
+    public GitPullRequestWrapper(final GitPullRequestEx gitPullRequest) {
+        createdBy = gitPullRequest.getCreatedBy().getDisplayName();
+        creationDate = gitPullRequest.getCreationDate();
+        description = gitPullRequest.getDescription();
+        pullRequestId = gitPullRequest.getPullRequestId();
+        sourceRefName = gitPullRequest.getSourceRefName();
+        targetRefName = gitPullRequest.getTargetRefName();
+        title = gitPullRequest.getTitle();
+        url = gitPullRequest.getUrl();
+
+        if (gitPullRequest.getWorkItemRefs() != null) {
+            ResourceRefWrapper[] workItems = new ResourceRefWrapper[gitPullRequest.getWorkItemRefs().length];
+            for (int i = 0; i < gitPullRequest.getWorkItemRefs().length; i++) {
+                workItems[i] = new ResourceRefWrapper(gitPullRequest.getWorkItemRefs()[i]);
+            }
+            workItemRefs = workItems;
+        }
+
+        repository = new GitRepositoryWrapper(gitPullRequest.getRepository());
+    }
+}

--- a/tfs/src/main/java/hudson/plugins/tfs/model/GitRepositoryWrapper.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/model/GitRepositoryWrapper.java
@@ -1,0 +1,36 @@
+//CHECKSTYLE:OFF
+package hudson.plugins.tfs.model;
+
+import com.microsoft.teamfoundation.sourcecontrol.webapi.model.GitRepository;
+import org.kohsuke.stapler.export.ExportedBean;
+
+import java.io.Serializable;
+
+@ExportedBean(defaultVisibility = 999)
+public class GitRepositoryWrapper implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    public String defaultBranch;
+    public String name;
+    public String projectAbbreviation;
+    public String projectDescription;
+    public String projectName;
+    public String projectUrl;
+    public String remoteUrl;
+    public String url;
+
+    GitRepositoryWrapper() {
+
+    }
+
+    GitRepositoryWrapper(GitRepository gitRepository) {
+        defaultBranch = gitRepository.getDefaultBranch();
+        name = gitRepository.getName();
+        projectAbbreviation = gitRepository.getProject().getAbbreviation();
+        projectDescription = gitRepository.getProject().getDescription();
+        projectName = gitRepository.getProject().getName();
+        projectUrl = gitRepository.getProject().getUrl();
+        remoteUrl = gitRepository.getRemoteUrl();
+        url = gitRepository.getUrl();
+    }
+}

--- a/tfs/src/main/java/hudson/plugins/tfs/model/ResourceRefWrapper.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/model/ResourceRefWrapper.java
@@ -1,0 +1,24 @@
+//CHECKSTYLE:OFF
+package hudson.plugins.tfs.model;
+
+import com.microsoft.visualstudio.services.webapi.model.ResourceRef;
+import org.kohsuke.stapler.export.ExportedBean;
+
+import java.io.Serializable;
+
+@ExportedBean(defaultVisibility = 999)
+public class ResourceRefWrapper implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    public String id;
+    public String url;
+
+    ResourceRefWrapper() {
+
+    }
+
+    ResourceRefWrapper(ResourceRef resourceRef) {
+        id = resourceRef.getId();
+        url = resourceRef.getUrl();
+    }
+}

--- a/tfs/src/main/resources/hudson/plugins/tfs/TeamPullRequestMergedDetailsAction/index.jelly
+++ b/tfs/src/main/resources/hudson/plugins/tfs/TeamPullRequestMergedDetailsAction/index.jelly
@@ -6,19 +6,19 @@
 
         <dl>
             <dt>Pull request</dt>
-            <dd><a href="${it.pullRequestUrl}">#${it.gitPullRequest.pullRequestId}</a>: '${it.gitPullRequest.title}', created by ${it.gitPullRequest.createdBy.displayName}</dd>
+            <dd><a href="${it.pullRequestUrl}">#${it.gitPullRequestWrapper.pullRequestId}</a>: '${it.gitPullRequestWrapper.title}', created by ${it.gitPullRequestWrapper.createdBy}</dd>
 
             <dt>Description</dt>
-            <dd><pre>${it.gitPullRequest.description}</pre></dd>
+            <dd><pre>${it.gitPullRequestWrapper.description}</pre></dd>
 
             <dt>Message</dt>
             <dd><pre>${it.detailedMessage}</pre></dd>
 
             <dt>Git repository</dt>
-            <dd><a href="${it.gitPullRequest.repository.remoteUrl}">${it.gitPullRequest.repository.name}</a></dd>
+            <dd><a href="${it.gitPullRequestWrapper.repository.remoteUrl}">${it.gitPullRequestWrapper.repository.name}</a></dd>
 
             <dt>Project</dt>
-            <dd>${it.gitPullRequest.repository.project.name}</dd>
+            <dd>${it.gitPullRequestWrapper.repository.projectName}</dd>
 
             <j:if test="${it.hasWorkItems()}">
                 <dt>Associated work items</dt>

--- a/tfs/src/main/resources/hudson/plugins/tfs/TeamPullRequestMergedDetailsAction/summary.jelly
+++ b/tfs/src/main/resources/hudson/plugins/tfs/TeamPullRequestMergedDetailsAction/summary.jelly
@@ -4,7 +4,7 @@
     xmlns:f="/lib/form" xmlns:i="jelly:fmt">
     <t:summary icon="${it.iconFileName}">
 
-    Triggered by TFS/Team Services pull request <a href="${it.pullRequestUrl}">#${it.gitPullRequest.pullRequestId}</a>: '${it.gitPullRequest.title}', created by ${it.gitPullRequest.createdBy.displayName}
+    Triggered by TFS/Team Services pull request <a href="${it.pullRequestUrl}">#${it.gitPullRequestWrapper.pullRequestId}</a>: '${it.gitPullRequestWrapper.title}', created by ${it.gitPullRequestWrapper.createdBy}
     <j:if test="${it.hasWorkItems()}">
         <br />
         Associated work items:


### PR DESCRIPTION
Make sure to save the pull-request trigger details persistently for being able
to still display them after restarting Jenkins.

Fixes: JENKINS-54883