### PR TITLE
Implemented switch for 'local' or 'server' workspaces.

### DIFF
--- a/tfs/src/main/java/hudson/plugins/tfs/TeamFoundationServerScm.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/TeamFoundationServerScm.java
@@ -86,6 +86,7 @@ public class TeamFoundationServerScm extends SCM {
     private final String projectPath;
     private Collection<String> cloakedPaths;
     private String localPath;
+    private boolean isLocalWorkspace;
     private final String workspaceName;
     @Deprecated private String userPassword;
     private Secret password;
@@ -169,6 +170,10 @@ public class TeamFoundationServerScm extends SCM {
         this.localPath = localPath;
     }
 
+    public boolean isLocalWorkspace() {
+        return isLocalWorkspace;
+    }
+
     public String getVersionSpec() {
         return versionSpec;
     }
@@ -231,6 +236,11 @@ public class TeamFoundationServerScm extends SCM {
     @DataBoundSetter
     public void setCloakedPaths(final String cloakedPaths) {
         this.cloakedPaths = splitCloakedPaths(cloakedPaths);
+    }
+
+    @DataBoundSetter
+    public void setIsLocalWorkspace(final boolean isLocalWorkspace) {
+        this.isLocalWorkspace = isLocalWorkspace;
     }
 
     // Bean properties END
@@ -312,7 +322,7 @@ public class TeamFoundationServerScm extends SCM {
     public void checkout(final Run<?, ?> build, final Launcher launcher, final FilePath workspaceFilePath, final TaskListener listener, final File changelogFile, final SCMRevisionState baseline) throws IOException, InterruptedException {
         Server server = createServer(launcher, listener, build);
         try {
-            WorkspaceConfiguration workspaceConfiguration = new WorkspaceConfiguration(server.getUrl(), getWorkspaceName(build, workspaceFilePath.toComputer()), getProjectPath(build), getCloakedPaths(build), getLocalPath());
+            WorkspaceConfiguration workspaceConfiguration = new WorkspaceConfiguration(server.getUrl(), getWorkspaceName(build, workspaceFilePath.toComputer()), getProjectPath(build), getCloakedPaths(build), getLocalPath(), isLocalWorkspace());
             final Run<?, ?> previousBuild = build.getPreviousBuild();
             // Check if the configuration has changed
             if (previousBuild != null) {
@@ -342,7 +352,7 @@ public class TeamFoundationServerScm extends SCM {
             final Project project = server.getProject(projPath);
             final int changeSet = recordWorkspaceChangesetVersion(build, listener, project, projPath, singleVersionSpec);
 
-            CheckoutAction action = new CheckoutAction(workspaceConfiguration.getWorkspaceName(), workspaceConfiguration.getProjectPath(), workspaceConfiguration.getCloakedPaths(), workspaceConfiguration.getWorkfolder(), isUseUpdate(), isUseOverwrite());
+            CheckoutAction action = new CheckoutAction(workspaceConfiguration.getWorkspaceName(), workspaceConfiguration.getProjectPath(), workspaceConfiguration.getCloakedPaths(), workspaceConfiguration.getWorkfolder(), isUseUpdate(), isUseOverwrite(), workspaceConfiguration.isLocalWorkspace());
             List<ChangeSet> list;
             if (StringUtils.isNotEmpty(singleVersionSpec)) {
                 list = action.checkoutBySingleVersionSpec(server, workspaceFilePath, singleVersionSpec);

--- a/tfs/src/main/java/hudson/plugins/tfs/commands/ListWorkspacesCommand.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/commands/ListWorkspacesCommand.java
@@ -26,7 +26,7 @@ public class ListWorkspacesCommand extends AbstractCallableCommand<List<Workspac
     private final boolean shouldLogWorkspaces;
 
     public interface WorkspaceFactory {
-        Workspace createWorkspace(String name, String computer, String owner, String comment);
+        Workspace createWorkspace(String name, String computer, String owner, String comment, boolean isLocalWorkspace);
     }
     
     public ListWorkspacesCommand(final ServerConfigurationProvider server) {
@@ -69,12 +69,14 @@ public class ListWorkspacesCommand extends AbstractCallableCommand<List<Workspac
             final String computer = sdkWorkspace.getComputer();
             final String ownerName = sdkWorkspace.getOwnerName();
             final String comment = Util.fixNull(sdkWorkspace.getComment());
+            final boolean isLocalWorkspace = sdkWorkspace.isLocalWorkspace();
 
             final Workspace workspace = new Workspace(
                     name,
                     computer,
                     ownerName,
-                    comment);
+                    comment,
+                    isLocalWorkspace);
             result.add(workspace);
         }
 
@@ -94,7 +96,8 @@ public class ListWorkspacesCommand extends AbstractCallableCommand<List<Workspac
                 parser.getColumn(0), 
                 parser.getColumn(2),
                 parser.getColumn(1),
-                Util.fixNull(parser.getColumn(3)));
+                Util.fixNull(parser.getColumn(3)),
+                false);
             list.add(workspace);            
         }
         return list;

--- a/tfs/src/main/java/hudson/plugins/tfs/commands/NewWorkspaceCommand.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/commands/NewWorkspaceCommand.java
@@ -33,13 +33,15 @@ public class NewWorkspaceCommand extends AbstractCallableCommand<Void, Exception
     private final String serverPath;
     private final Collection<String> cloakedPaths;
     private final String localPath;
+    private final boolean isLocalWorkspace;
 
-    public NewWorkspaceCommand(final ServerConfigurationProvider server, final String workspaceName, final String serverPath, Collection<String> cloakedPaths, final String localPath) {
+    public NewWorkspaceCommand(final ServerConfigurationProvider server, final String workspaceName, final String serverPath, Collection<String> cloakedPaths, final String localPath, boolean isLocalWorkspace) {
         super(server);
         this.workspaceName = workspaceName;
         this.serverPath = serverPath;
         this.cloakedPaths = cloakedPaths;
         this.localPath = localPath;
+        this.isLocalWorkspace = isLocalWorkspace;
     }
 
     public Callable<Void, Exception> getCallable() {
@@ -84,7 +86,7 @@ public class NewWorkspaceCommand extends AbstractCallableCommand<Void, Exception
                 VersionControlConstants.AUTHENTICATED_USER,
                 VersionControlConstants.AUTHENTICATED_USER,
                 null /* TODO: set comment to something nice/useful */,
-                WorkspaceLocation.SERVER /* TODO: pull request #33 adds LOCAL support */,
+                (isLocalWorkspace) ? WorkspaceLocation.LOCAL : WorkspaceLocation.SERVER,
                 WorkspaceOptions.NONE
         );
 

--- a/tfs/src/main/java/hudson/plugins/tfs/model/Workspace.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/model/Workspace.java
@@ -12,16 +12,18 @@ public class Workspace implements Serializable{
     private final String computer;
     private final String owner;
     private final String comment;
+    private final boolean isLocalWorkspace;
 
-    public Workspace(String name, String computer, String owner, String comment) {
+    public Workspace(String name, String computer, String owner, String comment, boolean isLocalWorkspace) {
         this.name = name;
         this.computer = computer;
         this.owner = owner;
         this.comment = comment;
+        this.isLocalWorkspace = isLocalWorkspace;
     }
     
     public Workspace(String name) {
-        this(name, "", "", "");
+        this(name, "", "", "", false);
     }
 
     public String getName() {
@@ -40,9 +42,13 @@ public class Workspace implements Serializable{
         return comment;
     }
 
+	public boolean isLocalWorkspace() {
+		return isLocalWorkspace;
+	}
+
     @Override
     public int hashCode() {
-        return new HashCodeBuilder(13, 27).append(name).append(owner).append(computer).toHashCode();
+        return new HashCodeBuilder(13, 27).append(name).append(owner).append(computer).append(isLocalWorkspace).toHashCode();
     }
 
     @Override
@@ -56,6 +62,7 @@ public class Workspace implements Serializable{
         builder.append(this.name, other.name);
         builder.append(this.owner, other.owner);
         builder.append(this.computer, other.computer);
+        builder.append(this.isLocalWorkspace, other.isLocalWorkspace);
         return builder.isEquals();
     }
 }

--- a/tfs/src/main/java/hudson/plugins/tfs/model/WorkspaceConfiguration.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/model/WorkspaceConfiguration.java
@@ -1,6 +1,7 @@
 //CHECKSTYLE:OFF
 package hudson.plugins.tfs.model;
 
+
 import java.io.Serializable;
 import java.util.Collection;
 
@@ -12,7 +13,6 @@ import hudson.model.InvisibleAction;
  * @author Erik Ramfelt, redsolo
  */
 public class WorkspaceConfiguration extends InvisibleAction implements Serializable {
-
     private static final long serialVersionUID = 1L;
     
     private final String workspaceName;
@@ -21,14 +21,16 @@ public class WorkspaceConfiguration extends InvisibleAction implements Serializa
     private final String serverUrl;
     private boolean workspaceExists;
     private Collection<String> cloakedPaths;
+    private final boolean isLocalWorkspace;
 
-    public WorkspaceConfiguration(String serverUrl, String workspaceName, String projectPath, Collection<String> cloakedPaths, String workfolder) {
+    public WorkspaceConfiguration(String serverUrl, String workspaceName, String projectPath, Collection<String> cloakedPaths, String workfolder, boolean isLocalWorkspace) {
         this.workspaceName = workspaceName;
         this.workfolder = workfolder;
         this.projectPath = projectPath;
         this.serverUrl = serverUrl;
         this.workspaceExists = true;
         this.cloakedPaths = cloakedPaths;
+        this.isLocalWorkspace = isLocalWorkspace;
     }
 
     public WorkspaceConfiguration(WorkspaceConfiguration configuration) {
@@ -38,6 +40,7 @@ public class WorkspaceConfiguration extends InvisibleAction implements Serializa
         this.serverUrl = configuration.serverUrl;
         this.workspaceExists = configuration.workspaceExists;
         this.cloakedPaths = configuration.cloakedPaths;
+        this.isLocalWorkspace = configuration.isLocalWorkspace;
     }
 
     public String getWorkspaceName() {
@@ -68,6 +71,10 @@ public class WorkspaceConfiguration extends InvisibleAction implements Serializa
         return cloakedPaths;
     }
 
+    public boolean isLocalWorkspace() {
+        return isLocalWorkspace;
+    }
+
     @Override
     public int hashCode() {
         final int prime = 31;
@@ -78,6 +85,7 @@ public class WorkspaceConfiguration extends InvisibleAction implements Serializa
         result = prime * result + (workspaceExists ? 1231 : 1237);
         result = prime * result + ((workspaceName == null) ? 0 : workspaceName.hashCode());
         result = prime * result + ((cloakedPaths == null) ? 0 : cloakedPaths.hashCode());
+        result = prime * result + (isLocalWorkspace ? 1231 : 1237);
         return result;
     }
 
@@ -121,12 +129,14 @@ public class WorkspaceConfiguration extends InvisibleAction implements Serializa
             return false;
         else if (!cloakedPaths.containsAll(other.cloakedPaths))
             return false;
+        if (isLocalWorkspace != other.isLocalWorkspace)
+            return false;
         return true;
     }
 
     @Override
     public String toString() {
-        return String.format("WorkspaceConfiguration [projectPath=%s, serverUrl=%s, workfolder=%s, workspaceExists=%s, workspaceName=%s]", 
-                projectPath, serverUrl, workfolder, workspaceExists, workspaceName);
-    }    
+        return String.format("WorkspaceConfiguration [projectPath=%s, serverUrl=%s, workfolder=%s, workspaceExists=%s, workspaceName=%s, workspaceLocation=%s]", 
+                projectPath, serverUrl, workfolder, workspaceExists, workspaceName, isLocalWorkspace);
+    }
 }

--- a/tfs/src/main/java/hudson/plugins/tfs/model/Workspaces.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/model/Workspaces.java
@@ -104,8 +104,8 @@ public class Workspaces implements ListWorkspacesCommand.WorkspaceFactory {
      * @param localPath the path in the local filesystem to map
      * @return a workspace
      */
-    public Workspace newWorkspace(final String workspaceName, final String serverPath, Collection<String> cloakedPaths, final String localPath) {
-        NewWorkspaceCommand command = new NewWorkspaceCommand(server, workspaceName, serverPath, cloakedPaths, localPath);
+    public Workspace newWorkspace(final String workspaceName, final String serverPath, Collection<String> cloakedPaths, final String localPath, boolean isLocalWorkspace) {
+        NewWorkspaceCommand command = new NewWorkspaceCommand(server, workspaceName, serverPath, cloakedPaths, localPath, isLocalWorkspace);
         server.execute(command.getCallable());
         Workspace workspace = new Workspace(workspaceName);
         workspaces.put(workspaceName, workspace);
@@ -122,7 +122,7 @@ public class Workspaces implements ListWorkspacesCommand.WorkspaceFactory {
         server.execute(command.getCallable());
     }
 
-    public Workspace createWorkspace(String name, String computer, String owner, String comment) {
-        return new Workspace(name, computer, owner, comment);
+    public Workspace createWorkspace(String name, String computer, String owner, String comment, boolean isLocalWorkspace) {
+        return new Workspace(name, computer, owner, comment, isLocalWorkspace);
     }
 }

--- a/tfs/src/main/resources/hudson/plugins/tfs/TeamFoundationServerScm/config.jelly
+++ b/tfs/src/main/resources/hudson/plugins/tfs/TeamFoundationServerScm/config.jelly
@@ -25,6 +25,10 @@
 			<f:checkbox default="true"/>
 		</f:entry>
 
+		<f:entry field="isLocalWorkspace" title="Use local workspace" description="If checked, the workspace will be 'local'.">
+			<f:checkbox default="true"/>
+		</f:entry>
+
 	    <f:entry field="localPath" title="Local workfolder">
 	        <f:textbox default="."
 	             clazz="required" checkMessage="${%Local workfolder is mandatory, empty field will use job workspace as workfolder.}"/>

--- a/tfs/src/test/java/hudson/plugins/tfs/actions/CheckoutActionTest.java
+++ b/tfs/src/test/java/hudson/plugins/tfs/actions/CheckoutActionTest.java
@@ -66,12 +66,12 @@ public class CheckoutActionTest {
         prepareCommonMocks();
         when(project.getProjectPath()).thenReturn("project");
     	when(workspaces.exists("workspace")).thenReturn(true).thenReturn(false);
-        when(workspaces.newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class))).thenReturn(workspace);
+        when(workspaces.newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class), eq(false))).thenReturn(workspace);
     	when(workspaces.getWorkspace("workspace")).thenReturn(workspace);
     	
-        new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, ".", false, false).checkoutBySingleVersionSpec(server, hudsonWs, MY_LABEL);
+        new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, ".", false, false, false).checkoutBySingleVersionSpec(server, hudsonWs, MY_LABEL);
 
-        verify(workspaces).newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class));
+        verify(workspaces).newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class), eq(false));
     	verify(project).getFiles(isA(String.class), eq(MY_LABEL), eq(false));
     	verify(workspaces).deleteWorkspace(workspace);    	
     }
@@ -81,12 +81,12 @@ public class CheckoutActionTest {
         prepareCommonMocks();
         when(project.getProjectPath()).thenReturn("project");
         when(workspaces.exists("workspace")).thenReturn(true).thenReturn(false);
-        when(workspaces.newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class))).thenReturn(workspace);
+        when(workspaces.newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class), eq(false))).thenReturn(workspace);
         when(workspaces.getWorkspace("workspace")).thenReturn(workspace);
         
-        new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, ".", false, false).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
+        new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, ".", false, false, false).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
         
-        verify(workspaces).newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class));
+        verify(workspaces).newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class), eq(false));
         verify(project).getFiles(isA(String.class), eq("D2009-09-24T00:00:00Z"), eq(false));
         verify(workspaces).deleteWorkspace(workspace);
     }
@@ -96,11 +96,11 @@ public class CheckoutActionTest {
         prepareCommonMocks();
         when(project.getProjectPath()).thenReturn("project");
         when(workspaces.exists(new Workspace("workspace"))).thenReturn(false);
-        when(workspaces.newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class))).thenReturn(workspace);
+        when(workspaces.newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class), eq(false))).thenReturn(workspace);
         
-        new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, ".", true, false).checkoutBySingleVersionSpec(server, hudsonWs, MY_LABEL);
+        new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, ".", true, false, false).checkoutBySingleVersionSpec(server, hudsonWs, MY_LABEL);
         
-        verify(workspaces).newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class));
+        verify(workspaces).newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class), eq(false));
         verify(project).getFiles(isA(String.class), eq(MY_LABEL), eq(false));
         verify(workspaces, never()).deleteWorkspace(isA(Workspace.class));
     }
@@ -110,11 +110,11 @@ public class CheckoutActionTest {
         prepareCommonMocks();
         when(project.getProjectPath()).thenReturn("project");
     	when(workspaces.exists(new Workspace("workspace"))).thenReturn(false);
-        when(workspaces.newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class))).thenReturn(workspace);
+        when(workspaces.newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class), eq(false))).thenReturn(workspace);
     	
-        new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, ".", true, false).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
+        new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, ".", true, false, false).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
     	
-        verify(workspaces).newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class));
+        verify(workspaces).newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class), eq(false));
     	verify(project).getFiles(isA(String.class), eq("D2009-09-24T00:00:00Z"), eq(false));
     	verify(workspaces, never()).deleteWorkspace(isA(Workspace.class));
     }
@@ -126,10 +126,10 @@ public class CheckoutActionTest {
         when(workspaces.getWorkspace("workspace")).thenReturn(workspace);
         when(workspace.getComputer()).thenReturn("LocalComputer");
         
-        new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, ".", true, false).checkoutBySingleVersionSpec(server, hudsonWs, MY_LABEL);
+        new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, ".", true, false, false).checkoutBySingleVersionSpec(server, hudsonWs, MY_LABEL);
 
         verify(project).getFiles(isA(String.class), eq(MY_LABEL), eq(false));
-        verify(workspaces, never()).newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class));
+        verify(workspaces, never()).newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class), eq(false));
         verify(workspaces, never()).deleteWorkspace(isA(Workspace.class));
     }
     
@@ -140,10 +140,10 @@ public class CheckoutActionTest {
         when(workspaces.getWorkspace("workspace")).thenReturn(workspace);
         when(workspace.getComputer()).thenReturn("LocalComputer");
         
-        new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, ".", true, false).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
+        new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, ".", true, false, false).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
 
         verify(project).getFiles(isA(String.class), eq("D2009-09-24T00:00:00Z"), eq(false));
-        verify(workspaces, never()).newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class));
+        verify(workspaces, never()).newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class), eq(false));
         verify(workspaces, never()).deleteWorkspace(isA(Workspace.class));
     }
 
@@ -152,12 +152,12 @@ public class CheckoutActionTest {
         prepareCommonMocks();
         when(project.getProjectPath()).thenReturn("project");
         when(workspaces.exists("workspace")).thenReturn(true).thenReturn(false);
-        when(workspaces.newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class))).thenReturn(workspace);
+        when(workspaces.newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class), eq(false))).thenReturn(workspace);
         when(workspaces.getWorkspace("workspace")).thenReturn(workspace);
         
-        new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, ".", false, false).checkoutBySingleVersionSpec(server, hudsonWs, MY_LABEL);
+        new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, ".", false, false, false).checkoutBySingleVersionSpec(server, hudsonWs, MY_LABEL);
 
-        verify(workspaces).newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class));
+        verify(workspaces).newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class), eq(false));
         verify(project).getFiles(isA(String.class), eq(MY_LABEL), eq(false));
         verify(workspaces).deleteWorkspace(workspace);
     }
@@ -167,12 +167,12 @@ public class CheckoutActionTest {
         prepareCommonMocks();
         when(project.getProjectPath()).thenReturn("project");
         when(workspaces.exists("workspace")).thenReturn(true).thenReturn(false);
-        when(workspaces.newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class))).thenReturn(workspace);
+        when(workspaces.newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class), eq(false))).thenReturn(workspace);
         when(workspaces.getWorkspace("workspace")).thenReturn(workspace);
         
-        new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, ".", false, false).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
+        new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, ".", false, false, false).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
 
-        verify(workspaces).newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class));
+        verify(workspaces).newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class), eq(false));
         verify(project).getFiles(isA(String.class), eq("D2009-09-24T00:00:00Z"), eq(false));
         verify(workspaces).deleteWorkspace(workspace);
     }
@@ -184,7 +184,7 @@ public class CheckoutActionTest {
         when(workspaces.getWorkspace("workspace")).thenReturn(workspace);
         when(workspace.getComputer()).thenReturn("LocalComputer");
         
-        new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, ".", true, false).checkoutBySingleVersionSpec(server, hudsonWs, MY_LABEL);
+        new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, ".", true, false, false).checkoutBySingleVersionSpec(server, hudsonWs, MY_LABEL);
         
         verify(project, never()).getDetailedHistory(isA(Calendar.class), isA(Calendar.class));
     }
@@ -195,8 +195,8 @@ public class CheckoutActionTest {
         when(workspaces.exists("workspace")).thenReturn(true);
         when(workspaces.getWorkspace("workspace")).thenReturn(workspace);
         when(workspace.getComputer()).thenReturn("LocalComputer");
-        
-        new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, ".", true, false).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
+
+        new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, ".", true, false, false).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
         
         verify(project, never()).getDetailedHistory(isA(Calendar.class), isA(Calendar.class));
     }
@@ -210,7 +210,7 @@ public class CheckoutActionTest {
         when(workspace.getComputer()).thenReturn("LocalComputer");
         when(project.getDetailedHistory(isA(String.class))).thenReturn(list);
         
-        CheckoutAction action = new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, ".", true, false);
+        CheckoutAction action = new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, ".", true, false, false);
         List<ChangeSet> actualList = action.checkoutBySingleVersionSpec(server, hudsonWs, MY_LABEL);
         assertSame("The list from the detailed history, was not the same as returned from checkout", list, actualList);
         
@@ -226,7 +226,7 @@ public class CheckoutActionTest {
         when(workspace.getComputer()).thenReturn("LocalComputer");
         when(project.getDetailedHistoryWithoutCloakedPaths(isA(VersionSpec.class), isA(VersionSpec.class), anyCollection())).thenReturn(list);
 
-        CheckoutAction action = new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, ".", true, false);
+        CheckoutAction action = new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, ".", true, false, false);
         final Calendar startDate = Util.getCalendar(2008, 9, 24);
         final Calendar endDate = Util.getCalendar(2008, 10, 24);
         List<ChangeSet> actualList = action.checkout(server, hudsonWs, startDate, endDate);
@@ -245,9 +245,9 @@ public class CheckoutActionTest {
         
         prepareCommonMocks();
         when(workspaces.exists(new Workspace("workspace"))).thenReturn(false);
-        when(workspaces.newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class))).thenReturn(workspace);
+        when(workspaces.newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class), eq(false))).thenReturn(workspace);
         
-        new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, "tfs-ws", false, false).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
+        new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, "tfs-ws", false, false, false).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
         
         assertTrue("The local folder was removed", tfsWs.exists());
         assertEquals("The local TFS folder was not cleaned", 0, tfsWs.list((FileFilter)null).size());
@@ -263,9 +263,9 @@ public class CheckoutActionTest {
         
         prepareCommonMocks();
         when(workspaces.exists(new Workspace("workspace"))).thenReturn(false);
-        when(workspaces.newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class))).thenReturn(workspace);
+        when(workspaces.newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class), eq(false))).thenReturn(workspace);
         
-        new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, "tfs-ws", false, false).checkoutBySingleVersionSpec(server, hudsonWs, MY_LABEL);
+        new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, "tfs-ws", false, false, false).checkoutBySingleVersionSpec(server, hudsonWs, MY_LABEL);
         
         assertTrue("The local folder was removed", tfsWs.exists());
         assertEquals("The local TFS folder was not cleaned", 0, tfsWs.list((FileFilter)null).size());
@@ -283,7 +283,7 @@ public class CheckoutActionTest {
         when(workspaces.getWorkspace("workspace")).thenReturn(workspace);
         when(workspace.getComputer()).thenReturn("LocalComputer");
         
-        new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, "tfs-ws", true, false).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
+        new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, "tfs-ws", true, false, false).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
 
         assertTrue("The local folder was removed", tfsWs.exists());
         assertEquals("The TFS workspace path was cleaned", 1, hudsonWs.list((FileFilter)null).size());
@@ -296,15 +296,15 @@ public class CheckoutActionTest {
         when(workspaces.exists("workspace")).thenReturn(true).thenReturn(false);
         when(workspaces.getWorkspace("workspace")).thenReturn(workspace);
         when(project.getProjectPath()).thenReturn("project");
-        when(workspaces.newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class))).thenReturn(workspace);
+        when(workspaces.newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class), eq(false))).thenReturn(workspace);
         
-        new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, ".", false, false).checkoutBySingleVersionSpec(server, hudsonWs, MY_LABEL);
+        new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, ".", false, false, false).checkoutBySingleVersionSpec(server, hudsonWs, MY_LABEL);
         
         verify(server).getWorkspaces();
         verify(workspaces, times(2)).exists("workspace");
-        verify(workspaces).getWorkspace("workspace");
+        verify(workspaces, times(2)).getWorkspace("workspace");
         verify(workspaces).deleteWorkspace(workspace);
-        verify(workspaces).newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class));
+        verify(workspaces).newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class), eq(false));
         verify(workspaces).getWorkspaceMapping(anyString());
         verifyNoMoreInteractions(workspaces);
     }
@@ -316,15 +316,15 @@ public class CheckoutActionTest {
         when(workspaces.exists("workspace")).thenReturn(true).thenReturn(false);
         when(workspaces.getWorkspace("workspace")).thenReturn(workspace);
         when(project.getProjectPath()).thenReturn("project");
-        when(workspaces.newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class))).thenReturn(workspace);
+        when(workspaces.newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class), eq(false))).thenReturn(workspace);
         
-        new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, ".", false, false).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
+        new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, ".", false, false, false).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
         
         verify(server).getWorkspaces();
         verify(workspaces, times(2)).exists("workspace");
-        verify(workspaces).getWorkspace("workspace");
+        verify(workspaces, times(2)).getWorkspace("workspace");
         verify(workspaces).deleteWorkspace(workspace);
-        verify(workspaces).newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class));
+        verify(workspaces).newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class), eq(false));
         verify(workspaces).getWorkspaceMapping(anyString());
         verifyNoMoreInteractions(workspaces);
     }
@@ -336,11 +336,11 @@ public class CheckoutActionTest {
         when(workspaces.exists("workspace")).thenReturn(true).thenReturn(true);
         when(workspaces.getWorkspace("workspace")).thenReturn(workspace);
         
-        new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, ".", true, false).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
+        new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, ".", true, false, false).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
         
         verify(server).getWorkspaces();
         verify(workspaces, times(2)).exists("workspace");
-        verify(workspaces).getWorkspace("workspace");
+        verify(workspaces, times(2)).getWorkspace("workspace");
         verify(workspaces).getWorkspaceMapping(anyString());
         verifyNoMoreInteractions(workspaces);
     }
@@ -352,11 +352,11 @@ public class CheckoutActionTest {
         when(workspaces.exists("workspace")).thenReturn(true).thenReturn(true);
         when(workspaces.getWorkspace("workspace")).thenReturn(workspace);
         
-        new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, ".", true, false).checkoutBySingleVersionSpec(server, hudsonWs, MY_LABEL);
+        new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, ".", true, false, false).checkoutBySingleVersionSpec(server, hudsonWs, MY_LABEL);
         
         verify(server).getWorkspaces();
         verify(workspaces, times(2)).exists("workspace");
-        verify(workspaces).getWorkspace("workspace");
+        verify(workspaces, times(2)).getWorkspace("workspace");
         verify(workspaces).getWorkspaceMapping(anyString());
         verifyNoMoreInteractions(workspaces);
     }
@@ -366,14 +366,14 @@ public class CheckoutActionTest {
     public void assertCheckoutDoesNotDeleteWorkspaceIfNotUsingUpdateAndThereIsNoWorkspace() throws Exception {
         prepareCommonMocks();
         when(workspaces.exists("workspace")).thenReturn(false).thenReturn(false);
-        when(workspaces.newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class))).thenReturn(workspace);
+        when(workspaces.newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class), eq(false))).thenReturn(workspace);
         when(project.getProjectPath()).thenReturn("project");
 
-        new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, ".", false, false).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
+        new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, ".", false, false, false).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
         
         verify(server).getWorkspaces();
         verify(workspaces, times(2)).exists("workspace");
-        verify(workspaces).newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class));
+        verify(workspaces).newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class), eq(false));
         verify(workspaces).getWorkspaceMapping(anyString());
         verifyNoMoreInteractions(workspaces);
     }
@@ -383,14 +383,14 @@ public class CheckoutActionTest {
     public void assertCheckoutBySingleVersionSpecDoesNotDeleteWorkspaceIfNotUsingUpdateAndThereIsNoWorkspace() throws Exception {
         prepareCommonMocks();
         when(workspaces.exists("workspace")).thenReturn(false).thenReturn(false);
-        when(workspaces.newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class))).thenReturn(workspace);
+        when(workspaces.newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class), eq(false))).thenReturn(workspace);
         when(project.getProjectPath()).thenReturn("project");
 
-        new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, ".", false, false).checkoutBySingleVersionSpec(server, hudsonWs, MY_LABEL);
+        new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, ".", false, false, false).checkoutBySingleVersionSpec(server, hudsonWs, MY_LABEL);
         
         verify(server).getWorkspaces();
         verify(workspaces, times(2)).exists("workspace");
-        verify(workspaces).newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class));
+        verify(workspaces).newWorkspace(eq("workspace"), eq("project"), eq(EMPTY_CLOAKED_PATHS_LIST), isA(String.class), eq(false));
         verify(workspaces).getWorkspaceMapping(anyString());
         verifyNoMoreInteractions(workspaces);
     }
@@ -405,7 +405,7 @@ public class CheckoutActionTest {
         when(workspace.getComputer()).thenReturn("LocalComputer");
         when(project.getDetailedHistoryWithoutCloakedPaths(isA(VersionSpec.class), isA(VersionSpec.class), anyCollection())).thenReturn(list);
         
-        CheckoutAction action = new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, ".", true, false);
+        CheckoutAction action = new CheckoutAction("workspace", "project", EMPTY_CLOAKED_PATHS_LIST, ".", true, false, false);
         final Calendar startDate = Util.getCalendar(2008, 9, 24);
         final Calendar endDate = Util.getCalendar(2009, 9, 24);
         List<ChangeSet> actualList = action.checkout(server, hudsonWs, startDate, endDate);

--- a/tfs/src/test/java/hudson/plugins/tfs/commands/ListWorkspacesCommandTest.java
+++ b/tfs/src/test/java/hudson/plugins/tfs/commands/ListWorkspacesCommandTest.java
@@ -215,8 +215,8 @@ public class ListWorkspacesCommandTest extends AbstractCallableCommandTest {
     @Test public void logWithManyWorkspaces() throws IOException {
 
         final ArrayList<Workspace> workspaces = new ArrayList<Workspace>();
-        workspaces.add(new Workspace("Hudson.JOBXXXXXXXXXXXXXX", "XXXX-XXXX-007", "First.LastXX", "This is a comment"));
-        workspaces.add(new Workspace("Hudson-newJob-MASTER", "COMPUTER", "jenkins-tfs-plugin", "Created by the Jenkins tfs-plugin functional tests."));
+        workspaces.add(new Workspace("Hudson.JOBXXXXXXXXXXXXXX", "XXXX-XXXX-007", "First.LastXX", "This is a comment", false));
+        workspaces.add(new Workspace("Hudson-newJob-MASTER", "COMPUTER", "jenkins-tfs-plugin", "Created by the Jenkins tfs-plugin functional tests.", false));
 
         ListWorkspacesCommand.log(workspaces, listener.getLogger());
 
@@ -231,7 +231,7 @@ public class ListWorkspacesCommandTest extends AbstractCallableCommandTest {
     @Test public void logWithOneWorkspace() throws IOException {
 
         final ArrayList<Workspace> workspaces = new ArrayList<Workspace>(1);
-        workspaces.add(new Workspace("asterix", "ASTERIX", "redsolo_cp", "This is a comment"));
+        workspaces.add(new Workspace("asterix", "ASTERIX", "redsolo_cp", "This is a comment", false));
 
         ListWorkspacesCommand.log(workspaces, listener.getLogger());
 

--- a/tfs/src/test/java/hudson/plugins/tfs/commands/NewWorkspaceCommandTest.java
+++ b/tfs/src/test/java/hudson/plugins/tfs/commands/NewWorkspaceCommandTest.java
@@ -28,7 +28,7 @@ public class NewWorkspaceCommandTest extends AbstractCallableCommandTest {
                 isA(String.class),
                 isA(WorkspaceLocation.class),
                 isA(WorkspaceOptions.class))).thenReturn(null);
-        final NewWorkspaceCommand command = new NewWorkspaceCommand(server, "TheWorkspaceName", null, EMPTY_CLOAKED_PATHS, null) {
+        final NewWorkspaceCommand command = new NewWorkspaceCommand(server, "TheWorkspaceName", null, EMPTY_CLOAKED_PATHS, null, false) {
             @Override
             public Server createServer() {
                 return server;
@@ -60,7 +60,7 @@ public class NewWorkspaceCommandTest extends AbstractCallableCommandTest {
                 isA(String.class),
                 isA(WorkspaceLocation.class),
                 isA(WorkspaceOptions.class))).thenReturn(null);
-        final NewWorkspaceCommand command = new NewWorkspaceCommand(server, "TheWorkspaceName", "$/Stuff", cloakedPaths, "/home/jenkins/jobs/stuff/workspace") {
+        final NewWorkspaceCommand command = new NewWorkspaceCommand(server, "TheWorkspaceName", "$/Stuff", cloakedPaths, "/home/jenkins/jobs/stuff/workspace", false) {
             @Override
             public Server createServer() {
                 return server;
@@ -84,6 +84,6 @@ public class NewWorkspaceCommandTest extends AbstractCallableCommandTest {
     }
 
     @Override protected AbstractCallableCommand createCommand(final ServerConfigurationProvider serverConfig) {
-        return new NewWorkspaceCommand(serverConfig, "workspaceName", "$/serverPath", EMPTY_CLOAKED_PATHS, "local/path");
+        return new NewWorkspaceCommand(serverConfig, "workspaceName", "$/serverPath", EMPTY_CLOAKED_PATHS, "local/path", false);
     }
 }

--- a/tfs/src/test/java/hudson/plugins/tfs/model/WorkspaceConfigurationTest.java
+++ b/tfs/src/test/java/hudson/plugins/tfs/model/WorkspaceConfigurationTest.java
@@ -15,15 +15,16 @@ public class WorkspaceConfigurationTest {
     @Test public void assertConfigurationsEquals() {
         final List<String> cloakList = Collections.singletonList("cloak");
 
-        WorkspaceConfiguration one = new WorkspaceConfiguration("server", "workspace", "project", cloakList, "workfolder");
-        WorkspaceConfiguration two = new WorkspaceConfiguration("server", "workspace", "project", cloakList, "workfolder");
+        WorkspaceConfiguration one = new WorkspaceConfiguration("server", "workspace", "project", cloakList, "workfolder", false);
+        WorkspaceConfiguration two = new WorkspaceConfiguration("server", "workspace", "project", cloakList, "workfolder", false);
         assertThat(one, is(two));
         assertThat(two, is(one));
         assertThat(one, is(one));
-        assertThat(one, not(new WorkspaceConfiguration("aserver", "workspace", "project", cloakList, "workfolder")));
-        assertThat(one, not(new WorkspaceConfiguration("server", "aworkspace", "project", cloakList, "workfolder")));
-        assertThat(one, not(new WorkspaceConfiguration("server", "workspace", "aproject", cloakList, "workfolder")));
-        assertThat(one, not(new WorkspaceConfiguration("server", "workspace", "project", cloakList, "aworkfolder")));
-        assertThat(one, not(new WorkspaceConfiguration("server", "workspace", "project", EMPTY_CLOAKED_PATHS_LIST, "workfolder")));
+        assertThat(one, not(new WorkspaceConfiguration("aserver", "workspace", "project", cloakList, "workfolder", false)));
+        assertThat(one, not(new WorkspaceConfiguration("server", "aworkspace", "project", cloakList, "workfolder", false)));
+        assertThat(one, not(new WorkspaceConfiguration("server", "workspace", "aproject", cloakList, "workfolder", false)));
+        assertThat(one, not(new WorkspaceConfiguration("server", "workspace", "project", cloakList, "aworkfolder", false)));
+        assertThat(one, not(new WorkspaceConfiguration("server", "workspace", "project", EMPTY_CLOAKED_PATHS_LIST, "workfolder", false)));
+        assertThat(one, not(new WorkspaceConfiguration("server", "workspace", "project", cloakList, "aworkfolder", true)));
     }
 }

--- a/tfs/src/test/java/hudson/plugins/tfs/model/WorkspacesTest.java
+++ b/tfs/src/test/java/hudson/plugins/tfs/model/WorkspacesTest.java
@@ -91,7 +91,7 @@ public class WorkspacesTest {
         when(server.execute(isA(Callable.class))).thenReturn(null);
         
         Workspaces workspaces = new Workspaces(server);
-        Workspace workspace = workspaces.newWorkspace("name1", null, EMPTY_CLOAKED_PATHS_LIST, null);
+        Workspace workspace = workspaces.newWorkspace("name1", null, EMPTY_CLOAKED_PATHS_LIST, null, false);
         assertNotNull("The new workspace was null", workspace);
         assertTrue("The workspace was reported as non existant", workspaces.exists(workspace));
     }
@@ -101,7 +101,7 @@ public class WorkspacesTest {
         when(server.execute(isA(Callable.class))).thenReturn(null);
         
         Workspaces workspaces = new Workspaces(server);
-        workspaces.newWorkspace("name1", null, EMPTY_CLOAKED_PATHS_LIST, null);
+        workspaces.newWorkspace("name1", null, EMPTY_CLOAKED_PATHS_LIST, null, false);
         assertNotNull("The get new workspace returned null", workspaces.getWorkspace("name1"));
         verify(server, times(1)).execute(isA(Callable.class));
     }
@@ -111,7 +111,7 @@ public class WorkspacesTest {
         when(server.execute(isA(Callable.class))).thenReturn(null);
         
         Workspaces workspaces = new Workspaces(server);
-        Workspace workspace = workspaces.newWorkspace("name1", null, EMPTY_CLOAKED_PATHS_LIST, null);
+        Workspace workspace = workspaces.newWorkspace("name1", null, EMPTY_CLOAKED_PATHS_LIST, null, false);
         assertTrue("The get new workspace did not exists", workspaces.exists(workspace));
         verify(server, times(1)).execute(isA(Callable.class));
     }
@@ -122,7 +122,7 @@ public class WorkspacesTest {
         Workspaces workspaces = new Workspaces(server);
         // Populate the map in test object
         assertFalse("The workspace was reported as existant", workspaces.exists(new Workspace("name")));
-        Workspace workspace = workspaces.newWorkspace("name", null, EMPTY_CLOAKED_PATHS_LIST, null);
+        Workspace workspace = workspaces.newWorkspace("name", null, EMPTY_CLOAKED_PATHS_LIST, null, false);
         assertTrue("The workspace was reported as non existant", workspaces.exists(new Workspace("name")));
         workspaces.deleteWorkspace(workspace);
         assertFalse("The workspace was reported as existant", workspaces.exists(workspace));
@@ -145,7 +145,7 @@ public class WorkspacesTest {
     @Test
     public void assertWorkspaceFactory() {        
         ListWorkspacesCommand.WorkspaceFactory factory = new Workspaces(server);
-        Workspace workspace = factory.createWorkspace("name", "computer", "owner", "comment");
+        Workspace workspace = factory.createWorkspace("name", "computer", "owner", "comment", false);
         assertEquals("Workspace name was incorrect", "name", workspace.getName());
         assertEquals("Workspace comment was incorrect", "comment", workspace.getComment());
     }

--- a/tfs/src/test/java/hudson/plugins/tfs/util/BuildWorkspaceConfigurationRetrieverTest.java
+++ b/tfs/src/test/java/hudson/plugins/tfs/util/BuildWorkspaceConfigurationRetrieverTest.java
@@ -27,7 +27,7 @@ public class BuildWorkspaceConfigurationRetrieverTest {
         AbstractBuild build = mock(AbstractBuild.class);
         Node node = mock(Node.class);
         Node needleNode = mock(Node.class);
-        WorkspaceConfiguration configuration = new WorkspaceConfiguration("serverUrl", "workspaceName", "projectPath", EMPTY_CLOAKED_PATHS_LIST, "workfolder");
+        WorkspaceConfiguration configuration = new WorkspaceConfiguration("serverUrl", "workspaceName", "projectPath", EMPTY_CLOAKED_PATHS_LIST, "workfolder", false);
         when(build.getPreviousBuild()).thenReturn(build).thenReturn(null);
         when(build.getBuiltOn()).thenReturn(node, node, null);
         when(node.getNodeName()).thenReturn("node1", "needleNode");
@@ -98,7 +98,7 @@ public class BuildWorkspaceConfigurationRetrieverTest {
         when(build.getPreviousBuild()).thenReturn(build);
         when(build.getBuiltOn()).thenReturn(node);
         when(node.getNodeName()).thenReturn("needleNode");
-        when(build.getAction(WorkspaceConfiguration.class)).thenReturn(new WorkspaceConfiguration("serverUrl", "workspaceName", "projectPath", EMPTY_CLOAKED_PATHS_LIST, "workfolder"));
+        when(build.getAction(WorkspaceConfiguration.class)).thenReturn(new WorkspaceConfiguration("serverUrl", "workspaceName", "projectPath", EMPTY_CLOAKED_PATHS_LIST, "workfolder", false));
         
         BuildWorkspaceConfiguration configuration = new BuildWorkspaceConfigurationRetriever().getLatestForNode(node, build);
         assertThat( configuration.getWorkspaceName(), is("workspaceName"));
@@ -113,7 +113,7 @@ public class BuildWorkspaceConfigurationRetrieverTest {
         AbstractBuild build = mock(AbstractBuild.class);
         Node node = mock(Node.class);
         Node needleNode = mock(Node.class);
-        WorkspaceConfiguration configuration = new WorkspaceConfiguration("serverUrl", "workspaceName", "projectPath", EMPTY_CLOAKED_PATHS_LIST, "workfolder");
+        WorkspaceConfiguration configuration = new WorkspaceConfiguration("serverUrl", "workspaceName", "projectPath", EMPTY_CLOAKED_PATHS_LIST, "workfolder", false);
         when(build.getPreviousBuild()).thenReturn(build).thenReturn(null);
         when(build.getBuiltOn()).thenReturn(null);
 


### PR DESCRIPTION
Under "ADVANCED" I added an extra checkbox if the workspace should be 'Local' or 'Server'.
The difference is described at https://docs.microsoft.com/en-us/azure/devops/repos/tfvc/decide-between-using-local-server-workspace
But one very important detail is that the file attributes also change with this option upon checkout. So for us, all workspaces must therefore be a 'Local' workspace.

This replaces pull request #215 