### PR TITLE
TeamStatus: Fix status posting for PRs and commits

### DIFF
--- a/tfs/src/main/java/hudson/plugins/tfs/model/AbstractHookEvent.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/model/AbstractHookEvent.java
@@ -145,12 +145,10 @@ public abstract class AbstractHookEvent {
                     final CauseAction causeAction = new CauseAction(cause);
                     final Action[] actionArray = ActionHelper.create(actionsWithSafeParams, causeAction);
                     scmTriggerItem.scheduleBuild2(quietPeriod, actionArray);
-                    if (gitCodePushedEventArgs instanceof PullRequestMergeCommitCreatedEventArgs) {
-                        try {
-                            TeamStatus.createFromJob((PullRequestMergeCommitCreatedEventArgs) gitCodePushedEventArgs, job);
-                        } catch (IOException ex) {
-                            LOGGER.warning("Could not create TeamStatus: " + ex.toString());
-                        }
+                    try {
+                        TeamStatus.createFromJob(gitCodePushedEventArgs, job);
+                    } catch (IOException ex) {
+                        LOGGER.warning("Could not create TeamStatus: " + ex.toString());
                     }
 
                     return new TeamEventsEndpoint.ScheduledResponseContributor(project);

--- a/tfs/src/main/java/hudson/plugins/tfs/model/GitPushEvent.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/model/GitPushEvent.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.microsoft.teamfoundation.core.webapi.model.TeamProjectReference;
 import com.microsoft.teamfoundation.sourcecontrol.webapi.model.GitCommitRef;
 import com.microsoft.teamfoundation.sourcecontrol.webapi.model.GitPush;
+import com.microsoft.teamfoundation.sourcecontrol.webapi.model.GitRefUpdate;
 import com.microsoft.teamfoundation.sourcecontrol.webapi.model.GitRepository;
 import com.microsoft.visualstudio.services.webapi.model.IdentityRef;
 import hudson.model.Action;
@@ -102,11 +103,18 @@ public class GitPushEvent extends AbstractHookEvent {
 
     static String determineCommit(final GitPush gitPush) {
         final List<GitCommitRef> commits = gitPush.getCommits();
-        if (commits == null || commits.size() < 1) {
-            return null;
+        if (commits != null && commits.size() > 0) {
+            final GitCommitRef commit = commits.get(0);
+            return commit.getCommitId();
         }
-        final GitCommitRef commit = commits.get(0);
-        return commit.getCommitId();
+
+        final List<GitRefUpdate> refs = gitPush.getRefUpdates();
+        if (refs != null && refs.size() > 0) {
+            final GitRefUpdate ref = refs.get(0);
+            return ref.getNewObjectId();
+        }
+
+        return null;
     }
 
     static String determinePushedBy(final GitPush gitPush) {


### PR DESCRIPTION
Due to some misasumptions about the ways the tfs-plugin can trigger a
job, there was a too early (and duplicated) check that caused calling
TeamStatus.addStatus with a null-pointer.

This also fixes the status posting for commits.

Fixes: JENKINS-54569