### PR TITLE
Account for bad repo path while searching projects

### DIFF
--- a/tfs/src/main/java/hudson/plugins/tfs/model/AbstractHookEvent.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/model/AbstractHookEvent.java
@@ -299,9 +299,14 @@ public abstract class AbstractHookEvent {
                     for (final RemoteConfig repository : git.getRepositories()) {
                         boolean repositoryMatches = false;
                         for (final URIish remoteURL : repository.getURIs()) {
-                            if (UriHelper.areSameGitRepo(uri, remoteURL)) {
-                                repositoryMatches = true;
-                                break;
+                            try {
+                                if (UriHelper.areSameGitRepo(uri, remoteURL)) {
+                                    repositoryMatches = true;
+                                    break;
+                                }
+                            }catch (Exception e) {
+                                LOGGER.fine("Error parsing " + remoteURL.toString() + " into URI");
+                                continue;
                             }
                         }
 


### PR DESCRIPTION
Any projects with Git repo paths that can not be converting to a URI stop all other repos from being scanned

The exception looks like the following

java.lang.IllegalArgumentException: Illegal character in opaque part at index 2: c:\repo\test_repo
        at java.net.URI.create(URI.java:852)
        at hudson.plugins.tfs.util.UriHelper.areSameGitRepo(UriHelper.java:133)
        at hudson.plugins.tfs.model.AbstractHookEvent.pollOrQueueFromEvent(AbstractHookEvent.java:302)
        at hudson.plugins.tfs.model.GitPushEvent.perform(GitPushEvent.java:55)
        at hudson.plugins.tfs.TeamEventsEndpoint.innerDispatch(TeamEventsEndpoint.java:171)
        at hudson.plugins.tfs.TeamEventsEndpoint.dispatch(TeamEventsEndpoint.java:141)
        at hudson.plugins.tfs.TeamEventsEndpoint.doGitPush(TeamEventsEndpoint.java:216)