### PR TITLE
Fix QueryHistory always returning latest changeset

### DIFF
--- a/tfs/src/main/java/hudson/plugins/tfs/commands/RemoteChangesetVersionCommand.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/commands/RemoteChangesetVersionCommand.java
@@ -70,7 +70,7 @@ public class RemoteChangesetVersionCommand extends AbstractCallableCommand<Integ
                 RecursionType.FULL,
                 null /* user */,
                 null,
-                null,
+                versionSpec,
                 1     /* maxCount */,
                 false /* includeFileDetails */,
                 true  /* slotMode */,

--- a/tfs/src/test/java/hudson/plugins/tfs/commands/RemoteChangesetVersionCommandTest.java
+++ b/tfs/src/test/java/hudson/plugins/tfs/commands/RemoteChangesetVersionCommandTest.java
@@ -65,7 +65,7 @@ public class RemoteChangesetVersionCommandTest extends AbstractCallableCommandTe
                 isA(RecursionType.class),
                 (String) isNull(),
                 (VersionSpec) isNull(),
-                (VersionSpec) isNull(),
+                isA(VersionSpec.class),
                 anyInt(),
                 anyBoolean(),
                 anyBoolean(),


### PR DESCRIPTION
When using VERSION_SPEC as a build parameter, the plugin should checkout the files as of that version. To do this QueryHistory is called on the version_spec, and the first changeset is returned.
The issue here is that if the project path references has been changed in newer changesets, the QueryHistory method, will return those as well, so the Plugin returns not the wanted changeset as defined by VERSION_SPEC, but the newest available changeset where changes where made to the path/project. 

This PR proposes to simply limit the upper range of the query to the versionspec. This makes it so that when we return the top element, it will at most be the wanted changeset. If the changeset does not exist it will fail.