### PR TITLE
Implement PR iteration status for generic build trigger

### DIFF
--- a/tfs/src/main/java/hudson/plugins/tfs/model/BuildCommand.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/model/BuildCommand.java
@@ -27,6 +27,7 @@ import hudson.plugins.tfs.UnsupportedIntegrationAction;
 import hudson.plugins.tfs.model.servicehooks.Event;
 import hudson.plugins.tfs.util.ActionHelper;
 import hudson.plugins.tfs.util.MediaType;
+import hudson.plugins.tfs.util.TeamRestClient;
 import hudson.util.RunList;
 import jenkins.model.Jenkins;
 import jenkins.util.TimeDuration;
@@ -143,6 +144,14 @@ public class BuildCommand extends AbstractCommand {
                 final String message = event.getMessage().getText();
                 final String detailedMessage = event.getDetailedMessage().getText();
                 final Action teamPullRequestMergedDetailsAction = new TeamPullRequestMergedDetailsAction(gitPullRequest, message, detailedMessage, args.collectionUri.toString());
+                if (gitPullRequest.getSupportsIterations()) {
+                    try {
+                        final TeamRestClient client = new TeamRestClient(args.collectionUri);
+                        args.iterationId = client.getPullRequestIteration(args);
+                    } catch (IOException e) {
+                        e.printStackTrace();
+                    }
+                }
                 actions.add(teamPullRequestMergedDetailsAction);
                 TeamGlobalStatusAction.addIfApplicable(actions);
             }

--- a/tfs/src/main/java/hudson/plugins/tfs/model/GitPullRequestEx.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/model/GitPullRequestEx.java
@@ -10,7 +10,22 @@ import java.util.Arrays;
  * by extending {@link GitPullRequest}.
  */
 public class GitPullRequestEx extends GitPullRequest {
+    private boolean supportsIterations;
     private ResourceRef[] workItemRefs;
+
+    /**
+     * Returns iteration support.
+     */
+    public boolean getSupportsIterations() {
+        return supportsIterations;
+    }
+
+    /**
+     * Sets if iterations are supported.
+     */
+    public void setSupportsIterations(final boolean supportsIterations) {
+        this.supportsIterations = supportsIterations;
+    }
 
     /**
      * Returns the work item references.

--- a/tfs/src/main/java/hudson/plugins/tfs/model/GitPullRequestIteration.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/model/GitPullRequestIteration.java
@@ -1,0 +1,10 @@
+//CHECKSTYLE:OFF
+package hudson.plugins.tfs.model;
+
+import com.microsoft.teamfoundation.sourcecontrol.webapi.model.GitCommitRef;
+
+public class GitPullRequestIteration {
+    public int id;
+    public GitCommitRef sourceRefCommit;
+    public GitCommitRef targetRefCommit;
+}

--- a/tfs/src/main/java/hudson/plugins/tfs/model/GitPullRequestMergedEvent.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/model/GitPullRequestMergedEvent.java
@@ -110,6 +110,8 @@ public class GitPullRequestMergedEvent extends GitPushEvent {
         final String pushedBy = determineCreatedBy(gitPullRequest);
         final int pullRequestId = gitPullRequest.getPullRequestId();
         final String targetBranch = determineTargetBranch(gitPullRequest);
+        final String targetCommit = gitPullRequest.getLastMergeTargetCommit().getCommitId();
+        final String sourceCommit = gitPullRequest.getLastMergeSourceCommit().getCommitId();
 
         final PullRequestMergeCommitCreatedEventArgs args = new PullRequestMergeCommitCreatedEventArgs();
         args.collectionUri = collectionUri;
@@ -120,6 +122,8 @@ public class GitPullRequestMergedEvent extends GitPushEvent {
         args.pushedBy = pushedBy;
         args.pullRequestId = pullRequestId;
         args.targetBranch = targetBranch;
+        args.targetCommit = targetCommit;
+        args.sourceCommit = sourceCommit;
         return args;
     }
 }

--- a/tfs/src/main/java/hudson/plugins/tfs/model/ListOfGitPullRequestIteration.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/model/ListOfGitPullRequestIteration.java
@@ -1,0 +1,9 @@
+//CHECKSTYLE:OFF
+package hudson.plugins.tfs.model;
+
+import java.util.List;
+
+public class ListOfGitPullRequestIteration {
+    public int count;
+    public List<GitPullRequestIteration> value;
+}

--- a/tfs/src/main/java/hudson/plugins/tfs/model/PullRequestMergeCommitCreatedEventArgs.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/model/PullRequestMergeCommitCreatedEventArgs.java
@@ -2,8 +2,10 @@
 package hudson.plugins.tfs.model;
 
 public class PullRequestMergeCommitCreatedEventArgs extends GitCodePushedEventArgs {
+    private static final long serialVersionUID = 1L;
 
     public int pullRequestId;
     public int iterationId = -1;
-
+    public String sourceCommit;
+    public String targetCommit;
 }

--- a/tfs/src/main/java/hudson/plugins/tfs/util/TeamRestClient.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/util/TeamRestClient.java
@@ -9,10 +9,12 @@ import com.microsoft.visualstudio.services.webapi.patch.Operation;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.plugins.tfs.TeamCollectionConfiguration;
 import hudson.plugins.tfs.model.GitCodePushedEventArgs;
+import hudson.plugins.tfs.model.GitPullRequestIteration;
 import hudson.plugins.tfs.model.HttpMethod;
 import hudson.plugins.tfs.model.JobCompletionEventArgs;
 import hudson.plugins.tfs.model.JsonPatchOperation;
 import hudson.plugins.tfs.model.Link;
+import hudson.plugins.tfs.model.ListOfGitPullRequestIteration;
 import hudson.plugins.tfs.model.ListOfGitRepositories;
 import hudson.plugins.tfs.model.PullRequestMergeCommitCreatedEventArgs;
 import hudson.plugins.tfs.model.Server;
@@ -329,4 +331,24 @@ public class TeamRestClient {
         request(Void.class, HttpMethod.POST, requestUri, json, headers);
     }
 
+    public int getPullRequestIteration(PullRequestMergeCommitCreatedEventArgs args) throws IOException {
+        final QueryString qs = new QueryString(API_VERSION, "4.1");
+        final URI requestUri = UriHelper.join(
+                collectionUri, args.projectId,
+                "_apis", "git",
+                "repositories", args.repoId,
+                "pullRequests", args.pullRequestId,
+                "iterations",
+                qs);
+
+        ListOfGitPullRequestIteration list = request(ListOfGitPullRequestIteration.class, HttpMethod.GET, requestUri, null);
+
+        for (GitPullRequestIteration iteration : list.value) {
+            if (iteration.sourceRefCommit.getCommitId().equals(args.sourceCommit)) {
+                return iteration.id;
+            }
+        }
+
+        return -1;
+    }
 }


### PR DESCRIPTION
The REST API does not make this particularly easy, so rely on comparing
the team-events source commit with the iteration statuses source commit.

Fixes: JENKINS-51973