### PR TITLE
Add support for dev.azure.com style URLs

### DIFF
--- a/tfs/src/main/java/hudson/plugins/tfs/TeamCollectionConfiguration.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/TeamCollectionConfiguration.java
@@ -172,7 +172,7 @@ public class TeamCollectionConfiguration extends AbstractDescribableImpl<TeamCol
     }
 
     static FormValidation checkTeamServices(final URI uri) {
-        if (UriHelper.hasPath(uri)) {
+        if (uri.getHost().contains(".visualstudio.com") && UriHelper.hasPath(uri)) {
             return FormValidation.error("A Team Services collection URL must have an empty path.");
         }
         return FormValidation.ok();
@@ -196,7 +196,8 @@ public class TeamCollectionConfiguration extends AbstractDescribableImpl<TeamCol
     }
 
     public static boolean isTeamServices(final String hostName) {
-        return StringHelper.endsWithIgnoreCase(hostName, ".visualstudio.com");
+        return StringHelper.endsWithIgnoreCase(hostName, ".visualstudio.com") ||
+            hostName.toLowerCase().contains("dev.azure.com");
     }
 
     static FormValidation testConnection(final String collectionUri, final StandardUsernamePasswordCredentials credentials) throws IOException {

--- a/tfs/src/test/java/hudson/plugins/tfs/TeamCollectionConfigurationTest.java
+++ b/tfs/src/test/java/hudson/plugins/tfs/TeamCollectionConfigurationTest.java
@@ -91,4 +91,11 @@ public class TeamCollectionConfigurationTest {
         Assert.assertEquals(FormValidation.Kind.ERROR, actual.kind);
     }
 
+    @Test public void checkTeamServices_azdoUrl() throws Exception {
+        final URI input = URI.create("https://dev.azure.com/fabrikam-fiber-inc");
+
+        final FormValidation actual = TeamCollectionConfiguration.checkTeamServices(input);
+
+        Assert.assertEquals(FormValidation.Kind.OK, actual.kind);
+    }
 }


### PR DESCRIPTION
Using the old visualstudio.com style URL still work to find and configure the project collection, but when trying to set up a Post-Build service callback back to Azure DevOps, the plugin currently fails with the following error:
`ERROR: There is no team project collection configured for the URL 'https://dev.azure.com/<collection>/'.
Please go to Jenkins > Manage Jenkins > Configure System and then add a Team Project Collection with a Collection URL of 'https://dev.azure.com/<collection>/'.`

Seems like at some level, the server must respond with it's own URL which is different than what the plugin expects. On top of that, new users of Azure DevOps may not know about the old URL format and putting in `dev.azure.com/<collection name>` gives a validation error.

This PR modified the validation methods that check the hostname for *.visualstudio.com to also accept dev.azure.com as a hostname. 