### PR TITLE
add null check, that on pipeline fail by syntax error in script no exception occur

### DIFF
--- a/tfs/src/main/java/hudson/plugins/tfs/TeamFoundationServerScm.java
+++ b/tfs/src/main/java/hudson/plugins/tfs/TeamFoundationServerScm.java
@@ -534,6 +534,10 @@ public class TeamFoundationServerScm extends SCM {
      * VERSION_SPEC during the build
      */
     public void buildEnvironment(final Run<?, ?> build, final Map<String, String> env) {
+		// catch null on pipeline fail
+		if(null == build) {
+			return;
+		}
         final TeamBuildDetailsAction buildDetailsAction = build.getAction(TeamBuildDetailsAction.class);
         if (buildDetailsAction != null) {
             //Add the TFS build variables as environment variables in the Jenkins environment


### PR DESCRIPTION
fix Null in case pipeline script was pulled from TFS. But this pulled script has a syntax error.