### PR TITLE
Encoding payload string to UTF-8 before publishing the evennt.

### DIFF
--- a/tfs/src/main/java/hudson/plugins/tfs/rm/ReleaseWebHookAction.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/rm/ReleaseWebHookAction.java
@@ -113,7 +113,7 @@ public class ReleaseWebHookAction extends Notifier implements Serializable {
             request.addHeader("X-Jenkins-Signature", signature);
         }
 
-        request.setEntity(new StringEntity(payload));
+        request.setEntity(new StringEntity(new String(payload.getBytes("UTF-8"))));
         final HttpResponse response = client.execute(request);
         final int statusCode = response.getStatusLine().getStatusCode();
 


### PR DESCRIPTION
The payload checksum was calculated after converting to UTF-8 string.
If we don't convert the payload as well, the checksum won't match.