### PR TITLE
 prevent nullpointer in SafeParametersAction

### DIFF
--- a/tfs/src/main/java/hudson/plugins/tfs/SafeParametersAction.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/SafeParametersAction.java
@@ -24,6 +24,7 @@ public class SafeParametersAction extends ParametersAction {
     private List<ParameterValue> parameters;
 
     public SafeParametersAction(final List<ParameterValue> parameters) {
+        super(parameters);
         this.parameters = parameters;
     }
 


### PR DESCRIPTION
In Jenkins 1.642 the following NullPointerException happens when pushing an event

SEVERE: Error while performing reaction to 'gitPush' event.
java.lang.NullPointerException
	at hudson.model.ParametersAction.buildEnvVars(ParametersAction.java:87)
	at hudson.plugins.git.util.GitUtils.addEnvironmentContributingActionsValues(GitUtils.java:292)
	at hudson.plugins.git.util.GitUtils.getPollEnvironment(GitUtils.java:278)
	at hudson.plugins.git.GitSCM.compareRemoteRevisionWithImpl(GitSCM.java:599)
	at hudson.plugins.git.GitSCM.compareRemoteRevisionWith(GitSCM.java:574)
	at hudson.scm.SCM.compareRemoteRevisionWith(SCM.java:381)
	at hudson.scm.SCM.poll(SCM.java:398)
	at hudson.model.AbstractProject._poll(AbstractProject.java:1453)
	at hudson.model.AbstractProject.poll(AbstractProject.java:1356)
	at hudson.plugins.tfs.TeamPushTrigger$Runner.runPolling(TeamPushTrigger.java:109)
	at hudson.plugins.tfs.TeamPushTrigger$Runner.run(TeamPushTrigger.java:142)

Later versions of Jenkins have deprecated buildEnvVars and also check for a NullPointer to prevent this.

Tracking it down shows the problem is ParemtersAction this.paremters is null.  SafeParametersAction was not correctly calling its parent constructor to pass in the parameters list.